### PR TITLE
Issue/29 paths istead of symbol literals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,6 @@ val settings = Seq(
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
 )
 
-
-
 val dependencies = Seq(
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % versions.scalaVersion,
@@ -127,7 +125,7 @@ lazy val publishSettings = Seq(
     <developers>
       <developer>
         <id>krzemin</id>
-        <name>Piotr Krzemiński</name>
+        <name>Piotr Krzemi?ski</name>
         <url>http://github.com/krzemin</url>
       </developer>
       <developer>

--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val publishSettings = Seq(
     <developers>
       <developer>
         <id>krzemin</id>
-        <name>Piotr Krzemi?ski</name>
+        <name>Piotr Krzemiński</name>
         <url>http://github.com/krzemin</url>
       </developer>
       <developer>

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,13 @@
+val versions = new {
+  val shapelessVersion = "2.3.2"
+  val scalatestVersion = "3.0.3"
+  val scalafmt = "1.0.0-RC1"
+  val scalaVersion = "2.12.2"
+}
+
 val settings = Seq(
   version := "0.1.4",
-  scalaVersion := "2.12.2",
+  scalaVersion := versions.scalaVersion,
   crossScalaVersions := Seq("2.11.11", "2.12.2"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
@@ -42,15 +49,14 @@ val settings = Seq(
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
 )
 
-val versions = new {
-  val shapelessVersion = "2.3.2"
-  val scalatestVersion = "3.0.3"
-  val scalafmt = "1.0.0-RC1"
-}
+
 
 val dependencies = Seq(
-  libraryDependencies += "com.chuusai" %%% "shapeless" % versions.shapelessVersion,
-  libraryDependencies += "org.scalatest" %%% "scalatest" % versions.scalatestVersion % "test"
+  libraryDependencies ++= Seq(
+    "org.scala-lang" % "scala-reflect" % versions.scalaVersion,
+    "com.chuusai" %%% "shapeless" % versions.shapelessVersion,
+    "org.scalatest" %%% "scalatest" % versions.scalatestVersion % "test"
+  )
 )
 
 lazy val root = project

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -31,12 +31,13 @@ private[chimney] object DslMacros {
   }
 
   def renamedFieldSelector(c: scala.reflect.macros.whitebox.Context)
-                           (selector: c.Tree, value: c.Tree): c.Tree = {
+                           (selectorFrom: c.Tree, selectorTo: c.Tree): c.Tree = {
     import c.universe._
-    selector match {
-      case q"($_) => $_.${fieldName: Name}" =>
-        val sym = Symbol(fieldName.decodedName.toString)
-        q"{${c.prefix}}.withFieldRenamed($sym, $value)"
+    (selectorFrom, selectorTo) match {
+      case (q"($_) => $_.${fromFieldName: Name}", q"($_) => $_.${toFieldName: Name}") =>
+        val symFrom = Symbol(fromFieldName.decodedName.toString)
+        val symTo = Symbol(toFieldName.decodedName.toString)
+        q"{${c.prefix}}.withFieldRenamed($symFrom, $symTo)"
       case _ =>
         c.abort(c.enclosingPosition, "Invalid selector!")
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -33,8 +33,12 @@ private[chimney] object DslMacros {
         val symFrom = Symbol(fromFieldName.decodedName.toString)
         val symTo = Symbol(toFieldName.decodedName.toString)
         q"{${c.prefix}}.withFieldRenamed($symFrom, $symTo)"
+      case (q"($_) => $_.${fromFieldName: Name}", _) =>
+        c.abort(c.enclosingPosition, "Invalid TO selector")
+      case (_, q"($_) => $_.${toFieldName: Name}") =>
+        c.abort(c.enclosingPosition, "Invalid FROM selector")
       case _ =>
-        c.abort(c.enclosingPosition, "Invalid selector!")
+        c.abort(c.enclosingPosition, "Invalid selectors!")
     }
   }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -1,0 +1,49 @@
+package io.scalaland.chimney
+
+
+import scala.language.experimental.macros
+
+
+
+private[chimney] object DslMacros {
+  def constFieldSelector(c: scala.reflect.macros.whitebox.Context)
+                        (selector: c.Tree, value: c.Tree): c.Tree = {
+    import c.universe._
+    selector match {
+      case q"($_) => $_.${fieldName: Name}" =>
+        val sym = Symbol(fieldName.decodedName.toString)
+        println(sym)
+        q"{${c.prefix}}.withFieldConst($sym, $value)"
+      case _ =>
+        c.abort(c.enclosingPosition, "Invalid selector!")
+    }
+  }
+
+  def computedFieldSelector(c: scala.reflect.macros.whitebox.Context)
+                        (selector: c.Tree, value: c.Tree): c.Tree = {
+    import c.universe._
+    selector match {
+      case q"($_) => $_.${fieldName: Name}" =>
+        val sym = Symbol(fieldName.decodedName.toString)
+        println(sym)
+        q"{${c.prefix}}.withFieldComputed($sym, $value)"
+      case _ =>
+        c.abort(c.enclosingPosition, "Invalid selector!")
+    }
+  }
+
+  def renamedFieldSelector(c: scala.reflect.macros.whitebox.Context)
+                           (selector: c.Tree, value: c.Tree): c.Tree = {
+    import c.universe._
+    selector match {
+      case q"($_) => $_.${fieldName: Name}" =>
+        val sym = Symbol(fieldName.decodedName.toString)
+        println(sym)
+        q"{${c.prefix}}.withFieldRenamed($sym, $value)"
+      case _ =>
+        c.abort(c.enclosingPosition, "Invalid selector!")
+    }
+  }
+
+
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -1,13 +1,9 @@
 package io.scalaland.chimney
 
-
 import scala.language.experimental.macros
 
-
-
 private[chimney] object DslMacros {
-  def constFieldSelector(c: scala.reflect.macros.whitebox.Context)
-                        (selector: c.Tree, value: c.Tree): c.Tree = {
+  def constFieldSelector(c: scala.reflect.macros.whitebox.Context)(selector: c.Tree, value: c.Tree): c.Tree = {
     import c.universe._
     selector match {
       case q"($_) => $_.${fieldName: Name}" =>
@@ -18,8 +14,7 @@ private[chimney] object DslMacros {
     }
   }
 
-  def computedFieldSelector(c: scala.reflect.macros.whitebox.Context)
-                        (selector: c.Tree, map: c.Tree): c.Tree = {
+  def computedFieldSelector(c: scala.reflect.macros.whitebox.Context)(selector: c.Tree, map: c.Tree): c.Tree = {
     import c.universe._
     selector match {
       case q"($_) => $_.${fieldName: Name}" =>
@@ -30,8 +25,8 @@ private[chimney] object DslMacros {
     }
   }
 
-  def renamedFieldSelector(c: scala.reflect.macros.whitebox.Context)
-                           (selectorFrom: c.Tree, selectorTo: c.Tree): c.Tree = {
+  def renamedFieldSelector(c: scala.reflect.macros.whitebox.Context)(selectorFrom: c.Tree,
+                                                                     selectorTo: c.Tree): c.Tree = {
     import c.universe._
     (selectorFrom, selectorTo) match {
       case (q"($_) => $_.${fromFieldName: Name}", q"($_) => $_.${toFieldName: Name}") =>
@@ -42,6 +37,5 @@ private[chimney] object DslMacros {
         c.abort(c.enclosingPosition, "Invalid selector!")
     }
   }
-
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -12,7 +12,6 @@ private[chimney] object DslMacros {
     selector match {
       case q"($_) => $_.${fieldName: Name}" =>
         val sym = Symbol(fieldName.decodedName.toString)
-        println(sym)
         q"{${c.prefix}}.withFieldConst($sym, $value)"
       case _ =>
         c.abort(c.enclosingPosition, "Invalid selector!")
@@ -20,13 +19,12 @@ private[chimney] object DslMacros {
   }
 
   def computedFieldSelector(c: scala.reflect.macros.whitebox.Context)
-                        (selector: c.Tree, value: c.Tree): c.Tree = {
+                        (selector: c.Tree, map: c.Tree): c.Tree = {
     import c.universe._
     selector match {
       case q"($_) => $_.${fieldName: Name}" =>
         val sym = Symbol(fieldName.decodedName.toString)
-        println(sym)
-        q"{${c.prefix}}.withFieldComputed($sym, $value)"
+        q"{${c.prefix}}.withFieldComputed($sym, $map)"
       case _ =>
         c.abort(c.enclosingPosition, "Invalid selector!")
     }
@@ -38,7 +36,6 @@ private[chimney] object DslMacros {
     selector match {
       case q"($_) => $_.${fieldName: Name}" =>
         val sym = Symbol(fieldName.decodedName.toString)
-        println(sym)
         q"{${c.prefix}}.withFieldRenamed($sym, $value)"
       case _ =>
         c.abort(c.enclosingPosition, "Invalid selector!")

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -17,29 +17,33 @@ object dsl {
 
   final class TransformerInto[From, To, Modifiers <: HList](val source: From, val modifiers: Modifiers) {
 
-
-    def withFieldConst[T](selector: To => T,
-                          value: T): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
-    macro DslMacros.constFieldSelector
-
+    def withFieldConst[T](
+      selector: To => T,
+      value: T
+    ): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
+      macro DslMacros.constFieldSelector
 
     def withFieldConst[T](label: Witness.Lt[Symbol],
                           value: T): TransformerInto[From, To, Modifier.fieldFunction[label.T, From, T] :: Modifiers] =
       withFieldComputed(label, (_ => value): From => T)
 
+    def withFieldComputed[T](
+      selector: To => T,
+      map: From => T
+    ): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
+      macro DslMacros.computedFieldSelector
 
-    def withFieldComputed[T](selector: To => T,
-                             map: From => T): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
-    macro DslMacros.computedFieldSelector
-
-    def withFieldComputed[T](label: Witness.Lt[Symbol],
-                             map: From => T
+    def withFieldComputed[T](
+      label: Witness.Lt[Symbol],
+      map: From => T
     ): TransformerInto[From, To, Modifier.fieldFunction[label.T, From, T] :: Modifiers] =
       new TransformerInto(source, new Modifier.fieldFunction[label.T, From, T](map) :: modifiers)
 
-    def withFieldRenamed[T](selectorFrom: From => T,
-                            selectorTo: To => T): TransformerInto[From, To, _ <: Modifier.relabel[Symbol, Symbol] :: Modifiers] =
-    macro DslMacros.renamedFieldSelector
+    def withFieldRenamed[T](
+      selectorFrom: From => T,
+      selectorTo: To => T
+    ): TransformerInto[From, To, _ <: Modifier.relabel[Symbol, Symbol] :: Modifiers] =
+      macro DslMacros.renamedFieldSelector
 
     def withFieldRenamed(
       labelFrom: Witness.Lt[Symbol],

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -37,8 +37,8 @@ object dsl {
     ): TransformerInto[From, To, Modifier.fieldFunction[label.T, From, T] :: Modifiers] =
       new TransformerInto(source, new Modifier.fieldFunction[label.T, From, T](map) :: modifiers)
 
-    def withFieldRenamed[T](selector: To => T,
-                          value: T): TransformerInto[From, To, _ <: Modifier.relabel[Symbol, From] :: Modifiers] =
+    def withFieldRenamed[T](selectorFrom: From => T,
+                            selectorTo: To => T): TransformerInto[From, To, _ <: Modifier.relabel[Symbol, Symbol] :: Modifiers] =
     macro DslMacros.renamedFieldSelector
 
     def withFieldRenamed(

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -29,12 +29,11 @@ object dsl {
 
 
     def withFieldComputed[T](selector: To => T,
-                          value: T): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
+                             map: From => T): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
     macro DslMacros.computedFieldSelector
 
-    def withFieldComputed[T](
-      label: Witness.Lt[Symbol],
-      map: From => T
+    def withFieldComputed[T](label: Witness.Lt[Symbol],
+                             map: From => T
     ): TransformerInto[From, To, Modifier.fieldFunction[label.T, From, T] :: Modifiers] =
       new TransformerInto(source, new Modifier.fieldFunction[label.T, From, T](map) :: modifiers)
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney
 
 import io.scalaland.chimney.internal.Modifier
 import shapeless.{::, HList, HNil, Witness}
+import scala.language.experimental.macros
 
 object dsl {
 
@@ -16,15 +17,30 @@ object dsl {
 
   final class TransformerInto[From, To, Modifiers <: HList](val source: From, val modifiers: Modifiers) {
 
+
+    def withFieldConst[T](selector: To => T,
+                          value: T): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
+    macro DslMacros.constFieldSelector
+
+
     def withFieldConst[T](label: Witness.Lt[Symbol],
                           value: T): TransformerInto[From, To, Modifier.fieldFunction[label.T, From, T] :: Modifiers] =
-      withFieldComputed(label, _ => value)
+      withFieldComputed(label, (_ => value): From => T)
+
+
+    def withFieldComputed[T](selector: To => T,
+                          value: T): TransformerInto[From, To, _ <: Modifier.fieldFunction[Symbol, From, T] :: Modifiers] =
+    macro DslMacros.computedFieldSelector
 
     def withFieldComputed[T](
       label: Witness.Lt[Symbol],
       map: From => T
     ): TransformerInto[From, To, Modifier.fieldFunction[label.T, From, T] :: Modifiers] =
       new TransformerInto(source, new Modifier.fieldFunction[label.T, From, T](map) :: modifiers)
+
+    def withFieldRenamed[T](selector: To => T,
+                          value: T): TransformerInto[From, To, _ <: Modifier.relabel[Symbol, From] :: Modifiers] =
+    macro DslMacros.renamedFieldSelector
 
     def withFieldRenamed(
       labelFrom: Witness.Lt[Symbol],

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -81,7 +81,7 @@ class DslSpec extends WordSpec with MustMatchers {
       "relabel fields with relabelling modifier" in {
         Foo(10, "something")
           .into[Bar]
-          .withFieldRenamed('y, 'z)
+          .withFieldRenamed(_.y, _.z)
           .transform mustBe
           Bar(10, "something")
       }

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -61,7 +61,7 @@ class DslSpec extends WordSpec with MustMatchers {
 
           Bar(3, 3.14)
             .into[Foo]
-            .withFieldComputed('y, _.x.toString)
+            .withFieldComputed(_.y, _.x.toString)
             .transform mustBe
             Foo(3, "3", 3.14)
         }


### PR DESCRIPTION
As requested in #29 I've added usages of paths instead of of symbol literals. Please review and comment. As a side effect I've rearranged `build.sbt` a bit.