### PR TITLE
Alternative solution of #105 issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val versions = new {
 }
 
 val settings = Seq(
-  version := "0.3.2",
+  version := "1.0.0",
   scalaVersion := versions.scalaVersion,
   crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
   scalacOptions ++= Seq(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
@@ -14,7 +14,7 @@ trait DslBlackboxMacros {
     val srcName = c.freshName("src")
     val config = captureConfiguration(C).copy(prefixValName = srcName)
 
-    val derivedTransformerTree = genTransformer[From, To](config).tree
+    val derivedTransformerTree = genTransformer[From, To](config, findImplicit = false).tree
 
     q"""
        val ${TermName(srcName)} = ${c.prefix.tree}

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -14,7 +14,6 @@ object DslSpec extends TestSuite {
 
       implicit def trans: Transformer[UserName, String] = userNameToStringTransformer
 
-      UserName("Batman").into[String].transform ==> "BatmanT"
       UserName("Batman").transformInto[String] ==> "BatmanT"
     }
 
@@ -29,6 +28,25 @@ object DslSpec extends TestSuite {
 
       batmanDTO.id ==> "123"
       batmanDTO.name ==> "BatmanT"
+    }
+
+    "use implicit transformer defined locally" - {
+
+      import Domain1._
+
+      implicit val trans: Transformer[User, UserDTO] =
+        (user: User) => user.into[UserDTO].withFieldComputed(_.name, _.name.value).transform
+
+      User("101", UserName("WOW")).transformInto[UserDTO] ==> UserDTO("101", "WOW")
+    }
+
+    "forbid use into[String].transform syntax" - {
+      case class User(name: String)
+
+      implicit val trans: Transformer[User, String] = _.name
+
+      compileError("""User("Kek").into[String].transform""")
+        .check("", "Chimney can't derive transformation from User to String")
     }
 
     "support different set of fields of source and target" - {


### PR DESCRIPTION
If we will forbid .into[B].transform and use only .transformTo[B] to direct transformation, we will able to use transformation DSL inside of Transformer definition.