### PR TITLE
Fix for Option[T] to Option[T] transformation

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
@@ -33,7 +33,8 @@ trait ValueClassInstances {
 trait OptionInstances {
 
   implicit final def optionTransformer[From, To, Modifiers <: HList](
-    implicit innerTransformer: DerivedTransformer[From, To, Modifiers]
+    implicit neq: From =:!= To,
+    innerTransformer: DerivedTransformer[From, To, Modifiers]
   ): DerivedTransformer[Option[From], Option[To], Modifiers] =
     (src: Option[From], modifiers: Modifiers) => src.map(innerTransformer.transform(_, modifiers))
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivedTransformerInstances.scala
@@ -52,7 +52,8 @@ trait OptionInstances {
 trait EitherInstances {
 
   implicit final def eitherTransformer[FromL, ToL, FromR, ToR, Modifiers <: HList](
-    implicit leftTransformer: DerivedTransformer[FromL, ToL, Modifiers],
+    implicit neq: (FromL, FromR) =:!= (ToL, ToR),
+    leftTransformer: DerivedTransformer[FromL, ToL, Modifiers],
     rightTransformer: DerivedTransformer[FromR, ToR, Modifiers]
   ): DerivedTransformer[Either[FromL, FromR], Either[ToL, ToR], Modifiers] =
     (src: Either[FromL, FromR], modifiers: Modifiers) =>
@@ -81,7 +82,8 @@ trait EitherInstances {
 trait CollectionInstances {
 
   implicit final def traversableTransformer[From, To, Modifiers <: HList, M1[_], M2[_]](
-    implicit innerTransformer: DerivedTransformer[From, To, Modifiers],
+    implicit neq: M1[From] =:!= M2[To],
+    innerTransformer: DerivedTransformer[From, To, Modifiers],
     ev1: M1[From] <:< Traversable[From],
     ev2: M2[To] <:< Traversable[To],
     cbf: CanBuildFrom[M1[From], To, M2[To]]
@@ -89,13 +91,15 @@ trait CollectionInstances {
     (src: M1[From], modifiers: Modifiers) => src.map(innerTransformer.transform(_: From, modifiers)).to[M2]
 
   implicit final def arrayTransformer[From, To, Modifiers <: HList](
-    implicit innerTransformer: DerivedTransformer[From, To, Modifiers],
+    implicit neq: From =:!= To,
+    innerTransformer: DerivedTransformer[From, To, Modifiers],
     toTag: ClassTag[To]
   ): DerivedTransformer[Array[From], Array[To], Modifiers] =
     (src: Array[From], modifiers: Modifiers) => src.map(innerTransformer.transform(_: From, modifiers))
 
   implicit final def mapTransformer[FromK, ToK, FromV, ToV, Modifiers <: HList](
-    implicit keyTransformer: DerivedTransformer[FromK, ToK, Modifiers],
+    implicit neq: (FromK, FromV) =:!= (ToK, ToV),
+    keyTransformer: DerivedTransformer[FromK, ToK, Modifiers],
     valueTransformer: DerivedTransformer[FromV, ToV, Modifiers]
   ): DerivedTransformer[Map[FromK, FromV], Map[ToK, ToV], Modifiers] =
     (src: Map[FromK, FromV], modifiers: Modifiers) =>

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -240,6 +240,8 @@ class DslSpec extends WordSpec with MustMatchers {
         (None: Option[Foo]).transformInto[Option[Bar]] mustBe None
         Some(Foo("a")).transformInto[Some[Bar]] mustBe Some(Bar("a"))
         None.transformInto[None.type] mustBe None
+        (None: Option[String]).transformInto[Option[String]] mustBe None
+        Option("abc").transformInto[Option[String]] mustBe Some("abc")
       }
 
       "support scala.util.Either" in {

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -251,6 +251,8 @@ class DslSpec extends WordSpec with MustMatchers {
         Right(Foo("a")).transformInto[Either[Bar, Bar]] mustBe Right(Bar("a"))
         Left(Foo("a")).transformInto[Left[Bar, Bar]] mustBe Left(Bar("a"))
         Right(Foo("a")).transformInto[Right[Bar, Bar]] mustBe Right(Bar("a"))
+        (Left("a"): Either[String, String]).transformInto[Either[String, String]] mustBe Left("a")
+        (Right("a"): Either[String, String]).transformInto[Either[String, String]] mustBe Right("a")
       }
 
       "support Traversable collections" in {
@@ -259,16 +261,26 @@ class DslSpec extends WordSpec with MustMatchers {
         Vector(Foo("a")).transformInto[Vector[Bar]] mustBe Vector(Bar("a"))
         Set(Foo("a")).transformInto[Set[Bar]] mustBe Set(Bar("a"))
 
+        Seq("a").transformInto[Seq[String]] mustBe Seq("a")
+        List("a").transformInto[List[String]] mustBe List("a")
+        Vector("a").transformInto[Vector[String]] mustBe Vector("a")
+        Set("a").transformInto[Set[String]] mustBe Set("a")
+
         List(Foo("a")).transformInto[Seq[Bar]] mustBe Seq(Bar("a"))
         Vector(Foo("a")).transformInto[Seq[Bar]] mustBe Seq(Bar("a"))
+
+        List("a").transformInto[Seq[String]] mustBe Seq("a")
+        Vector("a").transformInto[Seq[String]] mustBe Seq("a")
       }
 
       "support Arrays" in {
         Array(Foo("a")).transformInto[Array[Bar]] mustBe Array(Bar("a"))
+        Array("a").transformInto[Array[String]] mustBe Array("a")
       }
 
       "support Map" in {
         Map("test" -> Foo("a")).transformInto[Map[String, Bar]] mustBe Map("test" -> Bar("a"))
+        Map("test" -> "a").transformInto[Map[String, String]] mustBe Map("test" -> "a")
       }
     }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -33,6 +33,15 @@ class IssuesSpec extends WordSpec with MustMatchers {
       // https://github.com/milessabin/shapeless/pull/726
       // EntityWithTag1(0L, tag[Test]("name")).transformInto[EntityWithTag2] mustBe EntityWithTag2(tag[Test]("name"))
     }
+
+    "fix issue #40" in {
+
+      case class One(text: Option[String])
+      case class Two(text: Option[String])
+
+      One(None).transformInto[Two] mustBe Two(None)
+      One(Some("abc")).transformInto[Two] mustBe Two(Some("abc"))
+    }
   }
 
 }


### PR DESCRIPTION
This PR contains proposal for fixing #40. There was ambiguity between identity transformer instance and `Option[From]` to `Option[To]` one. This solution adds requirement on the latter instance that `From` has to be different than `To`.