### PR TITLE
Make Modifier classes public.

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/Modifier.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/Modifier.scala
@@ -6,10 +6,10 @@ sealed trait Modifier
 
 object Modifier {
 
-  private[chimney] class fieldFunction[Label <: Symbol, From, T](val map: From => T) extends Modifier
-  private[chimney] class relabel[FromLabel <: Symbol, ToLabel <: Symbol] extends Modifier
-  private[chimney] class coproductInstance[From, T](val f: From => T) extends Modifier
-  private[chimney] class enableDefaultValues extends Modifier
+  class fieldFunction[Label <: Symbol, From, T](val map: From => T) extends Modifier
+  class relabel[FromLabel <: Symbol, ToLabel <: Symbol] extends Modifier
+  class coproductInstance[From, T](val f: From => T) extends Modifier
+  class enableDefaultValues extends Modifier
 
   final def fieldConstant[From, T](label: Witness.Lt[Symbol], value: T): fieldFunction[label.T, From, T] =
     new fieldFunction[label.T, From, T]((_: From) => value)


### PR DESCRIPTION
This PR allows users to greate generic methods that call `_.transformInto[A]`.

Using Diode, I found myself writing a lot of `SPACircuit.connect(_.transformInto[...])` and when trying to abstract away the whole call (in order to have even less boilerplate) by creating a method:

```
def connect[A <: AnyRef](implicit derivedTransformer: DerivedTransformer[RootModel, A, Modifier.enableDefaultValues :: HNil]) = SPACircuit.connect(_.transformInto[A])
```

I found out it wouldn't compile because the type `Modifier.enableDefaultValues` was private.

This change allows further levels of abstraction on top of `chimney`, allowing intermediate methods to be parametrized or not on the `From` and `To` types.