### PR TITLE
Add path names to `NotSupportedDerivation` compile errors

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/DerivationError.scala
@@ -32,7 +32,8 @@ final case class IncompatibleSourceTuple(sourceArity: Int,
                                          targetTypeName: String)
     extends DerivationError
 
-final case class NotSupportedDerivation(sourceTypeName: String, targetTypeName: String) extends DerivationError
+final case class NotSupportedDerivation(fieldName: String, sourceTypeName: String, targetTypeName: String)
+    extends DerivationError
 
 object DerivationError {
 
@@ -55,8 +56,8 @@ object DerivationError {
               s"  can't transform coproduct instance $instance to $targetTypeName"
             case IncompatibleSourceTuple(sourceArity, targetArity, sourceTypeName, _) =>
               s"  source tuple $sourceTypeName is of arity $sourceArity, while target type $targetTypeName is of arity $targetArity; they need to be equal!"
-            case NotSupportedDerivation(sourceTypeName, _) =>
-              s"  derivation from $sourceTypeName to $targetTypeName is not supported in Chimney!"
+            case NotSupportedDerivation(fieldName, sourceTypeName, _) =>
+              s"  derivation from $fieldName: $sourceTypeName to $targetTypeName is not supported in Chimney!"
           }
 
           s"""$targetTypeName

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -135,7 +135,7 @@ object IssuesSpec extends TestSuite {
       Issue108.result ==> Issue108.expected
     }
 
-    "fix issue #133" - {
+    "fix issue #113" - {
       case class Bar1(i: Int)
       case class Bar2(i: String)
       case class Bar3(i: Option[Int])
@@ -156,6 +156,23 @@ object IssuesSpec extends TestSuite {
       Option(Bar1(1)).into[Bar2].enableUnsafeOption.transform ==> Bar2("1")
       Baz2(Option(Bar1(1))).into[Baz4].enableUnsafeOption.transform ==> Baz4(Option(Bar2("1")))
       Bar3(Option(1)).into[Bar2].enableUnsafeOption.transform ==> Bar2("1")
+    }
+
+    "fix issue #121" - {
+      case class FooNested(num: Option[Int])
+      case class Foo(maybeString: Option[Set[String]], nested: FooNested)
+
+      case class BarNested(num: String)
+      case class Bar(maybeString: scala.collection.immutable.Seq[String], nested: BarNested)
+
+      val foo = Foo(None, FooNested(None))
+
+      compileError("foo.into[Bar].transform")
+        .check(
+          "",
+          "derivation from foo.maybeString: scala.Option to scala.collection.immutable.Seq is not supported in Chimney!",
+          "derivation from foo.nested.num: scala.Option to java.lang.String is not supported in Chimney!"
+        )
     }
   }
 }


### PR DESCRIPTION
Summary
=======
Adds path names to compile errors.

Before
------
```
error: Chimney can't derive transformation from com.rallyhealth.chopshop.provider.model.PersonLocation to com.rallyhealth.chopshop.provider.es6.generated.EsPersonLocation

scala.Boolean
  derivation from scala.Option to scala.Boolean is not supported in Chimney!

java.lang.String
  derivation from scala.Option to java.lang.String is not supported in Chimney!
  derivation from scala.Int to java.lang.String is not supported in Chimney!

scala.collection.immutable.Set
  derivation from scala.Option to scala.collection.immutable.Set is not supported in Chimney!

scala.collection.Seq
  derivation from scala.Option to scala.collection.Seq is not supported in Chimney!

Consult https://scalalandio.github.io/chimney for usage examples.
```

After
-----
```
error: Chimney can't derive transformation from com.rallyhealth.chopshop.provider.model.PersonLocation to com.rallyhealth.chopshop.provider.es6.generated.EsPersonLocation

scala.Boolean
  derivation from personlocation.networkEnrollment.isCapitated: scala.Option to scala.Boolean is not supported in Chimney!

java.lang.String
  derivation from personlocation.networkEnrollment.effectiveInterval.start: scala.Option to java.lang.String is not supported in Chimney!
  derivation from personlocation.networkEnrollment.pcpId: scala.Option to java.lang.String is not supported in Chimney!
  derivation from personlocation.networkEnrollment.roles: scala.Int to java.lang.String is not supported in Chimney!
  derivation from personlocation.painManagementTier: scala.Option to java.lang.String is not supported in Chimney!
  derivation from personlocation.providerDigestId: scala.Option to java.lang.String is not supported in Chimney!

scala.collection.immutable.Set
  derivation from personlocation.networksByRole: scala.Option to scala.collection.immutable.Set is not supported in Chimney!

scala.collection.Seq
  derivation from personlocation.preferredPlans: scala.Option to scala.collection.Seq is not supported in Chimney!

Consult https://scalalandio.github.io/chimney for usage examples.
```