### PR TITLE
Support for optional fields in patchers

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/PatcherInstances.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/PatcherInstances.scala
@@ -26,12 +26,13 @@ trait PatcherInstances {
     upd: ops.record.Updater.Aux[TLG, FieldType[L, U], TLG],
     tailPatcher: Patcher[TLG, PTail]
   ): Patcher[TLG, FieldType[L, Option[T]] :: PTail] =
-    (obj: TLG, patch: FieldType[L, Option[T]] :: PTail) => (patch.head: Option[T]) match {
-      case Some(patchedValue) =>
-        val patchedHead = upd(obj, field[L](dt.transform(patchedValue, HNil)))
-        tailPatcher.patch(patchedHead, patch.tail)
-      case None =>
-        tailPatcher.patch(obj, patch.tail)
+    (obj: TLG, patch: FieldType[L, Option[T]] :: PTail) =>
+      (patch.head: Option[T]) match {
+        case Some(patchedValue) =>
+          val patchedHead = upd(obj, field[L](dt.transform(patchedValue, HNil)))
+          tailPatcher.patch(patchedHead, patch.tail)
+        case None =>
+          tailPatcher.patch(obj, patch.tail)
     }
 
   implicit def gen[T, P, TLG, PLG](implicit tlg: LabelledGeneric.Aux[T, TLG],

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -356,10 +356,7 @@ class DslSpec extends WordSpec with MustMatchers {
 
       "transforming isomorphic domains that differ a detail" in {
 
-        implicit val intToDoubleTransformer: Transformer[Int, Double] =
-          new Transformer[Int, Double] {
-            def transform(src: Int): Double = src.toDouble
-          }
+        implicit val intToDoubleTransformer: Transformer[Int, Double] = (_: Int).toDouble
 
         (shapes1
           .Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
@@ -380,9 +377,7 @@ object Domain1 {
   case class UserName(value: String)
 
   val userNameToStringTransformer: Transformer[UserName, String] =
-    new Transformer[UserName, String] {
-      def transform(src: UserName): String = src.value + "T"
-    }
+    (userName: UserName) => userName.value + "T"
 
   case class UserDTO(id: String, name: String)
   case class User(id: String, name: UserName)

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
@@ -33,9 +33,9 @@ class PatcherSpec extends WordSpec with MustMatchers {
 
       import TestDomain._
 
-      case class UserPatch(email: Option[Email], phone: Option[Phone])
+      case class UserPatch(email: Option[String], phone: Option[Phone])
 
-      val update = UserPatch(email = Some(Email("updated@example.com")), phone = None)
+      val update = UserPatch(email = Some("updated@example.com"), phone = None)
 
       exampleUser.patchWith(update) mustBe
         User(10, Email("updated@example.com"), Phone(1234567890L))

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
@@ -23,11 +23,22 @@ class PatcherSpec extends WordSpec with MustMatchers {
 
       import TestDomain._
 
-      val user = User(10, Email("abc@def.com"), Phone(1234567890L))
       val update = UpdateDetails("xyz@def.com", 123123123L)
 
-      user.patchWith(update) mustBe
+      exampleUser.patchWith(update) mustBe
         User(10, Email("xyz@def.com"), Phone(123123123L))
+    }
+
+    "support optional types in patch" in {
+
+      import TestDomain._
+
+      case class UserPatch(email: Option[Email], phone: Option[Phone])
+
+      val update = UserPatch(email = Some(Email("updated@example.com")), phone = None)
+
+      exampleUser.patchWith(update) mustBe
+        User(10, Email("updated@example.com"), Phone(1234567890L))
     }
   }
 
@@ -40,4 +51,7 @@ object TestDomain {
 
   case class User(id: Int, email: Email, phone: Phone)
   case class UpdateDetails(email: String, phone: Long)
+
+  val exampleUser = User(10, Email("abc@def.com"), Phone(1234567890L))
+
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
@@ -40,6 +40,16 @@ class PatcherSpec extends WordSpec with MustMatchers {
       exampleUser.patchWith(update) mustBe
         User(10, Email("updated@example.com"), Phone(1234567890L))
     }
+
+    "support mixed optional and regular types" in {
+
+      import TestDomain._
+
+      case class UserPatch(email: String, phone: Option[Phone])
+      val update = UserPatch(email = "updated@example.com", phone = None)
+
+      exampleUser.patchWith(update) mustBe User(10, Email("updated@example.com"), Phone(1234567890L))
+    }
   }
 
 }


### PR DESCRIPTION
This PR addresses #37 proposal.

It doesn't provide separate method in DSL, but integrates (I believe) clearly with current approach. 

So far, when we had a patch field field `f` of type `T`, we required a field `f` of type `U` to be present in target object, and transformation from `T` to `U`.

This PR adds a rule, that beside this one above, supports also fields `f` of type `Option[T]` in patch, and requires transformation from `T` to `U`.

See the test case for reference.