### PR TITLE
Initial support for coproduct instances modifiers

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/CoproductInstanceProvider.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/CoproductInstanceProvider.scala
@@ -1,14 +1,14 @@
 package io.scalaland.chimney
 
-import shapeless.{Coproduct, HList, Witness, ops}
-import shapeless.labelled.{field, FieldType}
+import shapeless.labelled.{FieldType, field}
+import shapeless.{::, Coproduct, HList, LabelledGeneric, Witness, ops}
 
 trait CoproductInstanceProvider[Label <: Symbol, FromT, ToLG <: Coproduct, Modifiers <: HList] {
 
   def provide(src: FieldType[Label, FromT], modifiers: Modifiers): ToLG
 }
 
-object CoproductInstanceProvider {
+object CoproductInstanceProvider extends LowPriCIP {
 
   implicit final def matchingObjCase[ToLG <: Coproduct, Label <: Symbol, FromT, TargetT, Modifiers <: HList](
     implicit sel: ops.union.Selector.Aux[ToLG, Label, TargetT],
@@ -16,4 +16,24 @@ object CoproductInstanceProvider {
     inj: ops.coproduct.Inject[ToLG, FieldType[Label, TargetT]]
   ): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
     (_: FieldType[Label, FromT], _: Modifiers) => inj(field[Label](wit.value))
+
+}
+
+trait LowPriCIP {
+
+  implicit final def coproductInstanceCase[ToLG <: Coproduct,
+                                           Label <: Symbol,
+                                           Inst,
+                                           FromT <: Inst,
+                                           To,
+                                           Modifiers <: HList](
+    implicit lg: LabelledGeneric.Aux[To, ToLG]
+  ): CoproductInstanceProvider[Label, FromT, ToLG, Modifier.coproductInstance[Inst, To] :: Modifiers] =
+    (src: FieldType[Label, FromT], modifiers: Modifier.coproductInstance[Inst, To] :: Modifiers) =>
+      lg.to(modifiers.head.f(src))
+
+  implicit final def cconsTailCase[ToLG <: Coproduct, Label <: Symbol, FromT, M <: Modifier, Modifiers <: HList](
+    implicit cip: CoproductInstanceProvider[Label, FromT, ToLG, Modifiers]
+  ): CoproductInstanceProvider[Label, FromT, ToLG, M :: Modifiers] =
+    (src: FieldType[Label, FromT], modifiers: M :: Modifiers) => cip.provide(src, modifiers.tail)
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Modifier.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Modifier.scala
@@ -8,6 +8,7 @@ object Modifier {
 
   private[chimney] class fieldFunction[Label <: Symbol, From, T](val map: From => T) extends Modifier
   private[chimney] class relabel[FromLabel <: Symbol, ToLabel <: Symbol] extends Modifier
+  private[chimney] class coproductInstance[From, T](val f: From => T) extends Modifier
 
   final def fieldConstant[From, T](label: Witness.Lt[Symbol], value: T): fieldFunction[label.T, From, T] =
     new fieldFunction[label.T, From, T]((_: From) => value)
@@ -17,4 +18,7 @@ object Modifier {
 
   final def relabel(label1: Witness.Lt[Symbol], label2: Witness.Lt[Symbol]): relabel[label1.T, label2.T] =
     new relabel
+
+  final def coproductInstance[From, T](convert: From => T): coproductInstance[From, T] =
+    new coproductInstance(convert)
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -32,6 +32,11 @@ object dsl {
     ): TransformerInto[From, To, Modifier.relabel[labelFrom.T, labelTo.T] :: Modifiers] =
       new TransformerInto(source, new Modifier.relabel[labelFrom.T, labelTo.T] :: modifiers)
 
+    def withCoproductInstance[Inst](
+      f: Inst => To
+    ): TransformerInto[From, To, Modifier.coproductInstance[Inst, To] :: Modifiers] =
+      new TransformerInto(source, new Modifier.coproductInstance[Inst, To](f) :: modifiers)
+
     def transform(implicit transformer: DerivedTransformer[From, To, Modifiers]): To =
       transformer.transform(source, modifiers)
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/CoproductInstanceProviderSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CoproductInstanceProviderSpec.scala
@@ -1,0 +1,46 @@
+package io.scalaland.chimney
+
+import org.scalatest.{MustMatchers, WordSpec}
+import shapeless.HNil
+import shapeless.syntax.singleton._
+
+class CoproductInstanceProviderSpec extends WordSpec with MustMatchers {
+
+  "CoproductInstanceProvider" should {
+
+    "provide instance for coproducts by matching label of singleton type" in {
+
+      import examples._
+
+      CoproductInstanceProvider
+        .provide('Red ->> colors1.Red, classOf[colors2.Color], HNil) mustBe
+        colors2.Red
+    }
+
+    "respect specific instances overriding" in {
+
+      import examples._
+
+      val overrideModifier = Modifier.coproductInstance { (_: colors1.Red.type) =>
+        colors2.Black: colors2.Color
+      }
+
+      CoproductInstanceProvider
+        .provide('Red ->> colors1.Red, classOf[colors2.Color], overrideModifier :: HNil) mustBe
+        colors2.Black
+    }
+
+    "respect general transformation overriding" in {
+
+      import examples._
+
+      val overrideModifier = Modifier.coproductInstance[colors1.Color, colors2.Color] { _ =>
+        colors2.Blue
+      }
+
+      CoproductInstanceProvider
+        .provide('Red ->> colors1.Red, classOf[colors2.Color], overrideModifier :: HNil) mustBe
+        colors2.Blue
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -217,8 +217,8 @@ class DslSpec extends WordSpec with MustMatchers {
 
         triangle
           .into[shapes2.Shape]
-          .withCoproductInstance[shapes1.Triangle](triangleToPolygon)
-          .withCoproductInstance[shapes1.Rectangle](rectangleToPolygon)
+          .withCoproductInstance(triangleToPolygon)
+          .withCoproductInstance(rectangleToPolygon)
           .transform mustBe shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0)))
 
         val rectangle: shapes1.Shape =
@@ -226,8 +226,10 @@ class DslSpec extends WordSpec with MustMatchers {
 
         rectangle
           .into[shapes2.Shape]
-          .withCoproductInstance(triangleToPolygon)
-          .withCoproductInstance(rectangleToPolygon)
+          .withCoproductInstance[shapes1.Shape] {
+            case r: shapes1.Rectangle => rectangleToPolygon(r)
+            case t: shapes1.Triangle => triangleToPolygon(t)
+          }
           .transform mustBe shapes2.Polygon(
           List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
         )

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -156,6 +156,83 @@ class DslSpec extends WordSpec with MustMatchers {
         Map("test" -> Foo("a")).transformInto[Map[String, Bar]] mustBe Map("test" -> Bar("a"))
       }
     }
+
+    "support for sealed hierarhies" when {
+
+      "enum types encoded as sealed hierarchies of case objects" when {
+        "transforming from smaller to bigger enum" in {
+          import examples._
+
+          (colors1.Red: colors1.Color)
+            .transformInto[colors2.Color] mustBe colors2.Red
+          (colors1.Green: colors1.Color)
+            .transformInto[colors2.Color] mustBe colors2.Green
+          (colors1.Blue: colors1.Color)
+            .transformInto[colors2.Color] mustBe colors2.Blue
+        }
+
+        "transforming from bigger to smaller enum" in {
+          import examples._
+
+//          (colors2.Red: colors2.Color)
+//            .transformInto[colors1.Color] mustBe colors1.Red
+//          (colors2.Green: colors2.Color)
+//            .transformInto[colors1.Color] mustBe colors1.Green
+//          (colors2.Blue: colors2.Color)
+//            .transformInto[colors1.Color] mustBe colors1.Blue
+//          (colors2.Black: colors2.Color)
+//            .into[colors1.Color]
+//            .withCoproductInstance[colors2.Black.type] {
+//              case colors2.Black => colors1.Red
+//            }
+//            .transform mustBe colors1.Red
+        }
+      }
+
+      "transformic non-isomorphic domains" in {
+
+        import examples._
+
+        def triangleToPolygon(t: shapes1.Triangle): shapes2.Shape =
+          shapes2.Polygon(
+            List(
+              t.p1.transformInto[shapes2.Point],
+              t.p2.transformInto[shapes2.Point],
+              t.p3.transformInto[shapes2.Point]
+            )
+          )
+
+        def rectangleToPolygon(r: shapes1.Rectangle): shapes2.Shape =
+          shapes2.Polygon(
+            List(
+              r.p1.transformInto[shapes2.Point],
+              shapes2.Point(r.p1.x, r.p2.y),
+              r.p2.transformInto[shapes2.Point],
+              shapes2.Point(r.p2.x, r.p1.y)
+            )
+          )
+
+        val triangle: shapes1.Shape =
+          shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+
+        triangle
+          .into[shapes2.Shape]
+          .withCoproductInstance[shapes1.Triangle](triangleToPolygon)
+          .withCoproductInstance[shapes1.Rectangle](rectangleToPolygon)
+          .transform mustBe shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0)))
+
+        val rectangle: shapes1.Shape =
+          shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4))
+
+        rectangle
+          .into[shapes2.Shape]
+          .withCoproductInstance(triangleToPolygon)
+          .withCoproductInstance(rectangleToPolygon)
+          .transform mustBe shapes2.Polygon(
+          List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
+        )
+      }
+    }
   }
 }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -157,7 +157,7 @@ class DslSpec extends WordSpec with MustMatchers {
       }
     }
 
-    "support for sealed hierarhies" when {
+    "support for sealed hierarchies" when {
 
       "enum types encoded as sealed hierarchies of case objects" when {
         "transforming from smaller to bigger enum" in {

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -174,18 +174,28 @@ class DslSpec extends WordSpec with MustMatchers {
         "transforming from bigger to smaller enum" in {
           import examples._
 
-//          (colors2.Red: colors2.Color)
-//            .transformInto[colors1.Color] mustBe colors1.Red
-//          (colors2.Green: colors2.Color)
-//            .transformInto[colors1.Color] mustBe colors1.Green
-//          (colors2.Blue: colors2.Color)
-//            .transformInto[colors1.Color] mustBe colors1.Blue
-//          (colors2.Black: colors2.Color)
-//            .into[colors1.Color]
-//            .withCoproductInstance[colors2.Black.type] {
-//              case colors2.Black => colors1.Red
-//            }
-//            .transform mustBe colors1.Red
+          def blackIsRed(b: colors2.Black.type): colors1.Color =
+            colors1.Red
+
+          (colors2.Red: colors2.Color)
+            .into[colors1.Color]
+            .withCoproductInstance(blackIsRed)
+            .transform mustBe colors1.Red
+
+          (colors2.Green: colors2.Color)
+            .into[colors1.Color]
+            .withCoproductInstance(blackIsRed)
+            .transform mustBe colors1.Green
+
+          (colors2.Blue: colors2.Color)
+            .into[colors1.Color]
+            .withCoproductInstance(blackIsRed)
+            .transform mustBe colors1.Blue
+
+          (colors2.Black: colors2.Color)
+            .into[colors1.Color]
+            .withCoproductInstance(blackIsRed)
+            .transform mustBe colors1.Red
         }
       }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/Colors.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/Colors.scala
@@ -1,0 +1,16 @@
+package io.scalaland.chimney.examples
+
+package colors1 {
+  sealed trait Color
+  case object Red extends Color
+  case object Green extends Color
+  case object Blue extends Color
+}
+
+package colors2 {
+  sealed trait Color
+  case object Blue extends Color
+  case object Green extends Color
+  case object Red extends Color
+  case object Black extends Color
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/Shapes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/Shapes.scala
@@ -1,0 +1,18 @@
+package io.scalaland.chimney.examples
+
+package shapes1 {
+
+  case class Point(x: Int, y: Int)
+
+  sealed trait Shape
+  case class Triangle(p1: Point, p2: Point, p3: Point) extends Shape
+  case class Rectangle(p1: Point, p2: Point) extends Shape
+}
+
+package shapes2 {
+
+  case class Point(x: Int, y: Int)
+
+  sealed trait Shape
+  case class Polygon(points: List[Point]) extends Shape
+}


### PR DESCRIPTION
Multiple modifiers that covers all the cases that uses instance `coproductInstanceCase` seems to be working.

What doesn't work yet is a coproduct type that for different cases uses both `matchingObjCase` and modifier case. It causes ambigious implicit between `matchingObjCase` and `cconsTailCase` which is weird, since the latter is in low priority trait.