### PR TITLE
Add _root_.chimney package object with aliases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val readme = scalatex
     url = "https://github.com/scalalandio/chimney/tree/master",
     source = "Readme"
   )
-  .settings(noPublishSettings : _*)
+  .settings(noPublishSettings: _*)
   .settings(
     scalaVersion := versions.scalaVersion,
     siteSourceDirectory := target.value / "scalatex",

--- a/chimney/src/main/scala/chimney/package.scala
+++ b/chimney/src/main/scala/chimney/package.scala
@@ -1,0 +1,11 @@
+/**
+  * Aliases for easier access to the Chimney API.
+  * */
+package object chimney {
+  import io.scalaland.{chimney => ch}
+
+  val dsl: ch.dsl.type = ch.dsl
+
+  type Patcher[T, Patch] = ch.Patcher[T, Patch]
+  type Transformer[From, To] = ch.Transformer[From, To]
+}


### PR DESCRIPTION
Fixes #72.

For now I decided to go with the option of creating a new package object and aliasing the members of `io.scalaland.chimney` there - perhaps it's a better idea to leave them there than using a top-level chimney package. Feel free to suggest using one of the alternatives :)