### PR TITLE
Use .iterator when changing collection types.

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerMacros.scala
@@ -252,9 +252,9 @@ trait TransformerMacros {
           q"$srcPrefixTree.map($f)"
         } else if (scala.util.Properties.versionNumberString >= "2.13") {
           val ToCompanionRef = patchedCompanionRef(c)(To)
-          q"$srcPrefixTree.map($f).to($ToCompanionRef)"
+          q"$srcPrefixTree.iterator.map($f).to($ToCompanionRef)"
         } else {
-          q"$srcPrefixTree.map($f).to[${To.typeConstructor}]"
+          q"$srcPrefixTree.iterator.map($f).to[${To.typeConstructor}]"
         }
       }
     }

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -174,6 +174,19 @@ object IssuesSpec extends TestSuite {
           "derivation from foo.nested.num: scala.Option to java.lang.String is not supported in Chimney!"
         )
     }
+
+    "fix issue #125" - {
+      case class Strings(elems: Set[String])
+      case class Lengths(elems: Seq[Int])
+
+      implicit def lengthTranformer = new Transformer[String, Int] {
+        override def transform(string: String): Int = string.length
+      }
+
+      val inputStrings = Strings(Set("one", "two", "three"))
+      val lengths = inputStrings.into[Lengths].transform
+      lengths.elems.size ==> 3
+    }
   }
 }
 


### PR DESCRIPTION
# Summary
Changes macro expansion:

| | |
| -- | -- |
| before | `Set(1,2,3).map(f).to[Seq]` |
| after | `Set(1,2,3).iterator.map(f).to[Seq]` |

## Performance
I initially spotted this as a performance problem under the profiler. Creating unnecessary `scala.collection.immutable.HashSet` instances is [expensive](http://www.lihaoyi.com/post/BenchmarkingScalaCollections.html#sets-and-maps-are-slow)!

## Correctness
There's also a potential correctness problem with mapping over `Set`, as demonstrated by the new (somewhat contrived) unit test.

/cc @weisong-rallyhealth this should speed up indexing.