### PR TITLE
Reduce allocations in dsl

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/dsl/TransformerDefinition.scala
@@ -12,19 +12,19 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     val instances: Map[(String, String), Any]
 ) {
   def disableDefaultValues: TransformerDefinition[From, To, DisableDefaultValues[C]] =
-    new TransformerDefinition[From, To, DisableDefaultValues[C]](overrides, instances)
+    this.asInstanceOf[TransformerDefinition[From, To, DisableDefaultValues[C]]]
 
   def enableBeanGetters: TransformerDefinition[From, To, EnableBeanGetters[C]] =
-    new TransformerDefinition[From, To, EnableBeanGetters[C]](overrides, instances)
+    this.asInstanceOf[TransformerDefinition[From, To, EnableBeanGetters[C]]]
 
   def enableBeanSetters: TransformerDefinition[From, To, EnableBeanSetters[C]] =
-    new TransformerDefinition[From, To, EnableBeanSetters[C]](overrides, instances)
+    this.asInstanceOf[TransformerDefinition[From, To, EnableBeanSetters[C]]]
 
   def enableOptionDefaultsToNone: TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]] =
-    new TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]](overrides, instances)
+    this.asInstanceOf[TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]]]
 
   def enableUnsafeOption: TransformerDefinition[From, To, EnableUnsafeOption[C]] =
-    new TransformerDefinition[From, To, EnableUnsafeOption[C]](overrides, instances)
+    this.asInstanceOf[TransformerDefinition[From, To, EnableUnsafeOption[C]]]
 
   def withFieldConst[T, U](selector: To => T, value: U): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/dsl/TransformerInto.scala
@@ -12,19 +12,19 @@ final class TransformerInto[From, To, C <: TransformerCfg](
 ) {
 
   def disableDefaultValues: TransformerInto[From, To, DisableDefaultValues[C]] =
-    new TransformerInto(source, td.disableDefaultValues)
+    this.asInstanceOf[TransformerInto[From, To, DisableDefaultValues[C]]]
 
   def enableBeanGetters: TransformerInto[From, To, EnableBeanGetters[C]] =
-    new TransformerInto(source, td.enableBeanGetters)
+    this.asInstanceOf[TransformerInto[From, To, EnableBeanGetters[C]]]
 
   def enableBeanSetters: TransformerInto[From, To, EnableBeanSetters[C]] =
-    new TransformerInto(source, td.enableBeanSetters)
+    this.asInstanceOf[TransformerInto[From, To, EnableBeanSetters[C]]]
 
   def enableOptionDefaultsToNone: TransformerInto[From, To, EnableOptionDefaultsToNone[C]] =
-    new TransformerInto(source, td.enableOptionDefaultsToNone)
+    this.asInstanceOf[TransformerInto[From, To, EnableOptionDefaultsToNone[C]]]
 
   def enableUnsafeOption: TransformerInto[From, To, EnableUnsafeOption[C]] =
-    new TransformerInto(source, td.enableUnsafeOption)
+    this.asInstanceOf[TransformerInto[From, To, EnableUnsafeOption[C]]]
 
   def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]


### PR DESCRIPTION
This PR reduces object allocations in Transformer/Patcher DSLs in methods that refers only to type-level info. In such cases, instead of new object allocation, we can use `this.asInstanceOf[...]` and lift to correct type.

Proposed by @MateuszKubuszok