### PR TITLE
Prototyping transformer modifiers for fields

### DIFF
--- a/src/main/scala/io/scalaland/chimney/Modifier.scala
+++ b/src/main/scala/io/scalaland/chimney/Modifier.scala
@@ -1,0 +1,22 @@
+package io.scalaland.chimney
+
+import shapeless.Witness
+
+sealed trait Modifier
+
+object Modifier {
+  sealed trait empty extends Modifier
+  case object empty extends empty
+
+  case class fieldValue[L <: Symbol, T](label: Witness.Aux[L],
+                                        value: T)
+    extends Modifier
+
+  case class fieldFunction[L <: Symbol, T, F](label: Witness.Aux[L],
+                                              f: T => F)
+    extends Modifier
+
+  case class relabel[L1 <: Symbol, L2 <: Symbol](label1: Witness.Aux[L1],
+                                                 label2: Witness.Aux[L2])
+    extends Modifier
+}

--- a/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -4,29 +4,62 @@ import shapeless._
 import shapeless.labelled._
 import shapeless.ops.record._
 
-trait Transformer[From, To] {
+trait Transformer[From, To, M <: Modifier] {
 
-  def transform(src: From): To
+  def transform(src: From, modifier: M): To
 }
 
 object Transformer {
 
-  implicit def identityTransformer[T]: Transformer[T, T] =
-    (obj: T) => obj
+  type Aux[From, To] = Transformer[From, To, Modifier.empty]
 
-  implicit def hnilCase[FromG]: Transformer[FromG, HNil] =
-    (_: FromG) => HNil
 
-  implicit def hconsCase[FromG <: HList, Label <: Symbol, FromFieldT, ToFieldT, TailTo <: HList]
+  implicit def identityTransformer[T, M <: Modifier]: Transformer[T, T, M] =
+    (obj: T, _: M) => obj
+
+  implicit def hnilCase[FromG, M <: Modifier]: Transformer[FromG, HNil, M] =
+    (_: FromG, _: M) => HNil
+
+  implicit def hconsCase[FromG <: HList, Label <: Symbol, FromFieldT, ToFieldT, TailTo <: HList, M <: Modifier]
     (implicit fieldSelector: Selector.Aux[FromG, Label, FromFieldT],
-     fieldTransformer: Transformer[FromFieldT, ToFieldT],
-     tailTransformer: Transformer[FromG, TailTo]): Transformer[FromG, FieldType[Label, ToFieldT] :: TailTo] =
-    (obj: FromG) =>
-      field[Label](fieldTransformer.transform(fieldSelector(obj))) :: tailTransformer.transform(obj)
+     fieldTransformer: Transformer[FromFieldT, ToFieldT, M],
+     tailTransformer: Transformer[FromG, TailTo, M])
+  : Transformer[FromG, FieldType[Label, ToFieldT] :: TailTo, M] = {
+    (obj: FromG, modifier: M) =>
+      field[Label](fieldTransformer.transform(fieldSelector(obj), modifier)) :: tailTransformer.transform(obj, modifier)
+  }
 
+  implicit def hconsCaseFieldValueProvided[FromG <: HList, Label <: Symbol, ProvidedT, ToFieldT, TailToG <: HList]
+    (implicit fieldTransformer: Transformer[ProvidedT, ToFieldT, Modifier.fieldValue[Label, ProvidedT]],
+     tailTransformer: Transformer[FromG, TailToG, Modifier.fieldValue[Label, ProvidedT]])
+  : Transformer[FromG, FieldType[Label, ToFieldT] :: TailToG, Modifier.fieldValue[Label, ProvidedT]] = {
+    (obj: FromG, modifier: Modifier.fieldValue[Label, ProvidedT]) =>
+      field[Label](fieldTransformer.transform(modifier.value, modifier)) :: tailTransformer.transform(obj, modifier)
+  }
 
-  implicit def gen[From, To, FromG, ToG](implicit fromLG: LabelledGeneric.Aux[From, FromG],
-                                         toLG: LabelledGeneric.Aux[To, ToG],
-                                         genTransformer: Transformer[FromG, ToG]): Transformer[From, To] =
-    (src: From) => toLG.from(genTransformer.transform(fromLG.to(src)))
+  implicit def hconsCaseFieldFunctionProvided[FromG <: HList, Label <: Symbol, ProducedT, ToFieldT, TailToG <: HList, From]
+    (implicit fieldTransformer: Transformer[ProducedT, ToFieldT, Modifier.fieldFunction[Label, From, ProducedT]],
+     tailTransformer: Transformer[FromG, TailToG, Modifier.fieldFunction[Label, From, ProducedT]],
+     tLabGen: LabelledGeneric.Aux[From, FromG])
+  : Transformer[FromG, FieldType[Label, ToFieldT] :: TailToG, Modifier.fieldFunction[Label, From, ProducedT]] = {
+    (obj: FromG, modifier: Modifier.fieldFunction[Label, From, ProducedT]) =>
+      field[Label](fieldTransformer.transform(modifier.f(tLabGen.from(obj)), modifier)) :: tailTransformer.transform(obj, modifier)
+  }
+
+  implicit def hconsCaseFieldRelabelled[FromG <: HList, LabelFrom <: Symbol, Label <: Symbol, FromFieldT, ToFieldT, TailToG <: HList]
+  (implicit fieldSelector: Selector.Aux[FromG, LabelFrom, FromFieldT],
+   fieldTransformer: Transformer[FromFieldT, ToFieldT, Modifier.relabel[LabelFrom, Label]],
+   tailTransformer: Transformer[FromG, TailToG, Modifier.relabel[LabelFrom, Label]])
+  : Transformer[FromG, FieldType[Label, ToFieldT] :: TailToG, Modifier.relabel[LabelFrom, Label]] = {
+    (obj: FromG, modifier: Modifier.relabel[LabelFrom, Label]) =>
+      field[Label](fieldTransformer.transform(fieldSelector(obj), modifier)) :: tailTransformer.transform(obj, modifier)
+  }
+
+  implicit def gen[From, To, FromG, ToG, M <: Modifier]
+    (implicit fromLG: LabelledGeneric.Aux[From, FromG],
+     toLG: LabelledGeneric.Aux[To, ToG],
+     genTransformer: Transformer[FromG, ToG, M]): Transformer[From, To, M] = {
+    (src: From, modifier: M) =>
+      toLG.from(genTransformer.transform(fromLG.to(src), modifier))
+  }
 }

