### PR TITLE
Enable to use dsl inside transformer being defined

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -11,6 +11,9 @@ object dsl {
     final def into[To]: TransformerInto[From, To, Empty] =
       new TransformerInto[From, To, Empty](source, Map.empty, Map.empty)
 
+    final def defineInto[To]: TransformerInto[From, To, EnableOptionDefaultsToNone[Empty]] =
+      new TransformerInto[From, To, EnableOptionDefaultsToNone[Empty]](source, Map.empty, Map.empty)
+
     final def transformInto[To](implicit transformer: Transformer[From, To]): To =
       transformer.transform(source)
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -31,6 +31,9 @@ object dsl {
     def enableOptionDefaultsToNone: TransformerInto[From, To, EnableOptionDefaultsToNone[C]] =
       new TransformerInto[From, To, EnableOptionDefaultsToNone[C]](source, overrides, instances)
 
+    def disableLocalImplicitLookup: TransformerInto[From, To, DisableLocalImplicitLookup[C]] =
+      new TransformerInto[From, To, DisableLocalImplicitLookup[C]](source, overrides, instances)
+
     def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
       macro ChimneyWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl.scala
@@ -11,8 +11,8 @@ object dsl {
     final def into[To]: TransformerInto[From, To, Empty] =
       new TransformerInto[From, To, Empty](source, Map.empty, Map.empty)
 
-    final def defineInto[To]: TransformerInto[From, To, EnableOptionDefaultsToNone[Empty]] =
-      new TransformerInto[From, To, EnableOptionDefaultsToNone[Empty]](source, Map.empty, Map.empty)
+    final def defineInto[To]: TransformerInto[From, To, DisableLocalImplicitLookup[Empty]] =
+      new TransformerInto[From, To, DisableLocalImplicitLookup[Empty]](source, Map.empty, Map.empty)
 
     final def transformInto[To](implicit transformer: Transformer[From, To]): To =
       transformer.transform(source)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/Cfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/Cfg.scala
@@ -7,6 +7,7 @@ final class DisableDefaultValues[C <: Cfg] extends Cfg
 final class EnableBeanGetters[C <: Cfg] extends Cfg
 final class EnableBeanSetters[C <: Cfg] extends Cfg
 final class EnableOptionDefaultsToNone[C <: Cfg] extends Cfg
+final class DisableLocalImplicitLookup[C <: Cfg] extends Cfg
 final class FieldConst[Name <: String, C <: Cfg] extends Cfg
 final class FieldComputed[Name <: String, C <: Cfg] extends Cfg
 final class FieldRelabelled[FromName <: String, ToName <: String, C <: Cfg] extends Cfg

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/ChimneyBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/ChimneyBlackboxMacros.scala
@@ -12,7 +12,7 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
     with EitherUtils {
 
   def transformImpl[From: c.WeakTypeTag, To: c.WeakTypeTag, C: c.WeakTypeTag]: c.Expr[To] = {
-    c.Expr[To](expandTansform[From, To, C])
+    c.Expr[To](expandTransform[From, To, C])
   }
 
   def deriveTransformerImpl[From: c.WeakTypeTag, To: c.WeakTypeTag]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
@@ -17,10 +17,6 @@ trait DerivationConfig {
                     prefixValName: String = "") {
 
     def rec: Config =
-      copy(
-        disableLocalImplicitLookup = false,
-        overridenFields = Set.empty,
-        renamedFields = Map.empty
-      )
+      copy(disableLocalImplicitLookup = false, overridenFields = Set.empty, renamedFields = Map.empty)
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationConfig.scala
@@ -10,12 +10,17 @@ trait DerivationConfig {
                     enableBeanGetters: Boolean = false,
                     enableBeanSetters: Boolean = false,
                     optionDefaultsToNone: Boolean = false,
+                    disableLocalImplicitLookup: Boolean = false,
                     overridenFields: Set[String] = Set.empty,
                     renamedFields: Map[String, String] = Map.empty,
                     coproductInstances: Set[(c.Symbol, c.Type)] = Set.empty, // pair: inst type, target type
                     prefixValName: String = "") {
 
     def rec: Config =
-      copy(overridenFields = Set.empty, renamedFields = Map.empty)
+      copy(
+        disableLocalImplicitLookup = false,
+        overridenFields = Set.empty,
+        renamedFields = Map.empty
+      )
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
@@ -9,7 +9,7 @@ trait DslBlackboxMacros {
 
   import c.universe._
 
-  def expandTansform[From: c.WeakTypeTag, To: c.WeakTypeTag, C: c.WeakTypeTag]: c.Tree = {
+  def expandTransform[From: c.WeakTypeTag, To: c.WeakTypeTag, C: c.WeakTypeTag]: c.Tree = {
     val C = weakTypeOf[C]
     val srcName = c.freshName("src")
     val config = captureConfiguration(C).copy(prefixValName = srcName)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DslBlackboxMacros.scala
@@ -29,6 +29,7 @@ trait DslBlackboxMacros {
     val enableBeanGettersT = typeOf[EnableBeanGetters[_]].typeConstructor
     val enableBeanSettersT = typeOf[EnableBeanSetters[_]].typeConstructor
     val enableOptionDefaultsToNone = typeOf[EnableOptionDefaultsToNone[_]].typeConstructor
+    val disableLocalImplicitLookup = typeOf[DisableLocalImplicitLookup[_]].typeConstructor
     val fieldConstT = typeOf[FieldConst[_, _]].typeConstructor
     val fieldComputedT = typeOf[FieldComputed[_, _]].typeConstructor
     val fieldRelabelledT = typeOf[FieldRelabelled[_, _, _]].typeConstructor
@@ -44,6 +45,8 @@ trait DslBlackboxMacros {
       captureConfiguration(cfgTpe.typeArgs.head, config.copy(enableBeanSetters = true))
     } else if (cfgTpe.typeConstructor == enableOptionDefaultsToNone) {
       captureConfiguration(cfgTpe.typeArgs.head, config.copy(optionDefaultsToNone = true))
+    } else if (cfgTpe.typeConstructor == disableLocalImplicitLookup) {
+      captureConfiguration(cfgTpe.typeArgs.head, config.copy(disableLocalImplicitLookup = true))
     } else if (Set(fieldConstT, fieldComputedT).contains(cfgTpe.typeConstructor)) {
       val List(fieldNameT, rest) = cfgTpe.typeArgs
       val fieldName = fieldNameT.singletonString

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
@@ -140,9 +140,6 @@ trait TransformerMacros {
     val fnL = c.internal.reificationSupport.freshTermName("left$")
     val fnR = c.internal.reificationSupport.freshTermName("right$")
 
-    val dupa: Either[Int, String] = Left(2)
-    dupa.merge
-
     if (From <:< leftTpe && !(To <:< someTpe)) {
       val prefixTree = if (scala.util.Properties.versionNumberString >= "2.12") {
         q"$srcPrefixTree.value"

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -31,6 +31,21 @@ object DslSpec extends TestSuite {
       batmanDTO.name ==> "BatmanT"
     }
 
+    "use dsl inside implicit transformer definition" - {
+
+      import Domain1._
+
+      implicit val invalidTransformerDefinition: Transformer[User, UserDTO] =
+        (user: User) => {
+          user.into[UserDTO]
+            .disableLocalImplicitLookup
+            .withFieldComputed(_.name, _.name.value)
+            .transform
+        }
+
+      User("101", UserName("WOW")).transformInto[UserDTO] ==> UserDTO("101", "WOW")
+    }
+
     "support different set of fields of source and target" - {
 
       case class Foo(x: Int, y: String, z: (Double, Double))

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -37,7 +37,8 @@ object DslSpec extends TestSuite {
 
       implicit val invalidTransformerDefinition: Transformer[User, UserDTO] =
         (user: User) => {
-          user.into[UserDTO]
+          user
+            .into[UserDTO]
             .disableLocalImplicitLookup
             .withFieldComputed(_.name, _.name.value)
             .transform
@@ -52,7 +53,8 @@ object DslSpec extends TestSuite {
 
       implicit val invalidTransformerDefinition: Transformer[User, UserDTO] =
         (user: User) => {
-          user.defineInto[UserDTO]
+          user
+            .defineInto[UserDTO]
             .withFieldComputed(_.name, _.name.value)
             .transform
         }

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -46,6 +46,20 @@ object DslSpec extends TestSuite {
       User("101", UserName("WOW")).transformInto[UserDTO] ==> UserDTO("101", "WOW")
     }
 
+    "use dsl inside implicit transformer definition (alternative syntax - .defineInto)" - {
+
+      import Domain1._
+
+      implicit val invalidTransformerDefinition: Transformer[User, UserDTO] =
+        (user: User) => {
+          user.defineInto[UserDTO]
+            .withFieldComputed(_.name, _.name.value)
+            .transform
+        }
+
+      User("101", UserName("WOW")).transformInto[UserDTO] ==> UserDTO("101", "WOW")
+    }
+
     "support different set of fields of source and target" - {
 
       case class Foo(x: Int, y: String, z: (Double, Double))


### PR DESCRIPTION
This PR is one another proposal that addresses #105. The idea is pretty much the same as in #112, but this one:
- maintains backwards compatibility of `.into[T].transform`
- maintains semantical equivalence between `.into[T].transform` with `.transformInto[T]`
- doesn't introduce any wrapper types for exported definitions
- allows to manually disable top-level implicit lookup by using new modifier `.disableLocalImplicitLookup`
- provides alternative, shorter syntax `defineInto[T]`

@ulanzetz, @REDNBLACK - I'd be thankful for review and feedback.