### PR TITLE
fix issue #21 by updating shapeless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val versions = new {
-  val shapelessVersion = "2.3.2"
+  val shapelessVersion = "2.3.3"
   val scalatestVersion = "3.0.4"
   val scalaVersion = "2.12.4"
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -29,9 +29,7 @@ class IssuesSpec extends WordSpec with MustMatchers {
       case class EntityWithTag1(id: Long, name: String @@ Test)
       case class EntityWithTag2(name: String @@ Test)
 
-      // This test doesn't work on 2.12+ due to:
-      // https://github.com/milessabin/shapeless/pull/726
-      // EntityWithTag1(0L, tag[Test]("name")).transformInto[EntityWithTag2] mustBe EntityWithTag2(tag[Test]("name"))
+      EntityWithTag1(0L, tag[Test]("name")).transformInto[EntityWithTag2] mustBe EntityWithTag2(tag[Test]("name"))
     }
 
     "fix issue #40" in {


### PR DESCRIPTION
As https://github.com/milessabin/shapeless/pull/761 was merged to shapeless, I've decided to try updating to the newest snapshot version. It seems to fix the issue #21 on Scala 2.12+.

But I'd prefer not to depend on snapshot version and wait until shapeless 2.3.3 is released.