### PR TITLE
New configuration: .disableOptionDefaultsToNone

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -1,6 +1,13 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.{ChimneyBlackboxMacros, ChimneyWhiteboxMacros, DisableDefaults, Empty, Cfg, DisableOptionDefaultsToNone}
+import io.scalaland.chimney.internal.{
+  ChimneyBlackboxMacros,
+  ChimneyWhiteboxMacros,
+  DisableDefaults,
+  Empty,
+  Cfg,
+  DisableOptionDefaultsToNone
+}
 
 import scala.language.experimental.macros
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.{ChimneyBlackboxMacros, ChimneyWhiteboxMacros, DisableDefaults, Empty, Cfg}
+import io.scalaland.chimney.internal.{ChimneyBlackboxMacros, ChimneyWhiteboxMacros, DisableDefaults, Empty, Cfg, OptionDefaultsToNone}
 
 import scala.language.experimental.macros
 
@@ -21,6 +21,9 @@ object dsl {
 
     def disableDefaultValues: TransformerInto[From, To, DisableDefaults[C]] =
       new TransformerInto[From, To, DisableDefaults[C]](source, overrides, instances)
+
+    def optionDefaultsToNone: TransformerInto[From, To, OptionDefaultsToNone[C]] =
+      new TransformerInto[From, To, OptionDefaultsToNone[C]](source, overrides, instances)
 
     def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
       macro ChimneyWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.{ChimneyBlackboxMacros, ChimneyWhiteboxMacros, DisableDefaults, Empty, Cfg, OptionDefaultsToNone}
+import io.scalaland.chimney.internal.{ChimneyBlackboxMacros, ChimneyWhiteboxMacros, DisableDefaults, Empty, Cfg, DisableOptionDefaultsToNone}
 
 import scala.language.experimental.macros
 
@@ -22,8 +22,8 @@ object dsl {
     def disableDefaultValues: TransformerInto[From, To, DisableDefaults[C]] =
       new TransformerInto[From, To, DisableDefaults[C]](source, overrides, instances)
 
-    def optionDefaultsToNone: TransformerInto[From, To, OptionDefaultsToNone[C]] =
-      new TransformerInto[From, To, OptionDefaultsToNone[C]](source, overrides, instances)
+    def disableOptionDefaultsToNone: TransformerInto[From, To, DisableOptionDefaultsToNone[C]] =
+      new TransformerInto[From, To, DisableOptionDefaultsToNone[C]](source, overrides, instances)
 
     def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
       macro ChimneyWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/Cfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/Cfg.scala
@@ -8,4 +8,4 @@ final class FieldConst[Name <: String, C <: Cfg] extends Cfg
 final class FieldComputed[Name <: String, C <: Cfg] extends Cfg
 final class FieldRelabelled[FromName <: String, ToName <: String, C <: Cfg] extends Cfg
 final class CoproductInstance[InstType, TargetType, C <: Cfg] extends Cfg
-final class OptionDefaultsToNone[C <: Cfg] extends Cfg
+final class DisableOptionDefaultsToNone[C <: Cfg] extends Cfg

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/Cfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/Cfg.scala
@@ -8,3 +8,4 @@ final class FieldConst[Name <: String, C <: Cfg] extends Cfg
 final class FieldComputed[Name <: String, C <: Cfg] extends Cfg
 final class FieldRelabelled[FromName <: String, ToName <: String, C <: Cfg] extends Cfg
 final class CoproductInstance[InstType, TargetType, C <: Cfg] extends Cfg
+final class OptionDefaultsToNone[C <: Cfg] extends Cfg

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
@@ -10,6 +10,7 @@ trait DerivationConfig {
                     overridenFields: Set[String] = Set.empty,
                     renamedFields: Map[String, String] = Map.empty,
                     coproductInstances: Set[(c.Symbol, c.Type)] = Set.empty, // pair: inst type, target type
+                    optionDefaultsToNone: Boolean = false,
                     prefixValName: String = "") {
 
     def rec: Config =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
@@ -10,7 +10,7 @@ trait DerivationConfig {
                     overridenFields: Set[String] = Set.empty,
                     renamedFields: Map[String, String] = Map.empty,
                     coproductInstances: Set[(c.Symbol, c.Type)] = Set.empty, // pair: inst type, target type
-                    optionDefaultsToNone: Boolean = false,
+                    optionDefaultsToNone: Boolean = true,
                     prefixValName: String = "") {
 
     def rec: Config =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
@@ -26,7 +26,7 @@ trait DslBlackboxMacros {
 
     val emptyT = typeOf[Empty]
     val disableDefaultsT = typeOf[DisableDefaults[_]].typeConstructor
-    val optionDefaultsToNone = typeOf[OptionDefaultsToNone[_]].typeConstructor
+    val disableOptionDefaultsToNone = typeOf[DisableOptionDefaultsToNone[_]].typeConstructor
     val fieldConstT = typeOf[FieldConst[_, _]].typeConstructor
     val fieldComputedT = typeOf[FieldComputed[_, _]].typeConstructor
     val fieldRelabelledT = typeOf[FieldRelabelled[_, _, _]].typeConstructor
@@ -36,8 +36,8 @@ trait DslBlackboxMacros {
       config
     } else if (cfgTpe.typeConstructor == disableDefaultsT) {
       captureConfiguration(cfgTpe.typeArgs.head, config.copy(disableDefaultValues = true))
-    } else if (cfgTpe.typeConstructor == optionDefaultsToNone) {
-      captureConfiguration(cfgTpe.typeArgs.head, config.copy(optionDefaultsToNone = true))
+    } else if (cfgTpe.typeConstructor == disableOptionDefaultsToNone) {
+      captureConfiguration(cfgTpe.typeArgs.head, config.copy(optionDefaultsToNone = false))
     } else if (Set(fieldConstT, fieldComputedT).contains(cfgTpe.typeConstructor)) {
       val List(fieldNameT, rest) = cfgTpe.typeArgs
       val fieldName = fieldNameT.singletonString

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
@@ -26,6 +26,7 @@ trait DslBlackboxMacros {
 
     val emptyT = typeOf[Empty]
     val disableDefaultsT = typeOf[DisableDefaults[_]].typeConstructor
+    val optionDefaultsToNone = typeOf[OptionDefaultsToNone[_]].typeConstructor
     val fieldConstT = typeOf[FieldConst[_, _]].typeConstructor
     val fieldComputedT = typeOf[FieldComputed[_, _]].typeConstructor
     val fieldRelabelledT = typeOf[FieldRelabelled[_, _, _]].typeConstructor
@@ -35,6 +36,8 @@ trait DslBlackboxMacros {
       config
     } else if (cfgTpe.typeConstructor == disableDefaultsT) {
       captureConfiguration(cfgTpe.typeArgs.head, config.copy(disableDefaultValues = true))
+    } else if (cfgTpe.typeConstructor == optionDefaultsToNone) {
+      captureConfiguration(cfgTpe.typeArgs.head, config.copy(optionDefaultsToNone = true))
     } else if (Set(fieldConstT, fieldComputedT).contains(cfgTpe.typeConstructor)) {
       val List(fieldNameT, rest) = cfgTpe.typeArgs
       val fieldName = fieldNameT.singletonString

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
@@ -415,7 +415,7 @@ trait TransformerMacros {
         .orElse {
           val targetTypeIsOption = targetField.returnType <:< typeOf[Option[_]]
           if (targetTypeIsOption && config.optionDefaultsToNone) {
-            Some(ResolvedFieldTree(q"scala.None"))
+            Some(ResolvedFieldTree(q"_root_.scala.None"))
           } else {
             None
           }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
@@ -412,6 +412,14 @@ trait TransformerMacros {
             None
           }
         }
+        .orElse {
+          val targetTypeIsOption = targetField.returnType <:< typeOf[Option[_]]
+          if (targetTypeIsOption && config.optionDefaultsToNone) {
+            Some(ResolvedFieldTree(q"scala.None"))
+          } else {
+            None
+          }
+        }
     }
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -104,6 +104,7 @@ class DslSpec extends WordSpec with MustMatchers {
 
           "not use None as default when other default value is set" in {
             SomeFoo("foo").into[Foobar2].transform mustBe Foobar2("foo", Some(42))
+            SomeFoo("foo").into[Foobar2].disableOptionDefaultsToNone.transform mustBe Foobar2("foo", Some(42))
           }
 
           "not compile if default value is missing and .disableOptionDefaultsToNone" in {

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -111,7 +111,9 @@ class DslSpec extends WordSpec with MustMatchers {
           }
 
           "not compile if default value is disabled and .disableOptionDefaultsToNone" in {
-            assertTypeError("""SomeFoo("foo").into[Foobar2].disableDefaultValues.disableOptionDefaultsToNone.transform""")
+            assertTypeError(
+              """SomeFoo("foo").into[Foobar2].disableDefaultValues.disableOptionDefaultsToNone.transform"""
+            )
           }
         }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -108,8 +108,7 @@ class DslSpec extends WordSpec with MustMatchers {
             Foo("foo").into[Foobar2].optionDefaultsToNone.transform mustBe Foobar2("foo", Some(42))
           }
 
-          "not compile" when {
-            "flag is not set" in {
+          "not compile when flag is not set" in {
               assertTypeError("""Foo("foo").into[Foobar].transform""")
             }
           }

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -89,6 +89,32 @@ class DslSpec extends WordSpec with MustMatchers {
           }
         }
 
+        "support default values for Options" should {
+          case class Foo(x: String)
+          case class Foobar(x: String, y: Option[Int])
+          case class Foobar2(x: String, y: Option[Int] = Some(42))
+
+          "use None as default" when {
+            "flag is set" in {
+              Foo("foo").into[Foobar].optionDefaultsToNone.transform mustBe Foobar("foo", None)
+            }
+
+            "flag is set and target has default value, but default values are disabled" in {
+              Foo("foo").into[Foobar2].optionDefaultsToNone.disableDefaultValues.transform mustBe Foobar2("foo", None)
+            }
+          }
+
+          "not use None as default when other default value is set" in {
+            Foo("foo").into[Foobar2].optionDefaultsToNone.transform mustBe Foobar2("foo", Some(42))
+          }
+
+          "not compile" when {
+            "flag is not set" in {
+              assertTypeError("""Foo("foo").into[Foobar].transform""")
+            }
+          }
+        }
+
         "fill the field with provided generator function" should {
 
           "pass when selector is valid" in {

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -94,23 +94,24 @@ class DslSpec extends WordSpec with MustMatchers {
           case class Foobar(x: String, y: Option[Int])
           case class Foobar2(x: String, y: Option[Int] = Some(42))
 
-          "use None as default" when {
-            "flag is set" in {
-              Foo("foo").into[Foobar].optionDefaultsToNone.transform mustBe Foobar("foo", None)
-            }
+          "use None if default value is missing" in {
+            Foo("foo").into[Foobar].transform mustBe Foobar("foo", None)
+          }
 
-            "flag is set and target has default value, but default values are disabled" in {
-              Foo("foo").into[Foobar2].optionDefaultsToNone.disableDefaultValues.transform mustBe Foobar2("foo", None)
-            }
+          "target has default value, but default values are disabled" in {
+            Foo("foo").into[Foobar2].disableDefaultValues.transform mustBe Foobar2("foo", None)
           }
 
           "not use None as default when other default value is set" in {
-            Foo("foo").into[Foobar2].optionDefaultsToNone.transform mustBe Foobar2("foo", Some(42))
+            Foo("foo").into[Foobar2].transform mustBe Foobar2("foo", Some(42))
           }
 
-          "not compile when flag is not set" in {
-              assertTypeError("""Foo("foo").into[Foobar].transform""")
-            }
+          "not compile if default value is missing and .disableOptionDefaultsToNone" in {
+            assertTypeError("""Foo("foo").into[Foobar].disableOptionDefaultsToNone.transform""")
+          }
+
+          "not compile if default value is disabled and .disableOptionDefaultsToNone" in {
+            assertTypeError("""Foo("foo").into[Foobar2].disableDefaultValues.disableOptionDefaultsToNone.transform""")
           }
         }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -90,28 +90,28 @@ class DslSpec extends WordSpec with MustMatchers {
         }
 
         "support default values for Options" should {
-          case class Foo(x: String)
+          case class SomeFoo(x: String)
           case class Foobar(x: String, y: Option[Int])
           case class Foobar2(x: String, y: Option[Int] = Some(42))
 
           "use None if default value is missing" in {
-            Foo("foo").into[Foobar].transform mustBe Foobar("foo", None)
+            SomeFoo("foo").into[Foobar].transform mustBe Foobar("foo", None)
           }
 
           "target has default value, but default values are disabled" in {
-            Foo("foo").into[Foobar2].disableDefaultValues.transform mustBe Foobar2("foo", None)
+            SomeFoo("foo").into[Foobar2].disableDefaultValues.transform mustBe Foobar2("foo", None)
           }
 
           "not use None as default when other default value is set" in {
-            Foo("foo").into[Foobar2].transform mustBe Foobar2("foo", Some(42))
+            SomeFoo("foo").into[Foobar2].transform mustBe Foobar2("foo", Some(42))
           }
 
           "not compile if default value is missing and .disableOptionDefaultsToNone" in {
-            assertTypeError("""Foo("foo").into[Foobar].disableOptionDefaultsToNone.transform""")
+            assertTypeError("""SomeFoo("foo").into[Foobar].disableOptionDefaultsToNone.transform""")
           }
 
           "not compile if default value is disabled and .disableOptionDefaultsToNone" in {
-            assertTypeError("""Foo("foo").into[Foobar2].disableDefaultValues.disableOptionDefaultsToNone.transform""")
+            assertTypeError("""SomeFoo("foo").into[Foobar2].disableDefaultValues.disableOptionDefaultsToNone.transform""")
           }
         }
 


### PR DESCRIPTION
I stuck with the "enabling" semantics in https://github.com/scalalandio/chimney/issues/47.

The code quickly gets confusing with double negations if we go with something like ".disableOptionDefaultsToNone". Like `if (!disableOptionDefaultsToNone)`, but if you're ok with it, I'll make the change.