--- a/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -4,8 +4,21 @@ object dsl {
 
   implicit class TransformerOps[From](val source: From) extends AnyVal {
 
-    def transformTo[To](implicit transformer: Transformer[From, To]): To =
-      transformer.transform(source)
+    def transformer[To]: TransformTo[From, To] = new TransformTo(source)
   }
+
+  class TransformTo[From, To](val source: From) extends AnyVal {
+
+    def invoke(implicit transformer: Transformer.Aux[From, To]): To =
+      transformer.transform(source, Modifier.empty)
+
+    def invokeM[M <: Modifier](modifier: M)
+                              (implicit transformer: Transformer[From, To, M]): To =
+      transformer.transform(source, modifier)
+  }
+
+  type Modifier = io.scalaland.chimney.Modifier
+  val Modifier = io.scalaland.chimney.Modifier
+
 
 }

--- a/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -1,14 +1,15 @@
 package io.scalaland.chimney
 
 import org.scalatest.{MustMatchers, WordSpec}
+import shapeless.test._
 
 class DslSpec extends WordSpec with MustMatchers {
 
 
   case class UserName(value: String)
 
-  val userNameToStringTransformer: Transformer[UserName, String] =
-    (_: UserName).value
+  val userNameToStringTransformer: Transformer.Aux[UserName, String] =
+    (un: UserName, _: Modifier.empty) => un.value
 
   case class UserDTO(id: String, name: String)
   case class User(id: String, name: UserName)
@@ -21,7 +22,7 @@ class DslSpec extends WordSpec with MustMatchers {
 
       implicit val _ = userNameToStringTransformer
 
-      UserName("Batman").transformTo[String] mustBe "Batman"
+      UserName("Batman").transformer[String].invoke mustBe "Batman"
     }
 
     "use implicit transformer for nested field" in {
@@ -29,18 +30,55 @@ class DslSpec extends WordSpec with MustMatchers {
       implicit val _ = userNameToStringTransformer
 
       val batman = User("123", UserName("Batman"))
-      val batmanDTO = batman.transformTo[UserDTO]
+      val batmanDTO = batman.transformer[UserDTO].invoke
 
       batmanDTO.id mustBe batman.id
       batmanDTO.name mustBe batman.name.value
     }
 
-    "transform to a target case class which contains only subset of source fields" in {
+    "support different set of fields of source and target" when {
 
       case class Foo(x: Int, y: String, z: Double)
       case class Bar(x: Int, z: Double)
 
-      Foo(3, "pi", 3.14).transformTo[Bar] mustBe Bar(3, 3.14)
+      "field is dropped in the target" in {
+        Foo(3, "pi", 3.14).transformer[Bar].invoke mustBe Bar(3, 3.14)
+      }
+
+      "field is added to the target" should {
+
+        "not compile if source for the target fields is not provided" in {
+
+          illTyped("Bar(3, 3.14).transformer[Foo].invoke")
+        }
+
+        "fill the field with provided default value" in {
+
+          Bar(3, 3.14).transformer[Foo].invokeM(Modifier.fieldValue('y, "pi")) mustBe
+            Foo(3, "pi", 3.14)
+        }
+
+        "fill the field with provided generator function" in {
+
+          Bar(3, 3.14).transformer[Foo].invokeM(Modifier.fieldFunction('y, (bar: Bar) => bar.x.toString)) mustBe
+            Foo(3, "3", 3.14)
+        }
+      }
+    }
+
+    "support relabelling of fields" should {
+
+      case class Foo(x: Int, y: String)
+      case class Bar(x: Int, z: String)
+
+      "not compile if relabelling modifier is not provided" in {
+
+        illTyped("""Foo(10, "something").transform[Bar].invoke""")
+      }
+
+      "relabel fields with relabelling modifier" in {
+        Foo(10, "something").transformer[Bar].invokeM(Modifier.relabel('y, 'z))
+      }
     }
   }
 }


### PR DESCRIPTION
This is example of how we can override default transformation rules with overriding with modifiers. So far only single explicit modifier is supported.