### PR TITLE
Add support for Scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: scala
 scala:
-   - 2.11.9
    - 2.11.11
    # - 2.12.0 doesn't work due to SI-7046
    - 2.12.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 scala:
+   - 2.11.9
+   - 2.11.11
    # - 2.12.0 doesn't work due to SI-7046
    - 2.12.1
    - 2.12.2

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Chimney was created to remove the pain coming from such boilerplate.
 libraryDependencies += "io.scalaland" %% "chimney" % "0.1.3"
 ```
 
-Due to [SI-7046](https://issues.scala-lang.org/browse/SI-7046) some derivations require at least Scala 2.12.1.
+Due to [SI-7046](https://issues.scala-lang.org/browse/SI-7046) some derivations require at least Scala 2.12.1 or 2.11.9.
 
 ## Basic product type rewriting
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val settings = Seq(
     "-encoding",
     "UTF-8",
     "-unchecked",
-    "-deprecation:false", // just for the time being
+    "-deprecation",
     "-explaintypes",
     "-feature",
     "-language:existentials",
@@ -24,7 +24,6 @@ val settings = Seq(
     "-Xfuture",
     "-Xlint:adapted-args",
     "-Xlint:by-name-right-associative",
-//    "-Xlint:constant",
     "-Xlint:delayedinit-select",
     "-Xlint:doc-detached",
     "-Xlint:inaccessible",

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,13 @@
 val settings = Seq(
   version := "0.1.3",
   scalaVersion := "2.12.2",
+  crossScalaVersions := Seq("2.11.11", "2.12.2"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
     "-encoding",
     "UTF-8",
     "-unchecked",
-    "-deprecation",
+    "-deprecation:false", // just for the time being
     "-explaintypes",
     "-feature",
     "-language:existentials",
@@ -23,7 +24,7 @@ val settings = Seq(
     "-Xfuture",
     "-Xlint:adapted-args",
     "-Xlint:by-name-right-associative",
-    "-Xlint:constant",
+//    "-Xlint:constant",
     "-Xlint:delayedinit-select",
     "-Xlint:doc-detached",
     "-Xlint:inaccessible",

--- a/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DerivedTransformer.scala
@@ -20,4 +20,12 @@ object DerivedTransformer
   final def apply[From, To, Modifiers <: HList](
     implicit dt: DerivedTransformer[From, To, Modifiers]
   ): DerivedTransformer[From, To, Modifiers] = dt
+
+  final def instance[From, To, Modifiers <: HList](
+    f: (From, Modifiers) => To
+  ): DerivedTransformer[From, To, Modifiers] =
+    new DerivedTransformer[From, To, Modifiers] {
+      @inline final def transform(src: From, modifiers: Modifiers): To =
+        f(src, modifiers)
+    }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -3,7 +3,6 @@ package io.scalaland.chimney
 import io.scalaland.chimney.internal.Modifier
 import shapeless.{::, HList, HNil, Witness}
 
-/** Provides syntax for API user. */
 object dsl {
 
   implicit class TransformerOps[From](val source: From) extends AnyVal {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/CoproductInstanceProvider.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/CoproductInstanceProvider.scala
@@ -18,7 +18,9 @@ object CoproductInstanceProvider extends CoproductInstanceProviderDerivation {
   )(implicit lg: LabelledGeneric.Aux[To, ToLG], cip: CoproductInstanceProvider[Label, FromT, ToLG, Modifiers]): To =
     lg.from(cip.provide(src, modifiers))
 
-  final def instance[Label <: Symbol, FromT, ToLG <: Coproduct, Modifiers <: HList](f: (FieldType[Label, FromT], Modifiers) => ToLG): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
+  final def instance[Label <: Symbol, FromT, ToLG <: Coproduct, Modifiers <: HList](
+    f: (FieldType[Label, FromT], Modifiers) => ToLG
+  ): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
     new CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] {
       @inline final def provide(src: FieldType[Label, FromT], modifiers: Modifiers): ToLG = f(src, modifiers)
     }
@@ -31,8 +33,8 @@ trait CoproductInstanceProviderDerivation extends LowPriorityCoproductInstancePr
     wit: Witness.Aux[TargetT],
     inj: ops.coproduct.Inject[ToLG, FieldType[Label, TargetT]]
   ): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
-    CoproductInstanceProvider.instance {
-      (_: FieldType[Label, FromT], _: Modifiers) => inj(field[Label](wit.value))
+    CoproductInstanceProvider.instance { (_: FieldType[Label, FromT], _: Modifiers) =>
+      inj(field[Label](wit.value))
     }
 
   implicit final def coproductInstanceCase[ToLG <: Coproduct,
@@ -51,8 +53,8 @@ trait CoproductInstanceProviderDerivation extends LowPriorityCoproductInstancePr
   implicit final def cconsTailCase[ToLG <: Coproduct, Label <: Symbol, FromT, M <: Modifier, Modifiers <: HList](
     implicit cip: CoproductInstanceProvider[Label, FromT, ToLG, Modifiers]
   ): CoproductInstanceProvider[Label, FromT, ToLG, M :: Modifiers] =
-    CoproductInstanceProvider.instance {
-      (src: FieldType[Label, FromT], modifiers: M :: Modifiers) => cip.provide(src, modifiers.tail)
+    CoproductInstanceProvider.instance { (src: FieldType[Label, FromT], modifiers: M :: Modifiers) =>
+      cip.provide(src, modifiers.tail)
     }
 }
 
@@ -62,8 +64,8 @@ trait LowPriorityCoproductInstanceProvider {
     transformer: DerivedTransformer[FromT, TargetT, Modifiers],
     inj: ops.coproduct.Inject[ToLG, FieldType[Label, TargetT]]
   ): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
-    CoproductInstanceProvider.instance {
-      (src: FieldType[Label, FromT], modifiers: Modifiers) => inj(field[Label](transformer.transform(src, modifiers)))
+    CoproductInstanceProvider.instance { (src: FieldType[Label, FromT], modifiers: Modifiers) =>
+      inj(field[Label](transformer.transform(src, modifiers)))
     }
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/CoproductInstanceProvider.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/CoproductInstanceProvider.scala
@@ -17,6 +17,11 @@ object CoproductInstanceProvider extends CoproductInstanceProviderDerivation {
     modifiers: Modifiers
   )(implicit lg: LabelledGeneric.Aux[To, ToLG], cip: CoproductInstanceProvider[Label, FromT, ToLG, Modifiers]): To =
     lg.from(cip.provide(src, modifiers))
+
+  final def instance[Label <: Symbol, FromT, ToLG <: Coproduct, Modifiers <: HList](f: (FieldType[Label, FromT], Modifiers) => ToLG): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
+    new CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] {
+      @inline final def provide(src: FieldType[Label, FromT], modifiers: Modifiers): ToLG = f(src, modifiers)
+    }
 }
 
 trait CoproductInstanceProviderDerivation extends LowPriorityCoproductInstanceProvider {
@@ -26,7 +31,9 @@ trait CoproductInstanceProviderDerivation extends LowPriorityCoproductInstancePr
     wit: Witness.Aux[TargetT],
     inj: ops.coproduct.Inject[ToLG, FieldType[Label, TargetT]]
   ): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
-    (_: FieldType[Label, FromT], _: Modifiers) => inj(field[Label](wit.value))
+    CoproductInstanceProvider.instance {
+      (_: FieldType[Label, FromT], _: Modifiers) => inj(field[Label](wit.value))
+    }
 
   implicit final def coproductInstanceCase[ToLG <: Coproduct,
                                            Label <: Symbol,
@@ -36,13 +43,17 @@ trait CoproductInstanceProviderDerivation extends LowPriorityCoproductInstancePr
                                            Modifiers <: HList](
     implicit lg: LabelledGeneric.Aux[To, ToLG]
   ): CoproductInstanceProvider[Label, FromT, ToLG, Modifier.coproductInstance[Inst, To] :: Modifiers] =
-    (src: FieldType[Label, FromT], modifiers: Modifier.coproductInstance[Inst, To] :: Modifiers) =>
-      lg.to(modifiers.head.f(src))
+    CoproductInstanceProvider.instance {
+      (src: FieldType[Label, FromT], modifiers: Modifier.coproductInstance[Inst, To] :: Modifiers) =>
+        lg.to(modifiers.head.f(src))
+    }
 
   implicit final def cconsTailCase[ToLG <: Coproduct, Label <: Symbol, FromT, M <: Modifier, Modifiers <: HList](
     implicit cip: CoproductInstanceProvider[Label, FromT, ToLG, Modifiers]
   ): CoproductInstanceProvider[Label, FromT, ToLG, M :: Modifiers] =
-    (src: FieldType[Label, FromT], modifiers: M :: Modifiers) => cip.provide(src, modifiers.tail)
+    CoproductInstanceProvider.instance {
+      (src: FieldType[Label, FromT], modifiers: M :: Modifiers) => cip.provide(src, modifiers.tail)
+    }
 }
 
 trait LowPriorityCoproductInstanceProvider {
@@ -51,6 +62,8 @@ trait LowPriorityCoproductInstanceProvider {
     transformer: DerivedTransformer[FromT, TargetT, Modifiers],
     inj: ops.coproduct.Inject[ToLG, FieldType[Label, TargetT]]
   ): CoproductInstanceProvider[Label, FromT, ToLG, Modifiers] =
-    (src: FieldType[Label, FromT], modifiers: Modifiers) => inj(field[Label](transformer.transform(src, modifiers)))
+    CoproductInstanceProvider.instance {
+      (src: FieldType[Label, FromT], modifiers: Modifiers) => inj(field[Label](transformer.transform(src, modifiers)))
+    }
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedCoproductTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedCoproductTransformer.scala
@@ -14,7 +14,9 @@ object DerivedCoproductTransformer extends CoproductInstances {
     implicit dct: DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers]
   ): DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers] = dct
 
-  final def instance[From, FromLG <: Coproduct, ToLG <: Coproduct, Modifiers <: HList](f: (FromLG, Modifiers) => ToLG): DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers] =
+  final def instance[From, FromLG <: Coproduct, ToLG <: Coproduct, Modifiers <: HList](
+    f: (FromLG, Modifiers) => ToLG
+  ): DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers] =
     new DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers] {
       @inline final def transform(src: FromLG, modifiers: Modifiers): ToLG = f(src, modifiers)
     }
@@ -25,8 +27,8 @@ trait CoproductInstances {
   // $COVERAGE-OFF$
   implicit final def cnilCase[From, ToLG <: Coproduct, Modifiers <: HList]
     : DerivedCoproductTransformer[From, CNil, ToLG, Modifiers] =
-    DerivedCoproductTransformer.instance {
-      (_: CNil, _: Modifiers) => null.asInstanceOf[ToLG]
+    DerivedCoproductTransformer.instance { (_: CNil, _: Modifiers) =>
+      null.asInstanceOf[ToLG]
     }
   // $COVERAGE-ON$
 
@@ -39,11 +41,10 @@ trait CoproductInstances {
     implicit cip: CoproductInstanceProvider[Label, HeadToT, ToLG, Modifiers],
     tailTransformer: DerivedCoproductTransformer[From, TailFromLG, ToLG, Modifiers]
   ): DerivedCoproductTransformer[From, FieldType[Label, HeadToT] :+: TailFromLG, ToLG, Modifiers] =
-    DerivedCoproductTransformer.instance {
-      (src: FieldType[Label, HeadToT] :+: TailFromLG, modifiers: Modifiers) =>
-        src match {
-          case Inl(head) => cip.provide(head, modifiers)
-          case Inr(tail) => tailTransformer.transform(tail, modifiers)
-        }
+    DerivedCoproductTransformer.instance { (src: FieldType[Label, HeadToT] :+: TailFromLG, modifiers: Modifiers) =>
+      src match {
+        case Inl(head) => cip.provide(head, modifiers)
+        case Inr(tail) => tailTransformer.transform(tail, modifiers)
+      }
     }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedCoproductTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedCoproductTransformer.scala
@@ -13,6 +13,11 @@ object DerivedCoproductTransformer extends CoproductInstances {
   final def apply[From, FromLG <: Coproduct, ToLG <: Coproduct, Modifiers <: HList](
     implicit dct: DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers]
   ): DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers] = dct
+
+  final def instance[From, FromLG <: Coproduct, ToLG <: Coproduct, Modifiers <: HList](f: (FromLG, Modifiers) => ToLG): DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers] =
+    new DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers] {
+      @inline final def transform(src: FromLG, modifiers: Modifiers): ToLG = f(src, modifiers)
+    }
 }
 
 trait CoproductInstances {
@@ -20,7 +25,9 @@ trait CoproductInstances {
   // $COVERAGE-OFF$
   implicit final def cnilCase[From, ToLG <: Coproduct, Modifiers <: HList]
     : DerivedCoproductTransformer[From, CNil, ToLG, Modifiers] =
-    (_: CNil, _: Modifiers) => null.asInstanceOf[ToLG]
+    DerivedCoproductTransformer.instance {
+      (_: CNil, _: Modifiers) => null.asInstanceOf[ToLG]
+    }
   // $COVERAGE-ON$
 
   implicit final def coproductCase[From,
@@ -32,9 +39,11 @@ trait CoproductInstances {
     implicit cip: CoproductInstanceProvider[Label, HeadToT, ToLG, Modifiers],
     tailTransformer: DerivedCoproductTransformer[From, TailFromLG, ToLG, Modifiers]
   ): DerivedCoproductTransformer[From, FieldType[Label, HeadToT] :+: TailFromLG, ToLG, Modifiers] =
-    (src: FieldType[Label, HeadToT] :+: TailFromLG, modifiers: Modifiers) =>
-      src match {
-        case Inl(head) => cip.provide(head, modifiers)
-        case Inr(tail) => tailTransformer.transform(tail, modifiers)
+    DerivedCoproductTransformer.instance {
+      (src: FieldType[Label, HeadToT] :+: TailFromLG, modifiers: Modifiers) =>
+        src match {
+          case Inl(head) => cip.provide(head, modifiers)
+          case Inr(tail) => tailTransformer.transform(tail, modifiers)
+        }
     }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedProductTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedProductTransformer.scala
@@ -14,7 +14,9 @@ object DerivedProductTransformer extends ProductInstances {
     implicit dpt: DerivedProductTransformer[From, FromLG, ToLG, Modifiers]
   ): DerivedProductTransformer[From, FromLG, ToLG, Modifiers] = dpt
 
-  final def instance[From, FromLG <: HList, ToLG <: HList, Modifiers <: HList](f: (FromLG, Modifiers) => ToLG):  DerivedProductTransformer[From, FromLG, ToLG, Modifiers] =
+  final def instance[From, FromLG <: HList, ToLG <: HList, Modifiers <: HList](
+    f: (FromLG, Modifiers) => ToLG
+  ): DerivedProductTransformer[From, FromLG, ToLG, Modifiers] =
     new DerivedProductTransformer[From, FromLG, ToLG, Modifiers] {
       @inline final def transform(src: FromLG, modifiers: Modifiers): ToLG = f(src, modifiers)
     }
@@ -24,16 +26,15 @@ trait ProductInstances {
 
   implicit final def hnilCase[From, FromLG <: HList, Modifiers <: HList]
     : DerivedProductTransformer[From, FromLG, HNil, Modifiers] =
-    DerivedProductTransformer.instance {
-      (_: FromLG, _: Modifiers) => HNil
+    DerivedProductTransformer.instance { (_: FromLG, _: Modifiers) =>
+      HNil
     }
 
   implicit final def hconsCase[From, FromLG <: HList, Label <: Symbol, HeadToT, TailToLG <: HList, Modifiers <: HList](
     implicit vp: ValueProvider[From, FromLG, HeadToT, Label, Modifiers],
     tailTransformer: DerivedProductTransformer[From, FromLG, TailToLG, Modifiers]
   ): DerivedProductTransformer[From, FromLG, FieldType[Label, HeadToT] :: TailToLG, Modifiers] =
-    DerivedProductTransformer.instance {
-      (src: FromLG, modifiers: Modifiers) =>
-        field[Label](vp.provide(src, modifiers)) :: tailTransformer.transform(src, modifiers)
+    DerivedProductTransformer.instance { (src: FromLG, modifiers: Modifiers) =>
+      field[Label](vp.provide(src, modifiers)) :: tailTransformer.transform(src, modifiers)
     }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedProductTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedProductTransformer.scala
@@ -13,18 +13,27 @@ object DerivedProductTransformer extends ProductInstances {
   final def apply[From, FromLG <: HList, ToLG <: HList, Modifiers <: HList](
     implicit dpt: DerivedProductTransformer[From, FromLG, ToLG, Modifiers]
   ): DerivedProductTransformer[From, FromLG, ToLG, Modifiers] = dpt
+
+  final def instance[From, FromLG <: HList, ToLG <: HList, Modifiers <: HList](f: (FromLG, Modifiers) => ToLG):  DerivedProductTransformer[From, FromLG, ToLG, Modifiers] =
+    new DerivedProductTransformer[From, FromLG, ToLG, Modifiers] {
+      @inline final def transform(src: FromLG, modifiers: Modifiers): ToLG = f(src, modifiers)
+    }
 }
 
 trait ProductInstances {
 
   implicit final def hnilCase[From, FromLG <: HList, Modifiers <: HList]
     : DerivedProductTransformer[From, FromLG, HNil, Modifiers] =
-    (_: FromLG, _: Modifiers) => HNil
+    DerivedProductTransformer.instance {
+      (_: FromLG, _: Modifiers) => HNil
+    }
 
   implicit final def hconsCase[From, FromLG <: HList, Label <: Symbol, HeadToT, TailToLG <: HList, Modifiers <: HList](
     implicit vp: ValueProvider[From, FromLG, HeadToT, Label, Modifiers],
     tailTransformer: DerivedProductTransformer[From, FromLG, TailToLG, Modifiers]
   ): DerivedProductTransformer[From, FromLG, FieldType[Label, HeadToT] :: TailToLG, Modifiers] =
-    (src: FromLG, modifiers: Modifiers) =>
-      field[Label](vp.provide(src, modifiers)) :: tailTransformer.transform(src, modifiers)
+    DerivedProductTransformer.instance {
+      (src: FromLG, modifiers: Modifiers) =>
+        field[Label](vp.provide(src, modifiers)) :: tailTransformer.transform(src, modifiers)
+    }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
@@ -79,14 +79,16 @@ trait EitherInstances {
     implicit leftTransformer: DerivedTransformer[FromL, ToL, Modifiers]
   ): DerivedTransformer[Left[FromL, FromR], Either[ToL, ToR], Modifiers] =
     DerivedTransformer.instance { (src: Left[FromL, FromR], modifiers: Modifiers) =>
-      Left(leftTransformer.transform(src.a, modifiers))
+      val Left(value) = src
+      Left(leftTransformer.transform(value, modifiers))
     }
 
   implicit final def rightTransformer[FromL, ToL, FromR, ToR, Modifiers <: HList](
     implicit rightTransformer: DerivedTransformer[FromR, ToR, Modifiers]
   ): DerivedTransformer[Right[FromL, FromR], Either[ToL, ToR], Modifiers] =
     DerivedTransformer.instance { (src: Right[FromL, FromR], modifiers: Modifiers) =>
-      Right(rightTransformer.transform(src.b, modifiers))
+      val Right(value) = src
+      Right(rightTransformer.transform(value, modifiers))
     }
 }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
@@ -11,10 +11,14 @@ trait BasicInstances {
   implicit final def fromTransformer[T, U, Modifiers <: HList](
     implicit transformer: Transformer[T, U]
   ): DerivedTransformer[T, U, Modifiers] =
-    (src: T, _: Modifiers) => transformer.transform(src)
+    DerivedTransformer.instance { (src: T, _: Modifiers) =>
+      transformer.transform(src)
+    }
 
   implicit final def identityTransformer[T, Modifiers <: HList]: DerivedTransformer[T, T, Modifiers] =
-    (src: T, _: Modifiers) => src
+    DerivedTransformer.instance { (src: T, _: Modifiers) =>
+      src
+    }
 }
 
 trait ValueClassInstances {
@@ -22,12 +26,16 @@ trait ValueClassInstances {
   implicit final def toValueClassTransformer[C <: AnyVal, V, Modifiers <: HList](
     implicit gen: Generic.Aux[C, V :: HNil]
   ): DerivedTransformer[V, C, Modifiers] =
-    (src: V, _: Modifiers) => gen.from(src :: HNil)
+    DerivedTransformer.instance { (src: V, _: Modifiers) =>
+      gen.from(src :: HNil)
+    }
 
   implicit final def fromValueClassTransformer[C <: AnyVal, V, Modifiers <: HList](
     implicit gen: Generic.Aux[C, V :: HNil]
   ): DerivedTransformer[C, V, Modifiers] =
-    (src: C, _: Modifiers) => gen.to(src).head
+    DerivedTransformer.instance { (src: C, _: Modifiers) =>
+      gen.to(src).head
+    }
 }
 
 trait OptionInstances {
@@ -35,17 +43,23 @@ trait OptionInstances {
   implicit final def optionTransformer[From, To, Modifiers <: HList](
     implicit innerTransformer: DerivedTransformer[From, To, Modifiers]
   ): DerivedTransformer[Option[From], Option[To], Modifiers] =
-    (src: Option[From], modifiers: Modifiers) => src.map(innerTransformer.transform(_, modifiers))
+    DerivedTransformer.instance { (src: Option[From], modifiers: Modifiers) =>
+      src.map(innerTransformer.transform(_, modifiers))
+    }
 
   implicit final def someTransformer[From, To, Modifiers <: HList](
     implicit innerTransformer: DerivedTransformer[From, To, Modifiers]
   ): DerivedTransformer[Some[From], Option[To], Modifiers] =
-    (src: Some[From], modifiers: Modifiers) => Some(innerTransformer.transform(src.value, modifiers))
+    DerivedTransformer.instance[Some[From], Option[To], Modifiers] { (src: Some[From], modifiers: Modifiers) =>
+      Some(innerTransformer.transform(src.get, modifiers))
+    }
 
   implicit final def noneTransformer[From, To, Modifiers <: HList](
     implicit innerTransformer: DerivedTransformer[From, To, Modifiers]
   ): DerivedTransformer[None.type, Option[To], Modifiers] =
-    (_: None.type, _: Modifiers) => None
+    DerivedTransformer.instance { (_: None.type, _: Modifiers) =>
+      None
+    }
 }
 
 trait EitherInstances {
@@ -54,21 +68,26 @@ trait EitherInstances {
     implicit leftTransformer: DerivedTransformer[FromL, ToL, Modifiers],
     rightTransformer: DerivedTransformer[FromR, ToR, Modifiers]
   ): DerivedTransformer[Either[FromL, FromR], Either[ToL, ToR], Modifiers] =
-    (src: Either[FromL, FromR], modifiers: Modifiers) =>
+    DerivedTransformer.instance { (src: Either[FromL, FromR], modifiers: Modifiers) =>
       src match {
         case Left(value) => Left(leftTransformer.transform(value, modifiers))
         case Right(value) => Right(rightTransformer.transform(value, modifiers))
+      }
     }
 
   implicit final def leftTransformer[FromL, ToL, FromR, ToR, Modifiers <: HList](
     implicit leftTransformer: DerivedTransformer[FromL, ToL, Modifiers]
   ): DerivedTransformer[Left[FromL, FromR], Either[ToL, ToR], Modifiers] =
-    (src: Left[FromL, FromR], modifiers: Modifiers) => Left(leftTransformer.transform(src.value, modifiers))
+    DerivedTransformer.instance { (src: Left[FromL, FromR], modifiers: Modifiers) =>
+      Left(leftTransformer.transform(src.a, modifiers))
+    }
 
   implicit final def rightTransformer[FromL, ToL, FromR, ToR, Modifiers <: HList](
     implicit rightTransformer: DerivedTransformer[FromR, ToR, Modifiers]
   ): DerivedTransformer[Right[FromL, FromR], Either[ToL, ToR], Modifiers] =
-    (src: Right[FromL, FromR], modifiers: Modifiers) => Right(rightTransformer.transform(src.value, modifiers))
+    DerivedTransformer.instance { (src: Right[FromL, FromR], modifiers: Modifiers) =>
+      Right(rightTransformer.transform(src.b, modifiers))
+    }
 }
 
 trait CollectionInstances {
@@ -79,22 +98,27 @@ trait CollectionInstances {
     ev2: M2[To] <:< Traversable[To],
     cbf: CanBuildFrom[M1[From], To, M2[To]]
   ): DerivedTransformer[M1[From], M2[To], Modifiers] =
-    (src: M1[From], modifiers: Modifiers) => src.map(innerTransformer.transform(_: From, modifiers)).to[M2]
+    DerivedTransformer.instance { (src: M1[From], modifiers: Modifiers) =>
+      src.map(innerTransformer.transform(_: From, modifiers)).to[M2]
+    }
 
   implicit final def arrayTransformer[From, To, Modifiers <: HList](
     implicit innerTransformer: DerivedTransformer[From, To, Modifiers],
     toTag: ClassTag[To]
   ): DerivedTransformer[Array[From], Array[To], Modifiers] =
-    (src: Array[From], modifiers: Modifiers) => src.map(innerTransformer.transform(_: From, modifiers))
+    DerivedTransformer.instance { (src: Array[From], modifiers: Modifiers) =>
+      src.map(innerTransformer.transform(_: From, modifiers))
+    }
 
   implicit final def mapTransformer[FromK, ToK, FromV, ToV, Modifiers <: HList](
     implicit keyTransformer: DerivedTransformer[FromK, ToK, Modifiers],
     valueTransformer: DerivedTransformer[FromV, ToV, Modifiers]
   ): DerivedTransformer[Map[FromK, FromV], Map[ToK, ToV], Modifiers] =
-    (src: Map[FromK, FromV], modifiers: Modifiers) =>
+    DerivedTransformer.instance { (src: Map[FromK, FromV], modifiers: Modifiers) =>
       src.map {
         case (key, value) =>
           keyTransformer.transform(key, modifiers) -> valueTransformer.transform(value, modifiers)
+      }
     }
 }
 
@@ -105,12 +129,16 @@ trait GenericInstances {
     toLG: LabelledGeneric.Aux[To, ToLG],
     intermediateTransformer: Lazy[DerivedProductTransformer[From, FromLG, ToLG, Modifiers]]
   ): DerivedTransformer[From, To, Modifiers] =
-    (src: From, modifiers: Modifiers) => toLG.from(intermediateTransformer.value.transform(fromLG.to(src), modifiers))
+    DerivedTransformer.instance { (src: From, modifiers: Modifiers) =>
+      toLG.from(intermediateTransformer.value.transform(fromLG.to(src), modifiers))
+    }
 
   implicit final def genCoproduct[From, To, FromLG <: Coproduct, ToLG <: Coproduct, Modifiers <: HList](
     implicit fromLG: LabelledGeneric.Aux[From, FromLG],
     toLG: LabelledGeneric.Aux[To, ToLG],
     intermediateTransformer: Lazy[DerivedCoproductTransformer[From, FromLG, ToLG, Modifiers]]
   ): DerivedTransformer[From, To, Modifiers] =
-    (src: From, modifiers: Modifiers) => toLG.from(intermediateTransformer.value.transform(fromLG.to(src), modifiers))
+    DerivedTransformer.instance { (src: From, modifiers: Modifiers) =>
+      toLG.from(intermediateTransformer.value.transform(fromLG.to(src), modifiers))
+    }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/PatcherInstances.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/PatcherInstances.scala
@@ -6,8 +6,15 @@ import shapeless._
 
 trait PatcherInstances {
 
+  final def instance[T, P](f: (T, P) => T): Patcher[T, P] =
+    new Patcher[T, P] {
+      @inline final def patch(obj: T, patch: P): T = f(obj, patch)
+    }
+
   implicit def hnilCase[TLG <: HList]: Patcher[TLG, HNil] =
-    (obj: TLG, _: HNil) => obj
+    instance { (obj: TLG, _: HNil) =>
+      obj
+    }
 
   implicit def hconsCase[L <: Symbol, T, PTail <: HList, U, TLG <: HList](
     implicit sel: ops.record.Selector.Aux[TLG, L, U],
@@ -15,13 +22,17 @@ trait PatcherInstances {
     upd: ops.record.Updater.Aux[TLG, FieldType[L, U], TLG],
     tailPatcher: Patcher[TLG, PTail]
   ): Patcher[TLG, FieldType[L, T] :: PTail] =
-    (obj: TLG, patch: FieldType[L, T] :: PTail) => {
-      val patchedHead = upd(obj, field[L](dt.transform(patch.head, HNil)))
-      tailPatcher.patch(patchedHead, patch.tail)
+    instance { (obj: TLG, patch: FieldType[L, T] :: PTail) =>
+      {
+        val patchedHead = upd(obj, field[L](dt.transform(patch.head, HNil)))
+        tailPatcher.patch(patchedHead, patch.tail)
+      }
     }
 
   implicit def gen[T, P, TLG, PLG](implicit tlg: LabelledGeneric.Aux[T, TLG],
                                    plg: LabelledGeneric.Aux[P, PLG],
                                    patcher: Patcher[TLG, PLG]): Patcher[T, P] =
-    (obj: T, patch: P) => tlg.from(patcher.patch(tlg.to(obj), plg.to(patch)))
+    instance { (obj: T, patch: P) =>
+      tlg.from(patcher.patch(tlg.to(obj), plg.to(patch)))
+    }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/ValueProvider.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/ValueProvider.scala
@@ -18,7 +18,9 @@ object ValueProvider extends ValueProviderDerivation {
     vp: ValueProvider[From, FromLG, TargetT, targetLabel.T, Modifiers]
   ): TargetT = vp.provide(lg.to(from), modifiers)
 
-  final def instance[From, FromLG, TargetT, Label <: Symbol, Modifiers <: HList](f: (FromLG, Modifiers) => TargetT): ValueProvider[From, FromLG, TargetT, Label, Modifiers] =
+  final def instance[From, FromLG, TargetT, Label <: Symbol, Modifiers <: HList](
+    f: (FromLG, Modifiers) => TargetT
+  ): ValueProvider[From, FromLG, TargetT, Label, Modifiers] =
     new ValueProvider[From, FromLG, TargetT, Label, Modifiers] {
       @inline final def provide(src: FromLG, modifiers: Modifiers): TargetT = f(src, modifiers)
     }
@@ -30,16 +32,15 @@ trait ValueProviderDerivation {
     implicit fieldSelector: ops.record.Selector.Aux[FromLG, Label, FromT],
     fieldTransformer: DerivedTransformer[FromT, TargetT, Modifiers]
   ): ValueProvider[From, FromLG, TargetT, Label, Modifiers] =
-    ValueProvider.instance {
-      (src: FromLG, modifiers: Modifiers) => fieldTransformer.transform(fieldSelector(src), modifiers)
+    ValueProvider.instance { (src: FromLG, modifiers: Modifiers) =>
+      fieldTransformer.transform(fieldSelector(src), modifiers)
     }
 
   implicit final def hconsFieldFunctionCase[From, FromLG <: HList, TargetT, Label <: Symbol, Modifiers <: HList](
     implicit fromLG: LabelledGeneric.Aux[From, FromLG]
   ): ValueProvider[From, FromLG, TargetT, Label, Modifier.fieldFunction[Label, From, TargetT] :: Modifiers] =
-    ValueProvider.instance {
-      (src: FromLG, modifiers: Modifier.fieldFunction[Label, From, TargetT] :: Modifiers) =>
-        modifiers.head.map(fromLG.from(src))
+    ValueProvider.instance { (src: FromLG, modifiers: Modifier.fieldFunction[Label, From, TargetT] :: Modifiers) =>
+      modifiers.head.map(fromLG.from(src))
     }
 
   implicit final def hconsRelabelCase[From,
@@ -50,14 +51,14 @@ trait ValueProviderDerivation {
                                       Modifiers <: HList](
     implicit fieldSelector: ops.record.Selector.Aux[FromLG, LabelFrom, TargetT]
   ): ValueProvider[From, FromLG, TargetT, LabelTo, Modifier.relabel[LabelFrom, LabelTo] :: Modifiers] =
-    ValueProvider.instance {
-      (src: FromLG, _: Modifier.relabel[LabelFrom, LabelTo] :: Modifiers) => fieldSelector(src)
+    ValueProvider.instance { (src: FromLG, _: Modifier.relabel[LabelFrom, LabelTo] :: Modifiers) =>
+      fieldSelector(src)
     }
 
   implicit final def hconsTailCase[From, FromLG <: HList, TargetT, Label <: Symbol, M <: Modifier, Ms <: HList](
     implicit vp: ValueProvider[From, FromLG, TargetT, Label, Ms]
   ): ValueProvider[From, FromLG, TargetT, Label, M :: Ms] =
-    ValueProvider.instance {
-      (src: FromLG, modifiers: M :: Ms) => vp.provide(src, modifiers.tail)
+    ValueProvider.instance { (src: FromLG, modifiers: M :: Ms) =>
+      vp.provide(src, modifiers.tail)
     }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/ValueProvider.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/ValueProvider.scala
@@ -17,6 +17,11 @@ object ValueProvider extends ValueProviderDerivation {
     implicit lg: LabelledGeneric.Aux[From, FromLG],
     vp: ValueProvider[From, FromLG, TargetT, targetLabel.T, Modifiers]
   ): TargetT = vp.provide(lg.to(from), modifiers)
+
+  final def instance[From, FromLG, TargetT, Label <: Symbol, Modifiers <: HList](f: (FromLG, Modifiers) => TargetT): ValueProvider[From, FromLG, TargetT, Label, Modifiers] =
+    new ValueProvider[From, FromLG, TargetT, Label, Modifiers] {
+      @inline final def provide(src: FromLG, modifiers: Modifiers): TargetT = f(src, modifiers)
+    }
 }
 
 trait ValueProviderDerivation {
@@ -25,13 +30,17 @@ trait ValueProviderDerivation {
     implicit fieldSelector: ops.record.Selector.Aux[FromLG, Label, FromT],
     fieldTransformer: DerivedTransformer[FromT, TargetT, Modifiers]
   ): ValueProvider[From, FromLG, TargetT, Label, Modifiers] =
-    (src: FromLG, modifiers: Modifiers) => fieldTransformer.transform(fieldSelector(src), modifiers)
+    ValueProvider.instance {
+      (src: FromLG, modifiers: Modifiers) => fieldTransformer.transform(fieldSelector(src), modifiers)
+    }
 
   implicit final def hconsFieldFunctionCase[From, FromLG <: HList, TargetT, Label <: Symbol, Modifiers <: HList](
     implicit fromLG: LabelledGeneric.Aux[From, FromLG]
   ): ValueProvider[From, FromLG, TargetT, Label, Modifier.fieldFunction[Label, From, TargetT] :: Modifiers] =
-    (src: FromLG, modifiers: Modifier.fieldFunction[Label, From, TargetT] :: Modifiers) =>
-      modifiers.head.map(fromLG.from(src))
+    ValueProvider.instance {
+      (src: FromLG, modifiers: Modifier.fieldFunction[Label, From, TargetT] :: Modifiers) =>
+        modifiers.head.map(fromLG.from(src))
+    }
 
   implicit final def hconsRelabelCase[From,
                                       FromLG <: HList,
@@ -41,10 +50,14 @@ trait ValueProviderDerivation {
                                       Modifiers <: HList](
     implicit fieldSelector: ops.record.Selector.Aux[FromLG, LabelFrom, TargetT]
   ): ValueProvider[From, FromLG, TargetT, LabelTo, Modifier.relabel[LabelFrom, LabelTo] :: Modifiers] =
-    (src: FromLG, _: Modifier.relabel[LabelFrom, LabelTo] :: Modifiers) => fieldSelector(src)
+    ValueProvider.instance {
+      (src: FromLG, _: Modifier.relabel[LabelFrom, LabelTo] :: Modifiers) => fieldSelector(src)
+    }
 
   implicit final def hconsTailCase[From, FromLG <: HList, TargetT, Label <: Symbol, M <: Modifier, Ms <: HList](
     implicit vp: ValueProvider[From, FromLG, TargetT, Label, Ms]
   ): ValueProvider[From, FromLG, TargetT, Label, M :: Ms] =
-    (src: FromLG, modifiers: M :: Ms) => vp.provide(src, modifiers.tail)
+    ValueProvider.instance {
+      (src: FromLG, modifiers: M :: Ms) => vp.provide(src, modifiers.tail)
+    }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -243,7 +243,10 @@ class DslSpec extends WordSpec with MustMatchers {
 
       "transforming isomorphic domains that differ a detail" in {
 
-        implicit val intToDoubleTransformer: Transformer[Int, Double] = _.toDouble
+        implicit val intToDoubleTransformer: Transformer[Int, Double] =
+          new Transformer[Int, Double] {
+            def transform(src: Int): Double = src.toDouble
+          }
 
         (shapes1
           .Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
@@ -264,7 +267,9 @@ object Domain1 {
   case class UserName(value: String)
 
   val userNameToStringTransformer: Transformer[UserName, String] =
-    (_: UserName).value + "T"
+    new Transformer[UserName, String] {
+      def transform(src: UserName): String = src.value + "T"
+    }
 
   case class UserDTO(id: String, name: String)
   case class User(id: String, name: UserName)


### PR DESCRIPTION
This PR adds support for Scala 2.11, which was requested in #31.
It contains implicit instances rewritten from SAM-style to style with helper instance creators, which is supported also in 2.11. Due to explicit instances for `Left/Right` I had to temporarily disable deprecation checking as it was causing build failure. Later we may consider using silencer plugin to have more fine grained control over scoped deprecation warnings.
