### PR TITLE
More constrained selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ case class Student(name: String, education: String)
 case class Employee(name: String, education: String, experience: List[String])
 
 Student("Paul", "University of Things").into[Employee]
-    .withFieldConst('experience, List("Internship in Z Company"))
+    .withFieldConst(_.experience, List("Internship in Z Company"))
     .transform
 // Employee = Employee(Paul,University of Things,List(Internship in Z Company))
 Student("Paula", "University of Things").into[Employee]
-    .withFieldComputed('experience, student => List(s"${student.name}'s own company"))
+    .withFieldComputed(_.experience, student => List(s"${student.name}'s own company"))
     .transform
 // Employee = Employee(Paula,University of Things,List(Paula's own company))
 ```
@@ -104,8 +104,8 @@ case class SpyGB(name: String, surname: String)
 case class SpyRU(imya: String, familia: String)
 
 SpyGB("James", "Bond").into[SpyRU]
-    .withFieldRenamed('name, 'imya)
-    .withFieldRenamed('surname, 'familia)
+    .withFieldRenamed(_.name, _.imya)
+    .withFieldRenamed(_.surname, _.familia)
     .transform
 // SpyRU = SpyRU(James,Bond)
 ```

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -6,7 +6,6 @@ private[chimney] object DslMacros {
   def constFieldSelector(c: scala.reflect.macros.whitebox.Context)(selector: c.Tree, value: c.Tree): c.Tree = {
     import c.universe._
     selector match {
-
       case q"(${_: ValDef}) => ${_: Ident}.${fieldName: Name}" =>
         val sym = Symbol(fieldName.decodedName.toString)
         q"{${c.prefix}}.withFieldConst($sym, $value)"

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -30,16 +30,18 @@ private[chimney] object DslMacros {
                                                                      selectorTo: c.Tree): c.Tree = {
     import c.universe._
     (selectorFrom, selectorTo) match {
-      case (q"($_) => $_.${fromFieldName: Name}", q"($_) => $_.${toFieldName: Name}") =>
+      case (q"(${_: ValDef}) => ${_: Ident}.${fromFieldName: Name}", q"(${_: ValDef}) => ${_: Ident}.${toFieldName: Name}") =>
         val symFrom = Symbol(fromFieldName.decodedName.toString)
         val symTo = Symbol(toFieldName.decodedName.toString)
         q"{${c.prefix}}.withFieldRenamed($symFrom, $symTo)"
-      case (q"($_) => $_.${fromFieldName: Name}", _) =>
-        c.abort(c.enclosingPosition, "Invalid TO selector")
-      case (_, q"($_) => $_.${toFieldName: Name}") =>
-        c.abort(c.enclosingPosition, "Invalid FROM selector")
-      case _ =>
-        c.abort(c.enclosingPosition, "Invalid selectors!")
+      case (q"(${_: ValDef}) => ${_: Ident}.${_: Name}", sel@_) =>
+        c.abort(c.enclosingPosition, s"Selector of type ${sel.tpe} is not valid: $sel")
+      case (sel@_, q"(${_: ValDef}) => ${_: Ident}.${_: Name}") =>
+        c.abort(c.enclosingPosition, s"Selector of type ${sel.tpe} is not valid: $sel")
+      case (sel1, sel2) =>
+        val inv1 = s"Selector of type ${sel1.tpe} is not valid: $sel1"
+        val inv2 = s"Selector of type ${sel2.tpe} is not valid: $sel2"
+        c.abort(c.enclosingPosition, s"Invalid selectors:\n$inv1\n$inv2")
     }
   }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -30,13 +30,16 @@ private[chimney] object DslMacros {
                                                                      selectorTo: c.Tree): c.Tree = {
     import c.universe._
     (selectorFrom, selectorTo) match {
-      case (q"(${_: ValDef}) => ${_: Ident}.${fromFieldName: Name}", q"(${_: ValDef}) => ${_: Ident}.${toFieldName: Name}") =>
+      case (
+          q"(${_: ValDef}) => ${_: Ident}.${fromFieldName: Name}",
+          q"(${_: ValDef}) => ${_: Ident}.${toFieldName: Name}"
+          ) =>
         val symFrom = Symbol(fromFieldName.decodedName.toString)
         val symTo = Symbol(toFieldName.decodedName.toString)
         q"{${c.prefix}}.withFieldRenamed($symFrom, $symTo)"
-      case (q"(${_: ValDef}) => ${_: Ident}.${_: Name}", sel@_) =>
+      case (q"(${_: ValDef}) => ${_: Ident}.${_: Name}", sel @ _) =>
         c.abort(c.enclosingPosition, s"Selector of type ${sel.tpe} is not valid: $sel")
-      case (sel@_, q"(${_: ValDef}) => ${_: Ident}.${_: Name}") =>
+      case (sel @ _, q"(${_: ValDef}) => ${_: Ident}.${_: Name}") =>
         c.abort(c.enclosingPosition, s"Selector of type ${sel.tpe} is not valid: $sel")
       case (sel1, sel2) =>
         val inv1 = s"Selector of type ${sel1.tpe} is not valid: $sel1"

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -6,7 +6,8 @@ private[chimney] object DslMacros {
   def constFieldSelector(c: scala.reflect.macros.whitebox.Context)(selector: c.Tree, value: c.Tree): c.Tree = {
     import c.universe._
     selector match {
-      case q"($_) => $_.${fieldName: Name}" =>
+
+      case q"(${_: ValDef}) => ${_: Ident}.${fieldName: Name}" =>
         val sym = Symbol(fieldName.decodedName.toString)
         q"{${c.prefix}}.withFieldConst($sym, $value)"
       case _ =>
@@ -17,7 +18,7 @@ private[chimney] object DslMacros {
   def computedFieldSelector(c: scala.reflect.macros.whitebox.Context)(selector: c.Tree, map: c.Tree): c.Tree = {
     import c.universe._
     selector match {
-      case q"($_) => $_.${fieldName: Name}" =>
+      case q"(${_: ValDef}) => ${_: Ident}.${fieldName: Name}" =>
         val sym = Symbol(fieldName.decodedName.toString)
         q"{${c.prefix}}.withFieldComputed($sym, $map)"
       case _ =>

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -148,6 +148,39 @@ class DslSpec extends WordSpec with MustMatchers {
           Bar(10, "something")
       }
 
+      "not compile if relabelling selectors are invalid" in {
+
+        illTyped(
+          """
+            Foo(10, "something")
+              .into[Bar]
+              .withFieldRenamed(_.y + "abc", _.z)
+              .transform
+          """,
+          "Selector of type Foo => String is not valid: (.*)"
+        )
+
+        illTyped(
+          """
+            Foo(10, "something")
+              .into[Bar]
+              .withFieldRenamed(_.y, _.z + "abc")
+              .transform
+          """,
+          "Selector of type Bar => String is not valid: (.*)"
+        )
+
+        illTyped(
+          """
+            Foo(10, "something")
+              .into[Bar]
+              .withFieldRenamed(_.y + "abc", _.z + "abc")
+              .transform
+          """,
+          "Invalid selectors:(.*)"
+        )
+      }
+
       "not compile if relabelling wrongly" in {
 
         illTyped("""Foo(10, "something").into[Bar].withFieldRenamed('y, 'ne).transform""")

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -67,24 +67,18 @@ class DslSpec extends WordSpec with MustMatchers {
 
           "not compile when the selector is invalid" in {
 
-            illTyped(
-              """Bar(3, (3.14, 3.14))
+            illTyped("""Bar(3, (3.14, 3.14))
                   .into[Foo]
                   .withFieldConst(_.y, "pi")
                   .withFieldConst(_.z._1, 0.0)
                   .transform
-                """,
-              "Invalid selector!"
-            )
+                """, "Invalid selector!")
 
-            illTyped(
-              """Bar(3, (3.14, 3.14))
+            illTyped("""Bar(3, (3.14, 3.14))
                   .into[Foo]
                   .withFieldConst(_.y + "abc", "pi")
                   .transform
-                """,
-              "Invalid selector!"
-            )
+                """, "Invalid selector!")
           }
         }
 
@@ -107,24 +101,18 @@ class DslSpec extends WordSpec with MustMatchers {
 
           "not compile when the selector is invalid" in {
 
-            illTyped(
-              """Bar(3, (3.14, 3.14))
+            illTyped("""Bar(3, (3.14, 3.14))
                   .into[Foo]
                   .withFieldComputed(_.y, _.x.toString)
                   .withFieldComputed(_.z._1, _.z._1 * 10.0)
                   .transform
-                """,
-              "Invalid selector!"
-            )
+                """, "Invalid selector!")
 
-            illTyped(
-              """Bar(3, (3.14, 3.14))
+            illTyped("""Bar(3, (3.14, 3.14))
                   .into[Foo]
                   .withFieldComputed(_.y + "abc", _.x.toString)
                   .transform
-                """,
-              "Invalid selector!"
-            )
+                """, "Invalid selector!")
           }
         }
       }
@@ -150,35 +138,26 @@ class DslSpec extends WordSpec with MustMatchers {
 
       "not compile if relabelling selectors are invalid" in {
 
-        illTyped(
-          """
+        illTyped("""
             Foo(10, "something")
               .into[Bar]
               .withFieldRenamed(_.y + "abc", _.z)
               .transform
-          """,
-          "Selector of type Foo => String is not valid: (.*)"
-        )
+          """, "Selector of type Foo => String is not valid: (.*)")
 
-        illTyped(
-          """
+        illTyped("""
             Foo(10, "something")
               .into[Bar]
               .withFieldRenamed(_.y, _.z + "abc")
               .transform
-          """,
-          "Selector of type Bar => String is not valid: (.*)"
-        )
+          """, "Selector of type Bar => String is not valid: (.*)")
 
-        illTyped(
-          """
+        illTyped("""
             Foo(10, "something")
               .into[Bar]
               .withFieldRenamed(_.y + "abc", _.z + "abc")
               .transform
-          """,
-          "Invalid selectors:(.*)"
-        )
+          """, "Invalid selectors:(.*)")
       }
 
       "not compile if relabelling wrongly" in {


### PR DESCRIPTION
Current selector implementation allowed to simplify work with custom modifiers by providing IDE code completion (symbols couldn't be completed in IDE, had to be written by hand). However so far some errors might happen that there is invalid function passed, but quasi-quotes pattern matching didn't catch it as an invalid one. This PR improves this a bit and adds few more test cases.