### PR TITLE
Protocol buffer tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-   - 2.12.0
+   # - 2.12.0 doesn't work due to SI-7046
    - 2.12.1
    - 2.12.2
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,8 @@ lazy val protos = crossProject.crossType(CrossType.Pure)
     PB.targets in Compile := Seq(
       scalapb.gen() -> (sourceManaged in Compile).value
     ),
-    PB.protoSources in Compile := Seq(file("protos/src/main/protobuf"))
+    PB.protoSources in Compile := Seq(file("protos/src/main/protobuf")),
+    coverageExcludedPackages := "<empty>;(.*)"
   )
   .settings(settings: _*)
   .settings(noPublishSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -70,11 +70,27 @@ lazy val chimney = crossProject.crossType(CrossType.Pure)
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(dependencies: _*)
-
+  .dependsOn(protos % "test->compile")
 
 lazy val chimneyJVM = chimney.jvm
-
 lazy val chimneyJS = chimney.js
+
+
+lazy val protos = crossProject.crossType(CrossType.Pure)
+  .settings(
+    name := "chimney-protos",
+    libraryDependencies += "com.trueaccord.scalapb" %%% "scalapb-runtime" % com.trueaccord.scalapb.compiler.Version.scalapbVersion,
+    PB.targets in Compile := Seq(
+      scalapb.gen() -> (sourceManaged in Compile).value
+    ),
+    PB.protoSources in Compile := Seq(file("protos/src/main/protobuf"))
+  )
+  .settings(settings: _*)
+  .settings(noPublishSettings: _*)
+
+lazy val protosJVM = protos.jvm
+lazy val protosJS = protos.js
+
 
 lazy val publishSettings = Seq(
   organization := "io.scalaland",

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val root = project.in(file("."))
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(noPublishSettings: _*)
-  .aggregate(chimneyJVM, chimneyJS)
+  .aggregate(chimneyJVM, chimneyJS, protosJVM, protosJS)
   .dependsOn(chimneyJVM, chimneyJS)
 
 lazy val chimney = crossProject.crossType(CrossType.Pure)

--- a/chimney/src/main/scala/io/scalaland/chimney/CoproductInstanceProvider.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/CoproductInstanceProvider.scala
@@ -1,0 +1,19 @@
+package io.scalaland.chimney
+
+import shapeless.labelled.{FieldType, field}
+import shapeless.{Coproduct, HList, Witness, ops}
+
+trait CoproductInstanceProvider[ToG <: Coproduct, Label <: Symbol, T, Modifiers <: HList] {
+  def provide(srcInstance: FieldType[Label, T], modifiers: Modifiers): ToG
+}
+
+object CoproductInstanceProvider {
+
+  implicit def matchingObjCase[ToG <: Coproduct, ToHList <: HList, Label <: Symbol, T, TargetT, Modifiers <: HList]
+  (implicit sel: ops.union.Selector.Aux[ToG, Label, TargetT],
+   wit: Witness.Aux[TargetT],
+   inj: ops.coproduct.Inject[ToG, FieldType[Label, TargetT]])
+  : CoproductInstanceProvider[ToG, Label, T, Modifiers] =
+    (_: FieldType[Label, T], _: Modifiers) =>
+      inj(field[Label](wit.value))
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
@@ -90,14 +90,14 @@ trait EitherInstances {
 
 trait CollectionInstances {
 
-  implicit def traversableTransformer[From, To, Modifiers <: HList, M[_]]
+  implicit def traversableTransformer[From, To, Modifiers <: HList, M1[_], M2[_]]
     (implicit innerTransformer: DerivedTransformer[From, To, Modifiers],
-     ev1: M[From] <:< Traversable[From],
-     ev2: M[To] <:< Traversable[To],
-     cbf: CanBuildFrom[M[From], To, M[To]])
-  : DerivedTransformer[M[From], M[To], Modifiers] =
-    (src: M[From], modifiers: Modifiers) =>
-      src.map(innerTransformer.transform(_: From, modifiers)).to[M]
+     ev1: M1[From] <:< Traversable[From],
+     ev2: M2[To] <:< Traversable[To],
+     cbf: CanBuildFrom[M1[From], To, M2[To]])
+  : DerivedTransformer[M1[From], M2[To], Modifiers] =
+    (src: M1[From], modifiers: Modifiers) =>
+      src.map(innerTransformer.transform(_: From, modifiers)).to[M2]
 
   implicit def arrayTransformer[From, To, Modifiers <: HList]
     (implicit innerTransformer: DerivedTransformer[From, To, Modifiers], toTag: ClassTag[To])

--- a/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
@@ -114,7 +114,7 @@ trait CollectionInstances {
 
 }
 
-trait GenericInstances extends LowPriGenericInstances {
+trait GenericInstances extends LowPriorityGenericInstances {
 
   implicit def hnilCase[From, FromG <: HList, Modifiers <: HList]
   : DerivedTransformer[FromG @@ From, HNil, Modifiers] =
@@ -155,7 +155,7 @@ trait GenericInstances extends LowPriGenericInstances {
   }
 }
 
-trait LowPriGenericInstances {
+trait LowPriorityGenericInstances {
 
   implicit def gen2[From, To, FromG, ToG, Modifiers <: HList]
   (implicit fromLG: LabelledGeneric.Aux[From, FromG],

--- a/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
@@ -19,7 +19,11 @@ object DerivedTransformer
   with OptionInstances
   with EitherInstances
   with CollectionInstances
-  with GenericInstances
+  with GenericInstances {
+
+  def apply[From, To, Modifiers <: HList](implicit dt: DerivedTransformer[From, To, Modifiers]): DerivedTransformer[From, To, Modifiers] = dt
+
+}
 
 trait BasicInstances {
 
@@ -110,15 +114,15 @@ trait CollectionInstances {
 
 }
 
-trait GenericInstances {
+trait GenericInstances extends LowPriGenericInstances {
 
   implicit def hnilCase[From, FromG <: HList, Modifiers <: HList]
   : DerivedTransformer[FromG @@ From, HNil, Modifiers] =
     (_: FromG @@ From, _: Modifiers) => HNil
 
   implicit def hconsCase[From, FromG <: HList, Label <: Symbol, ToFieldT, TailToG <: HList, Modifiers <: HList]
-    (implicit vp: ValueProvider[FromG, From, ToFieldT, Label, Modifiers],
-     tailTransformer: DerivedTransformer[FromG @@ From, TailToG, Modifiers])
+  (implicit vp: ValueProvider[FromG, From, ToFieldT, Label, Modifiers],
+   tailTransformer: DerivedTransformer[FromG @@ From, TailToG, Modifiers])
   : DerivedTransformer[FromG @@ From, FieldType[Label, ToFieldT] :: TailToG, Modifiers] = {
     (src: FromG @@ From, modifiers: Modifiers) =>
       field[Label](vp.provide(src, modifiers)) :: tailTransformer.transform(src, modifiers)
@@ -128,6 +132,7 @@ trait GenericInstances {
   implicit def cnilCase[From, ToG <: Coproduct, Modifiers <: HList]
   : DerivedTransformer[CNil @@ From, ToG, Modifiers] =
     (_: CNil @@ From, _: Modifiers) => null.asInstanceOf[ToG]
+
   // $COVERAGE-ON$
 
   implicit def coproductCase[From, TailFromG <: Coproduct, Label <: Symbol, HeadT, ToG <: Coproduct, Modifiers <: HList]
@@ -135,15 +140,28 @@ trait GenericInstances {
    tailTransformer: DerivedTransformer[TailFromG @@ From, ToG, Modifiers])
   : DerivedTransformer[@@[FieldType[Label, HeadT] :+: TailFromG, From], ToG, Modifiers] =
     (src: @@[FieldType[Label, HeadT] :+: TailFromG, From], modifiers: Modifiers) =>
-      (src : FieldType[Label, HeadT] :+: TailFromG) match {
+      (src: FieldType[Label, HeadT] :+: TailFromG) match {
         case Inl(hd) => cip.provide(hd, modifiers)
         case Inr(tl) => tailTransformer.transform(tag[From](tl), modifiers)
       }
 
   implicit def gen[From, To, FromG, ToG, Modifiers <: HList]
-    (implicit fromLG: LabelledGeneric.Aux[From, FromG],
-     toLG: LabelledGeneric.Aux[To, ToG],
-     genTransformer: DerivedTransformer[FromG @@ From, ToG, Modifiers]): DerivedTransformer[From, To, Modifiers] = {
+  (implicit fromLG: LabelledGeneric.Aux[From, FromG],
+   toLG: LabelledGeneric.Aux[To, ToG],
+   genTransformer: Lazy[DerivedTransformer[FromG @@ From, ToG, Modifiers]])
+  : DerivedTransformer[From, To, Modifiers] = {
+    (src: From, modifiers: Modifiers) =>
+      toLG.from(genTransformer.value.transform(tag[From](fromLG.to(src)), modifiers))
+  }
+}
+
+trait LowPriGenericInstances {
+
+  implicit def gen2[From, To, FromG, ToG, Modifiers <: HList]
+  (implicit fromLG: LabelledGeneric.Aux[From, FromG],
+   toLG: LabelledGeneric.Aux[To, ToG],
+   genTransformer: DerivedTransformer[FromG @@ From, ToG, Modifiers])
+  : DerivedTransformer[From, To, Modifiers] = {
     (src: From, modifiers: Modifiers) =>
       toLG.from(genTransformer.transform(tag[From](fromLG.to(src)), modifiers))
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
@@ -157,12 +157,9 @@ object CoproductInstanceProvider {
 
   implicit def matchingObjCase[ToG <: Coproduct, ToHList <: HList, Label <: Symbol, T, TargetT, Modifiers <: HList]
     (implicit sel: ops.union.Selector.Aux[ToG, Label, TargetT],
-//     wit: Witness.Aux[TargetT],
-     wit2: Generic.Aux[TargetT, HNil],
+     wit: Witness.Aux[TargetT],
      inj: ops.coproduct.Inject[ToG, FieldType[Label, TargetT]])
   : CoproductInstanceProvider[ToG, Label, T, Modifiers] =
-    (_: FieldType[Label, T], _: Modifiers) => {
-//      inj(field[Label](wit.value))
-      inj(field[Label](wit2.from(HNil)))
-    }
+    (_: FieldType[Label, T], _: Modifiers) =>
+      inj(field[Label](wit.value))
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
@@ -166,18 +166,3 @@ trait LowPriGenericInstances {
       toLG.from(genTransformer.transform(tag[From](fromLG.to(src)), modifiers))
   }
 }
-
-trait CoproductInstanceProvider[ToG <: Coproduct, Label <: Symbol, T, Modifiers <: HList] {
-  def provide(srcInstance: FieldType[Label, T], modifiers: Modifiers): ToG
-}
-
-object CoproductInstanceProvider {
-
-  implicit def matchingObjCase[ToG <: Coproduct, ToHList <: HList, Label <: Symbol, T, TargetT, Modifiers <: HList]
-    (implicit sel: ops.union.Selector.Aux[ToG, Label, TargetT],
-     wit: Witness.Aux[TargetT],
-     inj: ops.coproduct.Inject[ToG, FieldType[Label, TargetT]])
-  : CoproductInstanceProvider[ToG, Label, T, Modifiers] =
-    (_: FieldType[Label, T], _: Modifiers) =>
-      inj(field[Label](wit.value))
-}

--- a/chimney/src/main/scala/io/scalaland/chimney/ValueProvider.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/ValueProvider.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney
 
-import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness, ops}
+import shapeless.{::, HList, HNil, LabelledGeneric, Witness, ops}
 
 trait ValueProvider[FromG, From, T, Label <: Symbol, Modifiers <: HList] {
   def provide(from: FromG, modifiers: Modifiers): T
@@ -18,12 +18,12 @@ object ValueProvider extends ValueProviderDerivation {
 
 trait ValueProviderDerivation {
 
-  implicit def hnilCase[FromG <: HList, From, FromT, ToT, L <: Symbol, Modifiers <: HNil]
+  implicit def hnilCase[Modifiers <: HNil, FromG <: HList, From, FromT, ToT, L <: Symbol]
   (implicit fieldSelector: ops.record.Selector.Aux[FromG, L, FromT],
-   fieldTransformer: Lazy[DerivedTransformer[FromT, ToT, Modifiers]])
+   fieldTransformer: DerivedTransformer[FromT, ToT, Modifiers])
   : ValueProvider[FromG, From, ToT, L, Modifiers] =
     (from: FromG, modifiers: Modifiers) =>
-      fieldTransformer.value.transform(fieldSelector(from), modifiers)
+      fieldTransformer.transform(fieldSelector(from), modifiers)
 
   implicit def hconsFieldFunctionCase[FromG <: HList, From, T, L <: Symbol, Modifiers <: HList]
   (implicit fromLG: LabelledGeneric.Aux[From, FromG])

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -147,6 +147,10 @@ class DslSpec extends WordSpec with MustMatchers {
         Seq(Foo("a")).transformInto[Seq[Bar]] mustBe Seq(Bar("a"))
         List(Foo("a")).transformInto[List[Bar]] mustBe List(Bar("a"))
         Vector(Foo("a")).transformInto[Vector[Bar]] mustBe Vector(Bar("a"))
+        Set(Foo("a")).transformInto[Set[Bar]] mustBe Set(Bar("a"))
+
+        List(Foo("a")).transformInto[Seq[Bar]] mustBe Seq(Bar("a"))
+        Vector(Foo("a")).transformInto[Seq[Bar]] mustBe Seq(Bar("a"))
       }
 
       "support Arrays" in {

--- a/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -116,9 +116,7 @@ class PBTransformationSpec extends WordSpec with MustMatchers {
             )
           ))
       }
-
     }
-
   }
 
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -26,7 +26,7 @@ class PBTransformationSpec extends WordSpec with MustMatchers {
 
     "transform enum represented as sealed trait hierarchy" in {
 
-      (addressbook.`PhoneType.MOBILE`: addressbook.PhoneType)
+      (addressbook.MOBILE: addressbook.PhoneType)
         .transformInto[examples.pb.addressbook.PhoneType] mustBe
         examples.pb.addressbook.PhoneType.MOBILE
     }

--- a/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -8,7 +8,7 @@ class PBTransformationSpec extends WordSpec with MustMatchers {
 
   import dsl._
 
-  "Chimney" should {
+  "Domain to Protobuf" should {
 
     "transform value classes between their primitive representations" in {
 
@@ -29,6 +29,27 @@ class PBTransformationSpec extends WordSpec with MustMatchers {
       (addressbook.MOBILE: addressbook.PhoneType)
         .transformInto[examples.pb.addressbook.PhoneType] mustBe
         examples.pb.addressbook.PhoneType.MOBILE
+
+      (addressbook.HOME: addressbook.PhoneType)
+        .transformInto[examples.pb.addressbook.PhoneType] mustBe
+        examples.pb.addressbook.PhoneType.HOME
+
+      (addressbook.WORK: addressbook.PhoneType)
+        .transformInto[examples.pb.addressbook.PhoneType] mustBe
+        examples.pb.addressbook.PhoneType.WORK
+    }
+
+    "transform bigger case classes" when {
+
+      "PhoneNumber" in {
+
+        addressbook.PhoneNumber("1234567", addressbook.HOME)
+          .transformInto[examples.pb.addressbook.Person.PhoneNumber] mustBe
+          examples.pb.addressbook.Person.PhoneNumber("1234567", examples.pb.addressbook.PhoneType.HOME)
+
+
+      }
+
     }
 
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -1,0 +1,36 @@
+package io.scalaland.chimney
+
+import org.scalatest.{MustMatchers, WordSpec}
+import io.scalaland.chimney.examples.addressbook
+import shapeless.test._
+
+class PBTransformationSpec extends WordSpec with MustMatchers {
+
+  import dsl._
+
+  "Chimney" should {
+
+    "transform value classes between their primitive representations" in {
+
+      addressbook.PersonName("John").transformInto[String] mustBe "John"
+      addressbook.PersonId(5).transformInto[Int] mustBe 5
+      addressbook.Email("john@example.com").transformInto[String] mustBe "john@example.com"
+    }
+
+    "not compile if target type is wrong for value class" in {
+
+      illTyped(""" addressbook.PersonName("John").transformInto[Int] """)
+      illTyped(""" addressbook.PersonId(5).transformInto[String] """)
+      illTyped(""" addressbook.Email("john@example.com").transformInto[Float] """)
+    }
+
+    "transform enum represented as sealed trait hierarchy" in {
+
+      (addressbook.`PhoneType.MOBILE`: addressbook.PhoneType)
+        .transformInto[examples.pb.addressbook.PhoneType] mustBe
+        examples.pb.addressbook.PhoneType.MOBILE
+    }
+
+  }
+
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -44,10 +44,8 @@ class PBTransformationSpec extends WordSpec with MustMatchers {
       "PhoneNumber" in {
 
         addressbook.PhoneNumber("1234567", addressbook.HOME)
-          .transformInto[examples.pb.addressbook.Person.PhoneNumber] mustBe
-          examples.pb.addressbook.Person.PhoneNumber("1234567", examples.pb.addressbook.PhoneType.HOME)
-
-
+          .transformInto[examples.pb.addressbook.PhoneNumber] mustBe
+          examples.pb.addressbook.PhoneNumber("1234567", examples.pb.addressbook.PhoneType.HOME)
       }
 
     }

--- a/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney
 
 import org.scalatest.{MustMatchers, WordSpec}
 import io.scalaland.chimney.examples.addressbook
+import io.scalaland.chimney.examples.pb
 import shapeless.test._
 
 class PBTransformationSpec extends WordSpec with MustMatchers {
@@ -27,16 +28,16 @@ class PBTransformationSpec extends WordSpec with MustMatchers {
     "transform enum represented as sealed trait hierarchy" in {
 
       (addressbook.MOBILE: addressbook.PhoneType)
-        .transformInto[examples.pb.addressbook.PhoneType] mustBe
-        examples.pb.addressbook.PhoneType.MOBILE
+        .transformInto[pb.addressbook.PhoneType] mustBe
+        pb.addressbook.PhoneType.MOBILE
 
       (addressbook.HOME: addressbook.PhoneType)
-        .transformInto[examples.pb.addressbook.PhoneType] mustBe
-        examples.pb.addressbook.PhoneType.HOME
+        .transformInto[pb.addressbook.PhoneType] mustBe
+        pb.addressbook.PhoneType.HOME
 
       (addressbook.WORK: addressbook.PhoneType)
-        .transformInto[examples.pb.addressbook.PhoneType] mustBe
-        examples.pb.addressbook.PhoneType.WORK
+        .transformInto[pb.addressbook.PhoneType] mustBe
+        pb.addressbook.PhoneType.WORK
     }
 
     "transform bigger case classes" when {
@@ -44,8 +45,76 @@ class PBTransformationSpec extends WordSpec with MustMatchers {
       "PhoneNumber" in {
 
         addressbook.PhoneNumber("1234567", addressbook.HOME)
-          .transformInto[examples.pb.addressbook.PhoneNumber] mustBe
-          examples.pb.addressbook.PhoneNumber("1234567", examples.pb.addressbook.PhoneType.HOME)
+          .transformInto[pb.addressbook.PhoneNumber] mustBe
+          pb.addressbook.PhoneNumber("1234567", pb.addressbook.PhoneType.HOME)
+      }
+
+      "Person" in {
+
+        addressbook.Person(
+          addressbook.PersonName("John"),
+          addressbook.PersonId(123),
+          addressbook.Email("john@example.com"),
+          List(
+            addressbook.PhoneNumber("1234567", addressbook.HOME),
+            addressbook.PhoneNumber("77332233", addressbook.WORK),
+            addressbook.PhoneNumber("88776655", addressbook.MOBILE)
+          )
+        ).transformInto[pb.addressbook.Person] mustBe
+          pb.addressbook.Person(
+            "John",
+            123,
+            "john@example.com",
+            Seq(
+              pb.addressbook.PhoneNumber("1234567", pb.addressbook.PhoneType.HOME),
+              pb.addressbook.PhoneNumber("77332233", pb.addressbook.PhoneType.WORK),
+              pb.addressbook.PhoneNumber("88776655", pb.addressbook.PhoneType.MOBILE)
+            )
+          )
+      }
+
+      "AddressBook" in {
+
+        addressbook.AddressBook(List(
+          addressbook.Person(
+            addressbook.PersonName("John"),
+            addressbook.PersonId(123),
+            addressbook.Email("john@example.com"),
+            List(
+              addressbook.PhoneNumber("1234567", addressbook.HOME),
+              addressbook.PhoneNumber("77332233", addressbook.WORK),
+              addressbook.PhoneNumber("88776655", addressbook.MOBILE)
+            )
+          ),
+          addressbook.Person(
+            addressbook.PersonName("Susan"),
+            addressbook.PersonId(321),
+            addressbook.Email("susan@example.com"),
+            List(
+              addressbook.PhoneNumber("200300400", addressbook.MOBILE)
+            )
+          )
+        )).transformInto[pb.addressbook.AddressBook] mustBe
+          pb.addressbook.AddressBook(Seq(
+            pb.addressbook.Person(
+              "John",
+              123,
+              "john@example.com",
+              Seq(
+                pb.addressbook.PhoneNumber("1234567", pb.addressbook.PhoneType.HOME),
+                pb.addressbook.PhoneNumber("77332233", pb.addressbook.PhoneType.WORK),
+                pb.addressbook.PhoneNumber("88776655", pb.addressbook.PhoneType.MOBILE)
+              )
+            ),
+            pb.addressbook.Person(
+              "Susan",
+              321,
+              "susan@example.com",
+              Seq(
+                pb.addressbook.PhoneNumber("200300400", pb.addressbook.PhoneType.MOBILE)
+              )
+            )
+          ))
       }
 
     }

--- a/chimney/src/test/scala/io/scalaland/chimney/ValueProviderSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/ValueProviderSpec.scala
@@ -89,6 +89,12 @@ class ValueProviderSpec extends WordSpec with MustMatchers {
 
       ValueProvider.provide(Response2("si", Yes), 'answer, classOf[Answer], HNil) mustBe
         Yes
+
+      ValueProvider.provide(Response2("no", No), 'other, classOf[String], HNil) mustBe
+        "no"
+
+      ValueProvider.provide(Response2("si", Yes), 'other, classOf[String], HNil) mustBe
+        "si"
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/ValueProviderSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/ValueProviderSpec.scala
@@ -75,5 +75,27 @@ class ValueProviderSpec extends WordSpec with MustMatchers {
           HNil) mustBe
         "provided1"
     }
+
+    "provide value for coproduct field" in {
+
+      ValueProvider.provide(Response(No), 'answer, classOf[Answer], HNil) mustBe
+        No
+
+      ValueProvider.provide(Response(Yes), 'answer, classOf[Answer], HNil) mustBe
+        Yes
+
+      ValueProvider.provide(Response2("no", No), 'answer, classOf[Answer], HNil) mustBe
+        No
+
+      ValueProvider.provide(Response2("si", Yes), 'answer, classOf[Answer], HNil) mustBe
+        Yes
+    }
   }
 }
+
+sealed trait Answer
+case object Yes extends Answer
+case object No extends Answer
+case class Response(answer: Answer)
+case class Response2(other: String, answer: Answer)
+

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/addressbook/AddressBook.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/addressbook/AddressBook.scala
@@ -5,10 +5,10 @@ case class PersonId(id: Int) extends AnyVal
 case class Email(email: String) extends AnyVal
 
 sealed trait PhoneType
-case object `PhoneType.MOBILE` extends PhoneType
-case object `PhoneType.HOME` extends PhoneType
-case object `PhoneType.WORK` extends PhoneType
 
+case object MOBILE extends PhoneType
+case object HOME extends PhoneType
+case object WORK extends PhoneType
 
 object Person {
 

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/addressbook/AddressBook.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/addressbook/AddressBook.scala
@@ -10,18 +10,13 @@ case object MOBILE extends PhoneType
 case object HOME extends PhoneType
 case object WORK extends PhoneType
 
-object Person {
-
-  case class PhoneNumber(number: String,
-                         `type`: PhoneType)
-}
+case class PhoneNumber(number: String,
+                       `type`: PhoneType)
 
 case class Person(name: PersonName,
                   id: PersonId,
                   email: Email,
-                  phones: List[Person.PhoneNumber])
-
-
+                  phones: List[PhoneNumber])
 
 
 case class AddressBook(people: List[Person])

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/addressbook/AddressBook.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/addressbook/AddressBook.scala
@@ -1,0 +1,27 @@
+package io.scalaland.chimney.examples.addressbook
+
+case class PersonName(name: String) extends AnyVal
+case class PersonId(id: Int) extends AnyVal
+case class Email(email: String) extends AnyVal
+
+sealed trait PhoneType
+case object `PhoneType.MOBILE` extends PhoneType
+case object `PhoneType.HOME` extends PhoneType
+case object `PhoneType.WORK` extends PhoneType
+
+
+object Person {
+
+  case class PhoneNumber(number: String,
+                         `type`: PhoneType)
+}
+
+case class Person(name: PersonName,
+                  id: PersonId,
+                  email: Email,
+                  phones: List[Person.PhoneNumber])
+
+
+
+
+case class AddressBook(people: List[Person])

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.8" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.10"))
+
+libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.0-pre4"

--- a/protos/src/main/protobuf/addressbook.proto
+++ b/protos/src/main/protobuf/addressbook.proto
@@ -10,15 +10,15 @@ enum PhoneType {
     WORK = 2;
 }
 
+message PhoneNumber {
+    string number = 1;
+    PhoneType type = 2;
+}
+
 message Person {
     string name = 1;
     int32 id = 2;  // Unique ID number for this person.
     string email = 3;
-
-    message PhoneNumber {
-        string number = 1;
-        PhoneType type = 2;
-    }
 
     repeated PhoneNumber phones = 4;
 }

--- a/protos/src/main/protobuf/addressbook.proto
+++ b/protos/src/main/protobuf/addressbook.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+package tutorial;
+
+option java_package = "io.scalaland.chimney.examples.pb";
+option java_outer_classname = "AddressBookProtos";
+
+message Person {
+    string name = 1;
+    int32 id = 2;  // Unique ID number for this person.
+    string email = 3;
+
+    enum PhoneType {
+        MOBILE = 0;
+        HOME = 1;
+        WORK = 2;
+    }
+
+    message PhoneNumber {
+        string number = 1;
+        PhoneType type = 2;
+    }
+
+    repeated PhoneNumber phones = 4;
+}
+
+message AddressBook {
+    repeated Person people = 1;
+}

--- a/protos/src/main/protobuf/addressbook.proto
+++ b/protos/src/main/protobuf/addressbook.proto
@@ -4,16 +4,16 @@ package tutorial;
 option java_package = "io.scalaland.chimney.examples.pb";
 option java_outer_classname = "AddressBookProtos";
 
+enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+}
+
 message Person {
     string name = 1;
     int32 id = 2;  // Unique ID number for this person.
     string email = 3;
-
-    enum PhoneType {
-        MOBILE = 0;
-        HOME = 1;
-        WORK = 2;
-    }
 
     message PhoneNumber {
         string number = 1;


### PR DESCRIPTION
It addresses #18 by defining simple domain model both in type-safe Scala code and Protobuf definition. For now it can derive conversion from scala to pb. There is `.proto` file provided in separate module, which scalaPB generates Scala case classes from and generated code is only used for tests.

Changes:
- added support for simple coproducts (#7), but only to handle enums by finding corresponding case objects instances. Due to SI-7046 we can't put Scala enum instances to companion object of sealed trait (but on the target side, in scalaPB generated code it can be enclosed in a such way)
- extended support for traversable collections (i.e. now we can require derived transformer from `List[A]` to `Seq[B]` assuming only that transformer from `A` to `B` exists)
- removed scala 2.12.0 from travis - due to bugs connected with SI-7046; on 2.12.1 and 2.12.2 it works fine

It still works for both JVM and JS targets.

One ugly hack was used to make things work. In GenericInstances of DerivedTransformer there is normal gen instance (with `Lazy`fied instance for generic case), but it doesn't handle some cases. OTOH, these cases are handled fine without `Lazy`, so when I put non-Lazy instance (gen2) to LowPriorityGenericInstances, all cases are magically handled! I would like to hear how to solve it properly :)