### PR TITLE
Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
    - 2.11.12
-   - 2.12.6
    - 2.12.7
+   - 2.13.0-M5
 jdk:
   - openjdk8
   - openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val versions = new {
 val settings = Seq(
   version := "0.2.1",
   scalaVersion := versions.scalaVersion,
-  crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0-M4"),
+  crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0-M5"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
     "-encoding",

--- a/build.sbt
+++ b/build.sbt
@@ -11,23 +11,16 @@ val settings = Seq(
   crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0-M5"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
-    "-encoding",
-    "UTF-8",
+    "-encoding", "UTF-8",
     "-unchecked",
     "-deprecation",
     "-explaintypes",
     "-feature",
-    "-language:existentials",
-    "-language:higherKinds",
-    "-language:implicitConversions",
     "-Ywarn-dead-code",
-    "-Ywarn-nullary-override",
-    "-Ywarn-nullary-unit",
     "-Ywarn-numeric-widen",
-    "-Xfatal-warnings",
+//    "-Xfatal-warnings",
     "-Xfuture",
     "-Xlint:adapted-args",
-    "-Xlint:by-name-right-associative",
     "-Xlint:delayedinit-select",
     "-Xlint:doc-detached",
     "-Xlint:inaccessible",
@@ -39,8 +32,7 @@ val settings = Seq(
     "-Xlint:poly-implicit-overload",
     "-Xlint:private-shadow",
     "-Xlint:stars-align",
-    "-Xlint:type-parameter-shadow",
-    "-Xlint:unsound-match",
+    "-Xlint:type-parameter-shadow"
   ) ++ (
     if (scalaVersion.value >= "2.13")
       Nil
@@ -49,7 +41,11 @@ val settings = Seq(
         "-Xexperimental",
         "-Yno-adapted-args",
         "-Ywarn-inaccessible",
-        "-Ywarn-infer-any"
+        "-Ywarn-infer-any",
+        "-Ywarn-nullary-override",
+        "-Ywarn-nullary-unit",
+        "-Xlint:by-name-right-associative",
+        "-Xlint:unsound-match"
       )
     ),
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ val settings = Seq(
     "-language:higherKinds",
     "-language:implicitConversions",
     "-Ywarn-dead-code",
-    "-Ywarn-inaccessible",
     "-Ywarn-infer-any",
     "-Ywarn-nullary-override",
     "-Ywarn-nullary-unit",
@@ -43,7 +42,7 @@ val settings = Seq(
     "-Xlint:stars-align",
     "-Xlint:type-parameter-shadow",
     "-Xlint:unsound-match",
-  ) ++ (if (scalaVersion.value >= "2.13") Nil else Seq("-Yno-adapted-args", "-Xexperimental")),
+  ) ++ (if (scalaVersion.value >= "2.13") Nil else Seq("-Yno-adapted-args", "-Xexperimental", "-Ywarn-inaccessible")),
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ val settings = Seq(
     "-language:higherKinds",
     "-language:implicitConversions",
     "-Ywarn-dead-code",
-    "-Ywarn-infer-any",
     "-Ywarn-nullary-override",
     "-Ywarn-nullary-unit",
     "-Ywarn-numeric-widen",
@@ -42,7 +41,17 @@ val settings = Seq(
     "-Xlint:stars-align",
     "-Xlint:type-parameter-shadow",
     "-Xlint:unsound-match",
-  ) ++ (if (scalaVersion.value >= "2.13") Nil else Seq("-Yno-adapted-args", "-Xexperimental", "-Ywarn-inaccessible")),
+  ) ++ (
+    if (scalaVersion.value >= "2.13")
+      Nil
+    else
+      Seq(
+        "-Xexperimental",
+        "-Yno-adapted-args",
+        "-Ywarn-inaccessible",
+        "-Ywarn-infer-any"
+      )
+    ),
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val versions = new {
 val settings = Seq(
   version := "0.2.1",
   scalaVersion := versions.scalaVersion,
-  crossScalaVersions := Seq("2.11.12", "2.12.7"),
+  crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0-M4"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
     "-encoding",
@@ -20,7 +20,6 @@ val settings = Seq(
     "-language:existentials",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-Yno-adapted-args",
     "-Ywarn-dead-code",
     "-Ywarn-inaccessible",
     "-Ywarn-infer-any",
@@ -44,8 +43,7 @@ val settings = Seq(
     "-Xlint:stars-align",
     "-Xlint:type-parameter-shadow",
     "-Xlint:unsound-match",
-    "-Xexperimental"
-  ),
+  ) ++ (if (scalaVersion.value >= "2.13") Nil else Seq("-Yno-adapted-args", "-Xexperimental")),
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
 )
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationGuards.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationGuards.scala
@@ -34,7 +34,7 @@ trait DerivationGuards {
   }
 
   def bothOfTraversableOrArray(from: Type, to: Type): Boolean = {
-    traversableOrArray(from) && traversableOrArray(to)
+    iterableOrArray(from) && iterableOrArray(to)
   }
 
   def destinationCaseClass(to: Type): Boolean = {
@@ -57,8 +57,8 @@ trait DerivationGuards {
     bothSealedClasses(from, to)
   }
 
-  def traversableOrArray(t: Type): Boolean = {
-    t <:< traversableTpe || t <:< arrayTpe
+  def iterableOrArray(t: Type): Boolean = {
+    t <:< iterableTpe || t <:< arrayTpe
   }
 
   val optionTpe: Type = typeOf[Option[_]]
@@ -68,6 +68,6 @@ trait DerivationGuards {
   val leftTpe: Type = typeOf[Left[_, _]]
   val rightTpe: Type = typeOf[Right[_, _]]
   val mapTpe: Type = typeOf[scala.collection.Map[_, _]]
-  val traversableTpe: Type = typeOf[Traversable[_]]
+  val iterableTpe: Type = typeOf[Iterable[_]]
   val arrayTpe: Type = typeOf[Array[_]]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
@@ -207,6 +207,9 @@ trait TransformerMacros {
       if (fn == innerTransformerTree) {
         if (sameCollectionTypes) {
           srcPrefixTree
+        } else if (scala.util.Properties.versionNumberString >= "2.13") {
+          val ToCompanionRef = patchedCompanionRef(c)(To)
+          q"$srcPrefixTree.to($ToCompanionRef)"
         } else {
           q"$srcPrefixTree.to[${To.typeConstructor}]"
         }
@@ -214,6 +217,9 @@ trait TransformerMacros {
         val f = q"($fn: $FromCollectionT) => $innerTransformerTree"
         if (sameCollectionTypes) {
           q"$srcPrefixTree.map($f)"
+        } else if (scala.util.Properties.versionNumberString >= "2.13") {
+          val ToCompanionRef = patchedCompanionRef(c)(To)
+          q"$srcPrefixTree.map($f).to($ToCompanionRef)"
         } else {
           q"$srcPrefixTree.map($f).to[${To.typeConstructor}]"
         }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 


### PR DESCRIPTION
As Scala 2.13 is going to be released soon, we need to cross support 2.13 too. I tried to play with latest available milestone (`2.13.0-M4`) and it seems that number of required changes in quite short, most of them caused by new standard library.

##### Deprecation of `Traversable`
We may use `Iterable` as well, covering all of the use cases. This doesn't even need special changes to 2.11/2.12 codebase.

##### No support for `collection.to[AnotherCollection]`
But `collection.to(AnotherCollection)` works great. We need to generate different code, depending on Scala version to keep the same semantics. But in 2.13 we need to use companion ref hack...

##### Unsupported compiler options
In 2.13.0-M4 it seems following two flags are not understood by scalac: `-Yno-adapted-args`, `-Xexperimental`.

##### Dependencies
Before merging, we need to wait for following dependencies:
- ~~[ ] scalatest (already published snapshot `3.0.6-SNAP2` for `2.13.0-M4`)~~ switched to utest
- ~~[ ] scalapb~~ not dependent on scalapb any more
- ~~[ ] scalatex~~ not needed for cross compilation
- [X] scoverage (bumped `sbt-scoverage` to `1.6.0-M5`)