### PR TITLE
Use sbt 1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,13 +65,13 @@ lazy val root = project
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(noPublishSettings: _*)
-  .settings(commands += Command.args("scalafmt", "Run scalafmt cli.") {
-    case (state, args) =>
-      val Right(scalafmt) =
-        org.scalafmt.bootstrap.ScalafmtBootstrap.fromVersion(versions.scalafmt)
-      scalafmt.main("--non-interactive" +: args.toArray)
-      state
-  })
+//  .settings(commands += Command.args("scalafmt", "Run scalafmt cli.") {
+//    case (state, args) =>
+//      val Right(scalafmt) =
+//        org.scalafmt.bootstrap.ScalafmtBootstrap.fromVersion(versions.scalafmt)
+//      scalafmt.main("--non-interactive" +: args.toArray)
+//      state
+//  })
   .aggregate(chimneyJVM, chimneyJS, protosJVM, protosJS)
   .dependsOn(chimneyJVM, chimneyJS)
 
@@ -141,4 +141,4 @@ lazy val publishSettings = Seq(
 )
 
 lazy val noPublishSettings =
-  Seq(publish := (), publishLocal := (), publishArtifact := false)
+  Seq(publish := (()), publishLocal := (()), publishArtifact := false)

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ val settings = Seq(
 
 val dependencies = Seq(
   libraryDependencies ++= Seq(
-    "org.scala-lang" % "scala-reflect" % versions.scalaVersion,
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "com.chuusai" %%% "shapeless" % versions.shapelessVersion,
     "org.scalatest" %%% "scalatest" % versions.scalatestVersion % "test"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-name := "chimney"
-
 val versions = new {
   val shapelessVersion = "2.3.2"
   val scalatestVersion = "3.0.4"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 val versions = new {
   val shapelessVersion = "2.3.2"
   val scalatestVersion = "3.0.4"
-  val scalafmt = "1.1.0"
   val scalaVersion = "2.12.3"
 }
 
@@ -63,13 +62,6 @@ lazy val root = project
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(noPublishSettings: _*)
-//  .settings(commands += Command.args("scalafmt", "Run scalafmt cli.") {
-//    case (state, args) =>
-//      val Right(scalafmt) =
-//        org.scalafmt.bootstrap.ScalafmtBootstrap.fromVersion(versions.scalafmt)
-//      scalafmt.main("--non-interactive" +: args.toArray)
-//      state
-//  })
   .aggregate(chimneyJVM, chimneyJS, protosJVM, protosJS)
   .dependsOn(chimneyJVM, chimneyJS)
 

--- a/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/DslMacros.scala
@@ -25,7 +25,8 @@ private[chimney] object DslMacros {
     }
   }
 
-  def renamedFieldSelector(c: scala.reflect.macros.whitebox.Context)(selectorFrom: c.Tree, selectorTo: c.Tree): c.Tree = {
+  def renamedFieldSelector(c: scala.reflect.macros.whitebox.Context)(selectorFrom: c.Tree,
+                                                                     selectorTo: c.Tree): c.Tree = {
     import c.universe._
     (selectorFrom, selectorTo) match {
       case (

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.16
+sbt.version = 1.0.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.0
+sbt.version = 1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.sonatypeRepo("snapshots")
-
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc6")
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,9 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.8" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.10"))
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.3"
+resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc5")
+libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.1"
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
 
-libraryDependencies += "com.geirsson" %% "scalafmt-bootstrap" % "0.6.6"
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.2.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc5")
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.1"
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12-rc6")
+libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")


### PR DESCRIPTION
Finally I was able to configure build that uses sbt 1.0.2 and all needed plugins (scalapb, scoverage, scalafmt). I had to downgrade scalapb to 0.6.0, but it seems to work seamlessly now.