### PR TITLE
Initial documentation of public interfaces

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -4,7 +4,7 @@ import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
 
 import scala.language.experimental.macros
 
-/** Type class definition that wraps patching behavior
+/** Type class definition that wraps patching behavior.
  *
  * @tparam T type of object to apply patch to
  * @tparam Patch type of patch object
@@ -16,7 +16,7 @@ trait Patcher[T, Patch] {
 object Patcher {
 
   /** Provides implicit [[io.scalaland.chimney.Patcher]] instance
-   * for arbitrary types
+   * for arbitrary types.
    *
    * @tparam T type of object to apply patch to
    * @tparam Patch type of patch object

--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -4,12 +4,24 @@ import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
 
 import scala.language.experimental.macros
 
+/** Type class definition that wraps patching behavior
+ *
+ * @tparam T type of object to apply patch to
+ * @tparam Patch type of patch object
+ */
 trait Patcher[T, Patch] {
   def patch(obj: T, patch: Patch): T
 }
 
 object Patcher {
 
+  /** Provides implicit [[io.scalaland.chimney.Patcher]] instance
+   * for arbitrary types
+   *
+   * @tparam T type of object to apply patch to
+   * @tparam Patch type of patch object
+   * @return [[io.scalaland.chimney.Patcher]] type class instance
+   */
   implicit def derive[T, Patch]: Patcher[T, Patch] =
     macro ChimneyBlackboxMacros.derivePatcherImpl[T, Patch]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -5,10 +5,10 @@ import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
 import scala.language.experimental.macros
 
 /** Type class definition that wraps patching behavior.
- *
- * @tparam T type of object to apply patch to
- * @tparam Patch type of patch object
- */
+  *
+  * @tparam T type of object to apply patch to
+  * @tparam Patch type of patch object
+  */
 trait Patcher[T, Patch] {
   def patch(obj: T, patch: Patch): T
 }
@@ -16,12 +16,12 @@ trait Patcher[T, Patch] {
 object Patcher {
 
   /** Provides implicit [[io.scalaland.chimney.Patcher]] instance
-   * for arbitrary types.
-   *
-   * @tparam T type of object to apply patch to
-   * @tparam Patch type of patch object
-   * @return [[io.scalaland.chimney.Patcher]] type class instance
-   */
+    * for arbitrary types.
+    *
+    * @tparam T type of object to apply patch to
+    * @tparam Patch type of patch object
+    * @return [[io.scalaland.chimney.Patcher]] type class instance
+    */
   implicit def derive[T, Patch]: Patcher[T, Patch] =
     macro ChimneyBlackboxMacros.derivePatcherImpl[T, Patch]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -8,102 +8,26 @@ import scala.language.experimental.macros
 
 /** Maps data from one type `From` into another `To`.
   *
-  * Extraction of `From => Into` logic into a separate type class allow
-  * us to define logic once in one place and refer to it
-  * in mutliple places:
-  *
-  * {{{
-  * class Foo(...)
-  * class Bar(...)
-  * object Bar {
-  *   implicit val fromBar: Transformer[Foo, Bar] = ...
-  * }
-  * implicit[Transformer[Foo, Bar]].transform(foo) // use predefined instance
-  * }}}
-  *
-  * and generate implementation using information from the type:
-  *
-  * {{{
-  * case class Foo(int: Int, str: String)
-  * case class Bar(int: Int, str: String)
-  * implicitly[Transformer[Foo, Bar]] // derive value
-  * }}}
-  *
-  * If the default setting of generator are not good enough, you can provide
-  * it with settings to customize the behavior:
-  *
-  * {{{
-  * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
-  *   .setting1
-  *   .setting2
-  *   .buildTransformer
-  * }}}
-  *
-  * For the list of available settings and their meaning consult
-  * [[io.scalaland.chimney.dsl.TransformerDefinition]].
-  *
-  *
-  * If transformation is derived ad hoc in place it is used, you can use
-  * convenient DSL:
-  *
-  * {{{
-  * import io.scalaland.chimney.dsl._ // enables DSL
-  * val foo: Foo = ...
-  * val bar = foo.into[Bar].modifier1.modifier2.transform
-  * }}}
-  *
-  * If there are no modifiers needed (or if implicit `Transformer` is already
-  * defined in scope) you can use shorter syntax:
-  *
-  * {{{
-  * import io.scalaland.chimney.dsl._ // enables DSL
-  * val foo: Foo = ...
-  * val bar = foo.transformInto[Bar]
-  * }}}
-  *
-  * @see [[io.scalaland.chimney.Transformer#derive]] for information how default generation works
-  * @see [[io.scalaland.chimney.Transformer#define]] for information how to start building customized Transformer
-  * @see [[io.scalaland.chimney.dsl.TransformerOps]] for syntax that starts building Transformer and applying it in the same time
-  * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for avilable settings of Transformer derivation
-  * @see [[io.scalaland.chimney.dsl.TransformerInto]] for availabe settings for building Transformer and applying it in thr same time
-  *
   * @tparam From data type that will be used as input
   * @tparam To   data type that will be used as output
   */
 trait Transformer[From, To] {
-
   def transform(src: From): To
 }
 
-/** The companion of [[io.scalaland.chimney.Transformer]].
-  *
-  * Used to provide implicit with default [[io.scalaland.chimney.Transformer]]
-  * implementation as well as DSL for building [[io.scalaland.chimney.Transformer]]
-  * using [[io.scalaland.chimney.dsl.TransformerDefinition]].
-  */
 object Transformer {
 
   /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
     *
-    * If derivation with defaults is not possible, macro expansion will fail
-    * and the instance should be define manually to solve e.g. field renames or
-    * missing values (it can be done using provided DSL).
-    *
     * @tparam From data type that will be used as input
     * @tparam Into data type that will be used as output
-    * @return default implementation (if posible)
+    * @return [[io.scalaland.chimney.Transformer]] type class definition
     */
   implicit def derive[From, To]: Transformer[From, To] =
     macro ChimneyBlackboxMacros.deriveTransformerImpl[From, To]
 
-  /** Convenient utility to create an empty [[io.scalaland.chimney.dsl.TransformerDefinition]].
-    *
-    * {{{
-    * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
-    *   .modifier1
-    *   .modifier2
-    *   .buildTransformer
-    * }}}
+  /** Creates an empty [[io.scalaland.chimney.dsl.TransformerDefinition]] that
+    * you can customize to derive [[io.scalaland.chimney.Transformer]].
     *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for available settings
     *

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -7,11 +7,11 @@ import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
 import scala.language.experimental.macros
 
 /** Maps data from one type `From` into another `To`.
-  * 
+  *
   * Extraction of `From => Into` logic into a separate type class allow
   * us to define logic once in one place and refer to it
   * in mutliple places:
-  * 
+  *
   * {{{
   * class Foo(...)
   * class Bar(...)
@@ -20,53 +20,53 @@ import scala.language.experimental.macros
   * }
   * implicit[Transformer[Foo, Bar]].transform(foo) // use predefined instance
   * }}}
-  * 
+  *
   * and generate implementation using information from the type:
-  * 
+  *
   * {{{
   * case class Foo(int: Int, str: String)
   * case class Bar(int: Int, str: String)
   * implicitly[Transformer[Foo, Bar]] // derive value
   * }}}
-  * 
+  *
   * If the default setting of generator are not good enough, you can provide
   * it with settings to customize the behavior:
-  * 
+  *
   * {{{
   * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
   *   .setting1
   *   .setting2
   *   .buildTransformer
   * }}}
-  * 
+  *
   * For the list of available settings and their meaning consult
   * [[io.scalaland.chimney.dsl.TransformerDefinition]].
-  * 
-  * 
+  *
+  *
   * If transformation is derived ad hoc in place it is used, you can use
   * convenient DSL:
-  * 
+  *
   * {{{
   * import io.scalaland.chimney.dsl._ // enables DSL
   * val foo: Foo = ...
   * val bar = foo.into[Bar].modifier1.modifier2.transform
   * }}}
-  * 
+  *
   * If there are no modifiers needed (or if implicit `Transformer` is already
   * defined in scope) you can use shorter syntax:
-  * 
+  *
   * {{{
   * import io.scalaland.chimney.dsl._ // enables DSL
   * val foo: Foo = ...
   * val bar = foo.transformInto[Bar]
   * }}}
-  * 
+  *
   * @see [[io.scalaland.chimney.Transformer#derive]] for information how default generation works
   * @see [[io.scalaland.chimney.Transformer#define]] for information how to start building customized Transformer
   * @see [[io.scalaland.chimney.dsl.TransformerOps]] for syntax that starts building Transformer and applying it in the same time
   * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for avilable settings of Transformer derivation
   * @see [[io.scalaland.chimney.dsl.TransformerInto]] for availabe settings for building Transformer and applying it in thr same time
-  * 
+  *
   * @tparam From data type that will be used as input
   * @tparam To   data type that will be used as output
   */
@@ -76,7 +76,7 @@ trait Transformer[From, To] {
 }
 
 /** The companion of [[io.scalaland.chimney.Transformer]].
-  * 
+  *
   * Used to provide implicit with default [[io.scalaland.chimney.Transformer]]
   * implementation as well as DSL for building [[io.scalaland.chimney.Transformer]]
   * using [[io.scalaland.chimney.dsl.TransformerDefinition]].
@@ -84,11 +84,11 @@ trait Transformer[From, To] {
 object Transformer {
 
   /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
-    * 
+    *
     * If derivation with defaults is not possible, macro expansion will fail
     * and the instance should be define manually to solve e.g. field renames or
     * missing values (it can be done using provided DSL).
-    * 
+    *
     * @tparam From data type that will be used as input
     * @tparam Into data type that will be used as output
     * @return default implementation (if posible)
@@ -97,16 +97,16 @@ object Transformer {
     macro ChimneyBlackboxMacros.deriveTransformerImpl[From, To]
 
   /** Convenient utility to create an empty [[io.scalaland.chimney.dsl.TransformerDefinition]].
-    * 
+    *
     * {{{
     * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
     *   .modifier1
     *   .modifier2
     *   .buildTransformer
     * }}}
-    * 
+    *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for available settings
-    * 
+    *
     * @tparam From data type that will be used as input
     * @tparam Into data type that will be used as output
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]] with defaults

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -6,16 +6,111 @@ import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
 
 import scala.language.experimental.macros
 
+/** Maps data from one type `From` into another `To`.
+  * 
+  * Extraction of `From => Into` logic into a separate type class allow
+  * us to define logic once in one place and refer to it
+  * in mutliple places:
+  * 
+  * {{{
+  * class Foo(...)
+  * class Bar(...)
+  * object Bar {
+  *   implicit val fromBar: Transformer[Foo, Bar] = ...
+  * }
+  * implicit[Transformer[Foo, Bar]].transform(foo) // use predefined instance
+  * }}}
+  * 
+  * and generate implementation using information from the type:
+  * 
+  * {{{
+  * case class Foo(int: Int, str: String)
+  * case class Bar(int: Int, str: String)
+  * implicitly[Transformer[Foo, Bar]] // derive value
+  * }}}
+  * 
+  * If the default setting of generator are not good enough, you can provide
+  * it with settings to customize the behavior:
+  * 
+  * {{{
+  * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
+  *   .setting1
+  *   .setting2
+  *   .buildTransformer
+  * }}}
+  * 
+  * For the list of available settings and their meaning consult
+  * [[io.scalaland.chimney.dsl.TransformerDefinition]].
+  * 
+  * 
+  * If transformation is derived ad hoc in place it is used, you can use
+  * convenient DSL:
+  * 
+  * {{{
+  * import io.scalaland.chimney.dsl._ // enables DSL
+  * val foo: Foo = ...
+  * val bar = foo.into[Bar].modifier1.modifier2.transform
+  * }}}
+  * 
+  * If there are no modifiers needed (or if implicit `Transformer` is already
+  * defined in scope) you can use shorter syntax:
+  * 
+  * {{{
+  * import io.scalaland.chimney.dsl._ // enables DSL
+  * val foo: Foo = ...
+  * val bar = foo.transformInto[Bar]
+  * }}}
+  * 
+  * @see [[io.scalaland.chimney.Transformer#derive]] for information how default generation works
+  * @see [[io.scalaland.chimney.Transformer#define]] for information how to start building customized Transformer
+  * @see [[io.scalaland.chimney.dsl.TransformerOps]] for syntax that starts building Transformer and applying it in the same time
+  * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for avilable settings of Transformer derivation
+  * @see [[io.scalaland.chimney.dsl.TransformerInto]] for availabe settings for building Transformer and applying it in thr same time
+  * 
+  * @tparam From data type that will be used as input
+  * @tparam To   data type that will be used as output
+  */
 trait Transformer[From, To] {
 
   def transform(src: From): To
 }
 
+/** The companion of [[io.scalaland.chimney.Transformer]].
+  * 
+  * Used to provide implicit with default [[io.scalaland.chimney.Transformer]]
+  * implementation as well as DSL for building [[io.scalaland.chimney.Transformer]]
+  * using [[io.scalaland.chimney.dsl.TransformerDefinition]].
+  */
 object Transformer {
 
+  /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
+    * 
+    * If derivation with defaults is not possible, macro expansion will fail
+    * and the instance should be define manually to solve e.g. field renames or
+    * missing values (it can be done using provided DSL).
+    * 
+    * @tparam From data type that will be used as input
+    * @tparam Into data type that will be used as output
+    * @return default implementation (if posible)
+    */
   implicit def derive[From, To]: Transformer[From, To] =
     macro ChimneyBlackboxMacros.deriveTransformerImpl[From, To]
 
+  /** Convenient utility to create an empty [[io.scalaland.chimney.dsl.TransformerDefinition]].
+    * 
+    * {{{
+    * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
+    *   .modifier1
+    *   .modifier2
+    *   .buildTransformer
+    * }}}
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for available settings
+    * 
+    * @tparam From data type that will be used as input
+    * @tparam Into data type that will be used as output
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]] with defaults
+    */
   def define[From, To]: TransformerDefinition[From, To, TransformerCfg.Empty] =
     new TransformerDefinition[From, To, TransformerCfg.Empty](Map.empty, Map.empty)
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -8,8 +8,8 @@ import scala.language.experimental.macros
 
 /** Maps data from one type `From` into another `To`.
   *
-  * @tparam From data type that will be used as input
-  * @tparam To   data type that will be used as output
+  * @tparam From type of input value
+  * @tparam To   type of output value
   */
 trait Transformer[From, To] {
   def transform(src: From): To
@@ -19,8 +19,8 @@ object Transformer {
 
   /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
     *
-    * @tparam From data type that will be used as input
-    * @tparam Into data type that will be used as output
+    * @tparam From type of input value
+    * @tparam Into type of output value
     * @return [[io.scalaland.chimney.Transformer]] type class definition
     */
   implicit def derive[From, To]: Transformer[From, To] =
@@ -31,8 +31,8 @@ object Transformer {
     *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for available settings
     *
-    * @tparam From data type that will be used as input
-    * @tparam Into data type that will be used as output
+    * @tparam From type of input value
+    * @tparam Into type of output value
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]] with defaults
     */
   def define[From, To]: TransformerDefinition[From, To, TransformerCfg.Empty] =

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
@@ -6,14 +6,48 @@ import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
 
 import scala.language.experimental.macros
 
+/** Provides operations to customize patcher logic for specific
+ * object value and patch value.
+ *
+ * @param obj object to patch
+ * @param objPatch patch object
+ * @tparam T type of object to apply patch to
+ * @tparam P type of patch object
+ * @tparam C type-level encoded configuration of patcher
+ */
 class PatcherUsing[T, P, C <: PatcherCfg](val obj: T, val objPatch: P) {
 
+  /** In case when both object to patch and patch value contain field
+   * of type `Option[T]`, this option allows to treat `None` value in
+   * patch like the value was not provided.
+   *
+   * By default, when `None` is delivered in patch, Chimney clears
+   * the value of such field on patching.
+   *
+   * @see [[https://scalalandio.github.io/chimney/#Patchers]] for more details
+   * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
+   */
   def ignoreNoneInPatch: PatcherUsing[T, P, IgnoreNoneInPatch[C]] =
     this.asInstanceOf[PatcherUsing[T, P, IgnoreNoneInPatch[C]]]
 
+  /** In case that patch object contains redundant field (i.e. field that
+   * is not present in patched object type), this option enables ignoring
+   * value of such fields and generate patch successfully.
+   *
+   * By default, when Chimney detects redundant field in patch object, it
+   * fails compilation in order to prevent silent oversight of field name
+   * typos.
+   *
+   * @see [[https://scalalandio.github.io/chimney/#Patchers]] for more details
+   * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
+   */
   def ignoreRedundantPatcherFields: PatcherUsing[T, P, IgnoreRedundantPatcherFields[C]] =
     this.asInstanceOf[PatcherUsing[T, P, IgnoreRedundantPatcherFields[C]]]
 
+  /** Applies configured patching in-place
+   *
+   * @return patched value
+   */
   def patch: T = macro ChimneyBlackboxMacros.patchImpl[T, P, C]
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
@@ -30,12 +30,12 @@ class PatcherUsing[T, P, C <: PatcherCfg](val obj: T, val objPatch: P) {
   def ignoreNoneInPatch: PatcherUsing[T, P, IgnoreNoneInPatch[C]] =
     this.asInstanceOf[PatcherUsing[T, P, IgnoreNoneInPatch[C]]]
 
-  /** In case that patch object contains redundant field (i.e. field that
+  /** In case that patch object contains a redundant field (i.e. field that
     * is not present in patched object type), this option enables ignoring
     * value of such fields and generate patch successfully.
     *
-    * By default, when Chimney detects redundant field in patch object, it
-    * fails compilation in order to prevent silent oversight of field name
+    * By default, when Chimney detects a redundant field in patch object, it
+    * fails the compilation in order to prevent silent oversight of field name
     * typos.
     *
     * @see [[https://scalalandio.github.io/chimney/#Patchers]] for more details
@@ -49,5 +49,4 @@ class PatcherUsing[T, P, C <: PatcherCfg](val obj: T, val objPatch: P) {
     * @return patched value
     */
   def patch: T = macro ChimneyBlackboxMacros.patchImpl[T, P, C]
-
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
@@ -7,47 +7,47 @@ import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
 import scala.language.experimental.macros
 
 /** Provides operations to customize patcher logic for specific
- * object value and patch value.
- *
- * @param obj object to patch
- * @param objPatch patch object
- * @tparam T type of object to apply patch to
- * @tparam P type of patch object
- * @tparam C type-level encoded configuration of patcher
- */
+  * object value and patch value.
+  *
+  * @param obj object to patch
+  * @param objPatch patch object
+  * @tparam T type of object to apply patch to
+  * @tparam P type of patch object
+  * @tparam C type-level encoded configuration of patcher
+  */
 class PatcherUsing[T, P, C <: PatcherCfg](val obj: T, val objPatch: P) {
 
   /** In case when both object to patch and patch value contain field
-   * of type `Option[T]`, this option allows to treat `None` value in
-   * patch like the value was not provided.
-   *
-   * By default, when `None` is delivered in patch, Chimney clears
-   * the value of such field on patching.
-   *
-   * @see [[https://scalalandio.github.io/chimney/#Patchers]] for more details
-   * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
-   */
+    * of type `Option[T]`, this option allows to treat `None` value in
+    * patch like the value was not provided.
+    *
+    * By default, when `None` is delivered in patch, Chimney clears
+    * the value of such field on patching.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Patchers]] for more details
+    * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
+    */
   def ignoreNoneInPatch: PatcherUsing[T, P, IgnoreNoneInPatch[C]] =
     this.asInstanceOf[PatcherUsing[T, P, IgnoreNoneInPatch[C]]]
 
   /** In case that patch object contains redundant field (i.e. field that
-   * is not present in patched object type), this option enables ignoring
-   * value of such fields and generate patch successfully.
-   *
-   * By default, when Chimney detects redundant field in patch object, it
-   * fails compilation in order to prevent silent oversight of field name
-   * typos.
-   *
-   * @see [[https://scalalandio.github.io/chimney/#Patchers]] for more details
-   * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
-   */
+    * is not present in patched object type), this option enables ignoring
+    * value of such fields and generate patch successfully.
+    *
+    * By default, when Chimney detects redundant field in patch object, it
+    * fails compilation in order to prevent silent oversight of field name
+    * typos.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Patchers]] for more details
+    * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
+    */
   def ignoreRedundantPatcherFields: PatcherUsing[T, P, IgnoreRedundantPatcherFields[C]] =
     this.asInstanceOf[PatcherUsing[T, P, IgnoreRedundantPatcherFields[C]]]
 
   /** Applies configured patching in-place
-   *
-   * @return patched value
-   */
+    *
+    * @return patched value
+    */
   def patch: T = macro ChimneyBlackboxMacros.patchImpl[T, P, C]
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -9,31 +9,6 @@ import scala.language.experimental.macros
 
 /** Allows customization of [[io.scalaland.chimney.Transformer]] derivation
   *
-  * By default derivation will expect that:
-  *
-  * - for every field in `To` there is a corresponding field in `From`
-  * - their types match or it is possible to find/derive [[io.scalaland.chimney.Transformer]] for them
-  *
-  * For some case this is insufficient and a manual intervention is needed:
-  *
-  * - derivation should be informed that field in `From` corresponds with field
-  *   of a different name in `To`,
-  * - derivation should be informed that missing `To` field's value should be
-  *   a constant/computed value,
-  * - convertion to/from `Option` should get a special treatment,
-  * - input/output type is a Java Bean with a convention different to Scala one's.
-  *
-  * In such case you can use methods of this class to change derivation configuration.
-  *
-  * {{{
-  * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
-  *   .setting1
-  *   .setting2
-  *   .buildTransformer
-  * }}}
-  *
-  * @see [[io.scalaland.chimney.dsl.TransformerInto]] for building transformer and applying it immediately
-  *
   * @tparam From data type that will be used as input
   * @tparam To   data type that will be used as output
   * @tparam C    type-level encoded config
@@ -46,6 +21,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
   /** Fail derivation if `From` type is missing field even if `To` has default value for it
     *
     * By default in such case derivation will fallback to default values.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def disableDefaultValues: TransformerDefinition[From, To, DisableDefaultValues[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, DisableDefaultValues[C]]]
@@ -53,6 +31,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
   /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`
     *
     * By default only Scala conversions (`.name`) are allowed.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableBeanGetters: TransformerDefinition[From, To, EnableBeanGetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanGetters[C]]]
@@ -60,6 +41,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
   /** Enable Java Beans naming convention (`.setName(value)`) on `To`
     *
     * By default only Scala conversions (`.copy(name = value)`) are allowed.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableBeanSetters: TransformerDefinition[From, To, EnableBeanSetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanSetters[C]]]
@@ -68,6 +52,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     * value is available but present in `To` as `Option` type
     *
     * By default in such case derivation will fail.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableOptionDefaultsToNone: TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]]]
@@ -75,6 +62,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
   /** Allow running `.get` if `From` contains `Option[A]` and `To` requires `A`
     *
     * By default in such case derivation will fail.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableUnsafeOption: TransformerDefinition[From, To, EnableUnsafeOption[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableUnsafeOption[C]]]
@@ -83,8 +73,10 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     *
     * By default if `From` is missing field picked by `selector` derivation will fail.
     *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
     * @param selector target field in `To`, defined like `_.name`
     * @param value    constant value to use for the target field
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def withFieldConst[T, U](selector: To => T, value: U): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]
@@ -93,8 +85,10 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     *
     * By default if `From` is missing field picked by `selector` derivation will fail.
     *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
     * @param selector target field in `To`, defined like `_.name`
     * @param map      function to use to compute value of the target field
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def withFieldComputed[T, U](selector: To => T, map: From => U): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withFieldComputedImpl[From, To, T, U, C]
@@ -103,8 +97,10 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     *
     * By default if `From` is missing field picked by `selectorTo` derivation will fail.
     *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
     * @param selectorFrom source field in `From`, defined like `_.originalName`
     * @param selectorTo   target field in `To`, defined like `_.newName`
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def withFieldRenamed[T, U](selectorFrom: From => T, selectorTo: To => U): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withFieldRenamedImpl[From, To, T, U, C]
@@ -116,12 +112,17 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it will fail.
     *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
     * @param f function to calculate values of components that cannot be mapped automatically
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def withCoproductInstance[Inst](f: Inst => To): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withCoproductInstanceImpl[From, To, Inst, C]
 
-  /** Build Transformer using current configuration */
+  /** Build Transformer using current configuration
+    *
+    * @return [[io.scalaland.chimney.Transformer]] type class definition
+    */
   def buildTransformer: Transformer[From, To] =
     macro ChimneyBlackboxMacros.buildTransformerImpl[From, To, C]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -8,32 +8,32 @@ import io.scalaland.chimney.internal.macros.{ChimneyBlackboxMacros, TransformerD
 import scala.language.experimental.macros
 
 /** Allows customization of [[io.scalaland.chimney.Transformer]] derivation
-  * 
+  *
   * By default derivation will expect that:
-  * 
+  *
   * - for every field in `To` there is a corresponding field in `From`
   * - their types match or it is possible to find/derive [[io.scalaland.chimney.Transformer]] for them
-  * 
+  *
   * For some case this is insufficient and a manual intervention is needed:
-  * 
+  *
   * - derivation should be informed that field in `From` corresponds with field
   *   of a different name in `To`,
   * - derivation should be informed that missing `To` field's value should be
   *   a constant/computed value,
   * - convertion to/from `Option` should get a special treatment,
   * - input/output type is a Java Bean with a convention different to Scala one's.
-  * 
+  *
   * In such case you can use methods of this class to change derivation configuration.
-  * 
+  *
   * {{{
   * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
   *   .setting1
   *   .setting2
   *   .buildTransformer
   * }}}
-  * 
+  *
   * @see [[io.scalaland.chimney.dsl.TransformerInto]] for building transformer and applying it immediately
-  * 
+  *
   * @tparam From data type that will be used as input
   * @tparam To   data type that will be used as output
   * @tparam C    type-level encoded config
@@ -44,21 +44,21 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
 ) {
 
   /** Fail derivation if `From` type is missing field even if `To` has default value for it
-    * 
+    *
     * By default in such case derivation will fallback to default values.
     */
   def disableDefaultValues: TransformerDefinition[From, To, DisableDefaultValues[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, DisableDefaultValues[C]]]
 
   /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`
-    * 
+    *
     * By default only Scala conversions (`.name`) are allowed.
     */
   def enableBeanGetters: TransformerDefinition[From, To, EnableBeanGetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanGetters[C]]]
 
   /** Enable Java Beans naming convention (`.setName(value)`) on `To`
-    * 
+    *
     * By default only Scala conversions (`.copy(name = value)`) are allowed.
     */
   def enableBeanSetters: TransformerDefinition[From, To, EnableBeanSetters[C]] =
@@ -66,23 +66,23 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
 
   /** Allow usage of None if field is missing in `From`, no rename/const value/calulated
     * value is available but present in `To` as `Option` type
-    * 
+    *
     * By default in such case derivation will fail.
     */
   def enableOptionDefaultsToNone: TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]]]
 
   /** Allow running `.get` if `From` contains `Option[A]` and `To` requires `A`
-    * 
+    *
     * By default in such case derivation will fail.
     */
   def enableUnsafeOption: TransformerDefinition[From, To, EnableUnsafeOption[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableUnsafeOption[C]]]
 
   /** Use `value` provided here for field picked using `selector`.
-    * 
+    *
     * By default if `From` is missing field picked by `selector` derivation will fail.
-    * 
+    *
     * @param selector target field in `To`, defined like `_.name`
     * @param value    constant value to use for the target field
     */
@@ -90,9 +90,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     macro TransformerDefinitionWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]
 
   /** Use `map` provided here to compute value of field picked using `selector`.
-    * 
+    *
     * By default if `From` is missing field picked by `selector` derivation will fail.
-    * 
+    *
     * @param selector target field in `To`, defined like `_.name`
     * @param map      function to use to compute value of the target field
     */
@@ -100,7 +100,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     macro TransformerDefinitionWhiteboxMacros.withFieldComputedImpl[From, To, T, U, C]
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
-    * 
+    *
     * By default if `From` is missing field picked by `selectorTo` derivation will fail.
     *
     * @param selectorFrom source field in `From`, defined like `_.originalName`
@@ -110,7 +110,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     macro TransformerDefinitionWhiteboxMacros.withFieldRenamedImpl[From, To, T, U, C]
 
   /** Use `f` to calculate the (missing) coproduct instance when mapping one coproduct into another
-    * 
+    *
     * By default if mapping one coproduct in `From` into another coproduct in `To` derivation
     * expects that coproducts will have matching names of its components, and for every component
     * in `To` field's type there is matching component in `From` type. If some component is missing

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -22,7 +22,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     *
     * By default in such case derivation will fallback to default values.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Defaultoptionvalues]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def disableDefaultValues: TransformerDefinition[From, To, DisableDefaultValues[C]] =
@@ -32,7 +32,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     *
     * By default only Scala conversions (`.name`) are allowed.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#ReadingfromJavabeans]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableBeanGetters: TransformerDefinition[From, To, EnableBeanGetters[C]] =
@@ -42,28 +42,29 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     *
     * By default only Scala conversions (`.copy(name = value)`) are allowed.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#WritingtoJavabeans]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableBeanSetters: TransformerDefinition[From, To, EnableBeanSetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanSetters[C]]]
 
-  /** Allow usage of None if field is missing in `From`, no rename/const value/calulated
-    * value is available but present in `To` as `Option` type
+  /** Sets target value of optional field to None if field is missing from source type From
     *
-    * By default in such case derivation will fail.
+    * By default in such case compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Defaultoptionvalues]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableOptionDefaultsToNone: TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]]]
 
-  /** Allow running `.get` if `From` contains `Option[A]` and `To` requires `A`
+  /** Enable unsafe call to `.get` when source type From contains field of type `Option[A]`, but target type To defines this fields as `A`
     *
-    * By default in such case derivation will fail.
+    * It's unsafe as code generated this way may throw at runtime.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * By default in such case compilation fails.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Unsafeoption]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */
   def enableUnsafeOption: TransformerDefinition[From, To, EnableUnsafeOption[C]] =
@@ -71,9 +72,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
 
   /** Use `value` provided here for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * By default if `From` is missing field picked by `selector` compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Providingmissingvalues]] for more details
     * @param selector target field in `To`, defined like `_.name`
     * @param value    constant value to use for the target field
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
@@ -83,9 +84,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
 
   /** Use `map` provided here to compute value of field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * By default if `From` is missing field picked by `selector` compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Providingmissingvalues]] for more details
     * @param selector target field in `To`, defined like `_.name`
     * @param map      function to use to compute value of the target field
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
@@ -95,9 +96,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
     *
-    * By default if `From` is missing field picked by `selectorTo` derivation will fail.
+    * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Fieldre-labelling]] for more details
     * @param selectorFrom source field in `From`, defined like `_.originalName`
     * @param selectorTo   target field in `To`, defined like `_.newName`
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
@@ -112,7 +113,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it will fail.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Coproductssupport]] for more details
     * @param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -7,37 +7,122 @@ import io.scalaland.chimney.internal.macros.{ChimneyBlackboxMacros, TransformerD
 
 import scala.language.experimental.macros
 
+/** Allows customization of [[io.scalaland.chimney.Transformer]] derivation
+  * 
+  * By default derivation will expect that:
+  * 
+  * - for every field in `To` there is a corresponding field in `From`
+  * - their types match or it is possible to find/derive [[io.scalaland.chimney.Transformer]] for them
+  * 
+  * For some case this is insufficient and a manual intervention is needed:
+  * 
+  * - derivation should be informed that field in `From` corresponds with field
+  *   of a different name in `To`,
+  * - derivation should be informed that missing `To` field's value should be
+  *   a constant/computed value,
+  * - convertion to/from `Option` should get a special treatment,
+  * - input/output type is a Java Bean with a convention different to Scala one's.
+  * 
+  * In such case you can use methods of this class to change derivation configuration.
+  * 
+  * {{{
+  * implicit val fooToBar: Transformer[Foo, Bar] = Transformer.define[Foo, Bar]
+  *   .setting1
+  *   .setting2
+  *   .buildTransformer
+  * }}}
+  * 
+  * @see [[io.scalaland.chimney.dsl.TransformerInto]] for building transformer and applying it immediately
+  * 
+  * @tparam From data type that will be used as input
+  * @tparam To   data type that will be used as output
+  * @tparam C    type-level encoded list of settings
+  *              (implementation detail, but it is important to not change it manually)
+  */
 final class TransformerDefinition[From, To, C <: TransformerCfg](
     val overrides: Map[String, Any],
     val instances: Map[(String, String), Any]
 ) {
+
+  /** Fail derivation if `From` type is missing field even if `To` has default value for it
+    * 
+    * By default in such case derivation will fallback to default values.
+    */
   def disableDefaultValues: TransformerDefinition[From, To, DisableDefaultValues[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, DisableDefaultValues[C]]]
 
+  /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`
+    * 
+    * By default only Scala conversions (`.name`) are allowed.
+    */
   def enableBeanGetters: TransformerDefinition[From, To, EnableBeanGetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanGetters[C]]]
 
+  /** Enable Java Beans naming convention (`.setName`) on `To`
+    * 
+    * By default only Scala conversions (`.name =`) are allowed.
+    */
   def enableBeanSetters: TransformerDefinition[From, To, EnableBeanSetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanSetters[C]]]
 
+  /** Allow usage of None if field is missing in `From`, no rename/const value/calulated
+    * value is available but present in `To` as `Option` type
+    * 
+    * By default in such case derivation will fail.
+    */
   def enableOptionDefaultsToNone: TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableOptionDefaultsToNone[C]]]
 
+  /** Allow running `.get` if `From` contains `Option[A]` and `To` requires `A`
+    * 
+    * By default in such case derivation will fail.
+    */
   def enableUnsafeOption: TransformerDefinition[From, To, EnableUnsafeOption[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableUnsafeOption[C]]]
 
+  /** Use `value` provided here for field picked using `selector`.
+    * 
+    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * 
+    * @param selector target field in `To`, defined like `_.name`
+    * @param value    constant value to use for the target field
+    */
   def withFieldConst[T, U](selector: To => T, value: U): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]
 
+  /** Use `map` provided here to compute value of field picked using `selector`.
+    * 
+    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * 
+    * @param selector target field in `To`, defined like `_.name`
+    * @param map      function to use to compute value of the target field
+    */
   def withFieldComputed[T, U](selector: To => T, map: From => U): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withFieldComputedImpl[From, To, T, U, C]
 
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+    * 
+    * By default if `From` is missing field picked by `selectorTo` derivation will fail.
+    *
+    * @param selectorFrom source field in `From`, defined like `_.originalName`
+    * @param selectorTo   target field in `To`, defined like `_.newName`
+    */
   def withFieldRenamed[T, U](selectorFrom: From => T, selectorTo: To => U): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withFieldRenamedImpl[From, To, T, U, C]
 
+  /** Use `f` to calculate the (missing) coproduct instance when mapping one coproduct into another
+    * 
+    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation
+    * expects that coproducts will have matching names of its components, and for every component
+    * in `To` field's type there is matching component in `From` type. If some component is missing
+    * it will fail.
+    *
+    * @param f function to calculate values of components that cannot be mapped automatically
+    */
   def withCoproductInstance[Inst](f: Inst => To): TransformerDefinition[From, To, _] =
     macro TransformerDefinitionWhiteboxMacros.withCoproductInstanceImpl[From, To, Inst, C]
 
+  /** Build Transformer using current configuration */
   def buildTransformer: Transformer[From, To] =
     macro ChimneyBlackboxMacros.buildTransformerImpl[From, To, C]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -36,8 +36,7 @@ import scala.language.experimental.macros
   * 
   * @tparam From data type that will be used as input
   * @tparam To   data type that will be used as output
-  * @tparam C    type-level encoded list of settings
-  *              (implementation detail, but it is important to not change it manually)
+  * @tparam C    type-level encoded config
   */
 final class TransformerDefinition[From, To, C <: TransformerCfg](
     val overrides: Map[String, Any],
@@ -58,9 +57,9 @@ final class TransformerDefinition[From, To, C <: TransformerCfg](
   def enableBeanGetters: TransformerDefinition[From, To, EnableBeanGetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanGetters[C]]]
 
-  /** Enable Java Beans naming convention (`.setName`) on `To`
+  /** Enable Java Beans naming convention (`.setName(value)`) on `To`
     * 
-    * By default only Scala conversions (`.name =`) are allowed.
+    * By default only Scala conversions (`.copy(name = value)`) are allowed.
     */
   def enableBeanSetters: TransformerDefinition[From, To, EnableBeanSetters[C]] =
     this.asInstanceOf[TransformerDefinition[From, To, EnableBeanSetters[C]]]

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -9,8 +9,8 @@ import scala.language.experimental.macros
 
 /** Allows customization of [[io.scalaland.chimney.Transformer]] derivation
   *
-  * @tparam From data type that will be used as input
-  * @tparam To   data type that will be used as output
+  * @tparam From type of input value
+  * @tparam To   type of output value
   * @tparam C    type-level encoded config
   */
 final class TransformerDefinition[From, To, C <: TransformerCfg](

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -24,7 +24,7 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default in such case derivation will fallback to default values.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Defaultoptionvalues]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def disableDefaultValues: TransformerInto[From, To, DisableDefaultValues[C]] =
@@ -34,7 +34,7 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default only Scala conversions (`.name`) are allowed.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#ReadingfromJavabeans]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def enableBeanGetters: TransformerInto[From, To, EnableBeanGetters[C]] =
@@ -44,28 +44,29 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default only Scala conversions (`.copy(name = value)`) are allowed.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#WritingtoJavabeans]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def enableBeanSetters: TransformerInto[From, To, EnableBeanSetters[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableBeanSetters[C]]]
 
-  /** Allow usage of None if field is missing in `From`, no rename/const value/calulated
-    * value is available but present in `To` as `Option` type
+  /** Sets target value of optional field to None if field is missing from source type From
     *
-    * By default in such case derivation will fail.
+    * By default in such case compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Defaultoptionvalues]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def enableOptionDefaultsToNone: TransformerInto[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableOptionDefaultsToNone[C]]]
 
-  /** Allow running `.get` if `From` contains `Option[A]` and `To` requires `A`
+  /** Enable unsafe call to `.get` when source type From contains field of type `Option[A]`, but target type To defines this fields as `A`
     *
-    * By default in such case derivation will fail.
+    * It's unsafe as code generated this way may throw at runtime.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * By default in such case compilation fails.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Unsafeoption]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def enableUnsafeOption: TransformerInto[From, To, EnableUnsafeOption[C]] =
@@ -73,9 +74,9 @@ final class TransformerInto[From, To, C <: TransformerCfg](
 
   /** Use `value` provided here for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * By default if `From` is missing field picked by `selector` compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Providingmissingvalues]] for more details
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
@@ -83,9 +84,9 @@ final class TransformerInto[From, To, C <: TransformerCfg](
 
   /** Use `map` provided here to compute value of field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * By default if `From` is missing field picked by `selector` compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Providingmissingvalues]] for more details
     * @param selector target field in `To`, defined like `_.name`
     * @param map      function to use to compute value of the target field
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
@@ -95,9 +96,9 @@ final class TransformerInto[From, To, C <: TransformerCfg](
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
     *
-    * By default if `From` is missing field picked by `selectorTo` derivation will fail.
+    * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Fieldre-labelling]] for more details
     * @param selectorFrom source field in `From`, defined like `_.originalName`
     * @param selectorTo   target field in `To`, defined like `_.newName`
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
@@ -112,7 +113,7 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it will fail.
     *
-    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @see [[https://scalalandio.github.io/chimney/#Coproductssupport]] for more details
     * @param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -55,9 +55,9 @@ final class TransformerInto[From, To, C <: TransformerCfg](
   def enableBeanGetters: TransformerInto[From, To, EnableBeanGetters[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableBeanGetters[C]]]
 
-  /** Enable Java Beans naming convention (`.setName`) on `To`
+  /** Enable Java Beans naming convention (`.setName(value)`) on `To`
     * 
-    * By default only Scala conversions (`.name =`) are allowed.
+    * By default only Scala conversions (`.copy(name = value)`) are allowed.
     * 
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableBeanSetters]]
     */
@@ -86,11 +86,6 @@ final class TransformerInto[From, To, C <: TransformerCfg](
   /** Use `value` provided here for field picked using `selector`.
     * 
     * By default if `From` is missing field picked by `selector` derivation will fail.
-    * 
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldConst]] 
-    * 
-    * @param selector target field in `To`, defined like `_.name`
-    * @param value    constant value to use for the target field
     */
   def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -6,38 +6,135 @@ import io.scalaland.chimney.internal.macros.{ChimneyBlackboxMacros, TransformerI
 
 import scala.language.experimental.macros
 
+/** Provides DSL for configuring [[io.scalaland.chimney.Transformer]]'s
+  * generation and using the result to transform value at the same time
+  * 
+  * For any ''.setting'' defined here (and in [[io.scalaland.chimney.dsl.TransformerDefinition]])
+  * we can:
+  * 
+  * {{{
+  * import io.scalaland.chimney.dsl._
+  * foo.into[Bar] // <- creates this builder initializing it with foo as source and empty config
+  *   .setting    // <- calls .setting on TransformerDefinition
+  *   .transform  // <- calls .buildTransformer.transform(foo)
+  * }}}
+  * 
+  * or (if only defaults are used, or there is some implicit [[io.scalaland.chimney.Transformer]]
+  * already in scope):
+  * 
+  * {{{
+  * import io.scalaland.chimney.dsl._
+  * foo.transformInto[Bar]
+  * }}}
+  * 
+  * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for building Transformer separately to applying it (in case you want to share it between several transformations)
+  * 
+  * @tparam From data type that will be used as input
+  * @tparam To   data type that will be used as output
+  * @tparam C    type-level encoded list of settings
+  */
 final class TransformerInto[From, To, C <: TransformerCfg](
     val source: From,
     val td: TransformerDefinition[From, To, C]
 ) {
 
+  /** Fail derivation if `From` type is missing field even if `To` has default value for it
+    * 
+    * By default in such case derivation will fallback to default values.
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#disableDefaultValues]]
+    */
   def disableDefaultValues: TransformerInto[From, To, DisableDefaultValues[C]] =
     this.asInstanceOf[TransformerInto[From, To, DisableDefaultValues[C]]]
 
+  /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`
+    * 
+    * By default only Scala conversions (`.name`) are allowed.
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableBeanGetters]]
+    */
   def enableBeanGetters: TransformerInto[From, To, EnableBeanGetters[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableBeanGetters[C]]]
 
+  /** Enable Java Beans naming convention (`.setName`) on `To`
+    * 
+    * By default only Scala conversions (`.name =`) are allowed.
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableBeanSetters]]
+    */
   def enableBeanSetters: TransformerInto[From, To, EnableBeanSetters[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableBeanSetters[C]]]
 
+  /** Allow usage of None if field is missing in `From`, no rename/const value/calulated
+    * value is available but present in `To` as `Option` type
+    * 
+    * By default in such case derivation will fail.
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableOptionDefaultsToNone]]
+    */
   def enableOptionDefaultsToNone: TransformerInto[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableOptionDefaultsToNone[C]]]
 
+  /** Allow running `.get` if `From` contains `Option[A]` and `To` requires `A`
+    * 
+    * By default in such case derivation will fail.
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableUnsafeOption]]
+    * */
   def enableUnsafeOption: TransformerInto[From, To, EnableUnsafeOption[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableUnsafeOption[C]]]
 
+  /** Use `value` provided here for field picked using `selector`.
+    * 
+    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldConst]] 
+    * 
+    * @param selector target field in `To`, defined like `_.name`
+    * @param value    constant value to use for the target field
+    */
   def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]
 
+  /** Use `map` provided here to compute value of field picked using `selector`.
+    * 
+    * By default if `From` is missing field picked by `selector` derivation will fail.
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldComputed]] 
+    * 
+    * @param selector target field in `To`, defined like `_.name`
+    * @param map      function to use to compute value of the target field
+    * */
   def withFieldComputed[T, U](selector: To => T, map: From => U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldComputedImpl[From, To, T, U, C]
 
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+    * 
+    * By default if `From` is missing field picked by `selectorTo` derivation will fail.
+    *
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldRenamed]] 
+    * 
+    * @param selectorFrom source field in `From`, defined like `_.originalName`
+    * @param selectorTo   target field in `To`, defined like `_.newName`
+    * */
   def withFieldRenamed[T, U](selectorFrom: From => T, selectorTo: To => U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldRenamedImpl[From, To, T, U, C]
 
+  /** Use `f` to calculate the (missing) coproduct instance when mapping one coproduct into another
+    * 
+    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation
+    * expects that coproducts will have matching names of its components, and for every component
+    * in `To` field's type there is matching component in `From` type. If some component is missing
+    * it will fail.
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withCoproductInstance]]
+    *
+    * @param f function to calculate values of components that cannot be mapped automatically
+    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withCoproductInstance]]*/
   def withCoproductInstance[Inst](f: Inst => To): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withCoproductInstanceImpl[From, To, Inst, C]
 
+  /** Derive [[io.scalaland.chimney.Transformer]] and pass transformed value into it */
   def transform: To =
     macro ChimneyBlackboxMacros.transformImpl[From, To, C]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -8,27 +8,27 @@ import scala.language.experimental.macros
 
 /** Provides DSL for configuring [[io.scalaland.chimney.Transformer]]'s
   * generation and using the result to transform value at the same time
-  * 
+  *
   * For any ''.setting'' defined here (and in [[io.scalaland.chimney.dsl.TransformerDefinition]])
   * we can:
-  * 
+  *
   * {{{
   * import io.scalaland.chimney.dsl._
   * foo.into[Bar] // <- creates this builder initializing it with foo as source and empty config
   *   .setting    // <- calls .setting on TransformerDefinition
   *   .transform  // <- calls .buildTransformer.transform(foo)
   * }}}
-  * 
+  *
   * or (if only defaults are used, or there is some implicit [[io.scalaland.chimney.Transformer]]
   * already in scope):
-  * 
+  *
   * {{{
   * import io.scalaland.chimney.dsl._
   * foo.transformInto[Bar]
   * }}}
-  * 
+  *
   * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for building Transformer separately to applying it (in case you want to share it between several transformations)
-  * 
+  *
   * @tparam From data type that will be used as input
   * @tparam To   data type that will be used as output
   * @tparam C    type-level encoded list of settings
@@ -39,16 +39,16 @@ final class TransformerInto[From, To, C <: TransformerCfg](
 ) {
 
   /** Fail derivation if `From` type is missing field even if `To` has default value for it
-    * 
+    *
     * By default in such case derivation will fallback to default values.
-    * 
+    *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#disableDefaultValues]]
     */
   def disableDefaultValues: TransformerInto[From, To, DisableDefaultValues[C]] =
     this.asInstanceOf[TransformerInto[From, To, DisableDefaultValues[C]]]
 
   /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`
-    * 
+    *
     * By default only Scala conversions (`.name`) are allowed.
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableBeanGetters]]
     */
@@ -56,9 +56,9 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     this.asInstanceOf[TransformerInto[From, To, EnableBeanGetters[C]]]
 
   /** Enable Java Beans naming convention (`.setName(value)`) on `To`
-    * 
+    *
     * By default only Scala conversions (`.copy(name = value)`) are allowed.
-    * 
+    *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableBeanSetters]]
     */
   def enableBeanSetters: TransformerInto[From, To, EnableBeanSetters[C]] =
@@ -66,36 +66,36 @@ final class TransformerInto[From, To, C <: TransformerCfg](
 
   /** Allow usage of None if field is missing in `From`, no rename/const value/calulated
     * value is available but present in `To` as `Option` type
-    * 
+    *
     * By default in such case derivation will fail.
-    * 
+    *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableOptionDefaultsToNone]]
     */
   def enableOptionDefaultsToNone: TransformerInto[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableOptionDefaultsToNone[C]]]
 
   /** Allow running `.get` if `From` contains `Option[A]` and `To` requires `A`
-    * 
+    *
     * By default in such case derivation will fail.
-    * 
+    *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableUnsafeOption]]
     * */
   def enableUnsafeOption: TransformerInto[From, To, EnableUnsafeOption[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableUnsafeOption[C]]]
 
   /** Use `value` provided here for field picked using `selector`.
-    * 
+    *
     * By default if `From` is missing field picked by `selector` derivation will fail.
     */
   def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]
 
   /** Use `map` provided here to compute value of field picked using `selector`.
-    * 
+    *
     * By default if `From` is missing field picked by `selector` derivation will fail.
-    * 
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldComputed]] 
-    * 
+    *
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldComputed]]
+    *
     * @param selector target field in `To`, defined like `_.name`
     * @param map      function to use to compute value of the target field
     * */
@@ -103,11 +103,11 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     macro TransformerIntoWhiteboxMacros.withFieldComputedImpl[From, To, T, U, C]
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
-    * 
+    *
     * By default if `From` is missing field picked by `selectorTo` derivation will fail.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldRenamed]] 
-    * 
+    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldRenamed]]
+    *
     * @param selectorFrom source field in `From`, defined like `_.originalName`
     * @param selectorTo   target field in `To`, defined like `_.newName`
     * */
@@ -115,16 +115,16 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     macro TransformerIntoWhiteboxMacros.withFieldRenamedImpl[From, To, T, U, C]
 
   /** Use `f` to calculate the (missing) coproduct instance when mapping one coproduct into another
-    * 
+    *
     * By default if mapping one coproduct in `From` into another coproduct in `To` derivation
     * expects that coproducts will have matching names of its components, and for every component
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it will fail.
-    * 
+    *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withCoproductInstance]]
     *
     * @param f function to calculate values of components that cannot be mapped automatically
-    * 
+    *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withCoproductInstance]]*/
   def withCoproductInstance[Inst](f: Inst => To): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withCoproductInstanceImpl[From, To, Inst, C]

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -9,29 +9,11 @@ import scala.language.experimental.macros
 /** Provides DSL for configuring [[io.scalaland.chimney.Transformer]]'s
   * generation and using the result to transform value at the same time
   *
-  * For any ''.setting'' defined here (and in [[io.scalaland.chimney.dsl.TransformerDefinition]])
-  * we can:
-  *
-  * {{{
-  * import io.scalaland.chimney.dsl._
-  * foo.into[Bar] // <- creates this builder initializing it with foo as source and empty config
-  *   .setting    // <- calls .setting on TransformerDefinition
-  *   .transform  // <- calls .buildTransformer.transform(foo)
-  * }}}
-  *
-  * or (if only defaults are used, or there is some implicit [[io.scalaland.chimney.Transformer]]
-  * already in scope):
-  *
-  * {{{
-  * import io.scalaland.chimney.dsl._
-  * foo.transformInto[Bar]
-  * }}}
-  *
-  * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for building Transformer separately to applying it (in case you want to share it between several transformations)
-  *
-  * @tparam From data type that will be used as input
-  * @tparam To   data type that will be used as output
-  * @tparam C    type-level encoded list of settings
+  * @param  source object to transform
+  * @param  td     transformer definition
+  * @tparam From   data type that will be used as input
+  * @tparam To     data type that will be used as output
+  * @tparam C      type-level encoded config
   */
 final class TransformerInto[From, To, C <: TransformerCfg](
     val source: From,
@@ -42,7 +24,8 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default in such case derivation will fallback to default values.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#disableDefaultValues]]
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def disableDefaultValues: TransformerInto[From, To, DisableDefaultValues[C]] =
     this.asInstanceOf[TransformerInto[From, To, DisableDefaultValues[C]]]
@@ -50,7 +33,9 @@ final class TransformerInto[From, To, C <: TransformerCfg](
   /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`
     *
     * By default only Scala conversions (`.name`) are allowed.
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableBeanGetters]]
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def enableBeanGetters: TransformerInto[From, To, EnableBeanGetters[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableBeanGetters[C]]]
@@ -59,7 +44,8 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default only Scala conversions (`.copy(name = value)`) are allowed.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableBeanSetters]]
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def enableBeanSetters: TransformerInto[From, To, EnableBeanSetters[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableBeanSetters[C]]]
@@ -69,7 +55,8 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default in such case derivation will fail.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableOptionDefaultsToNone]]
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def enableOptionDefaultsToNone: TransformerInto[From, To, EnableOptionDefaultsToNone[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableOptionDefaultsToNone[C]]]
@@ -78,14 +65,18 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default in such case derivation will fail.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#enableUnsafeOption]]
-    * */
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
+    */
   def enableUnsafeOption: TransformerInto[From, To, EnableUnsafeOption[C]] =
     this.asInstanceOf[TransformerInto[From, To, EnableUnsafeOption[C]]]
 
   /** Use `value` provided here for field picked using `selector`.
     *
     * By default if `From` is missing field picked by `selector` derivation will fail.
+    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     */
   def withFieldConst[T, U](selector: To => T, value: U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldConstImpl[From, To, T, U, C]
@@ -94,10 +85,10 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default if `From` is missing field picked by `selector` derivation will fail.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldComputed]]
-    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
     * @param selector target field in `To`, defined like `_.name`
     * @param map      function to use to compute value of the target field
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     * */
   def withFieldComputed[T, U](selector: To => T, map: From => U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldComputedImpl[From, To, T, U, C]
@@ -106,10 +97,10 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     *
     * By default if `From` is missing field picked by `selectorTo` derivation will fail.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withFieldRenamed]]
-    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
     * @param selectorFrom source field in `From`, defined like `_.originalName`
     * @param selectorTo   target field in `To`, defined like `_.newName`
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     * */
   def withFieldRenamed[T, U](selectorFrom: From => T, selectorTo: To => U): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withFieldRenamedImpl[From, To, T, U, C]
@@ -121,15 +112,17 @@ final class TransformerInto[From, To, C <: TransformerCfg](
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it will fail.
     *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withCoproductInstance]]
-    *
+    * @see [[https://scalalandio.github.io/chimney/#Usage]] for more details
     * @param f function to calculate values of components that cannot be mapped automatically
-    *
-    * @see [[io.scalaland.chimney.dsl.TransformerDefinition#withCoproductInstance]]*/
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
+    */
   def withCoproductInstance[Inst](f: Inst => To): TransformerInto[From, To, _] =
     macro TransformerIntoWhiteboxMacros.withCoproductInstanceImpl[From, To, Inst, C]
 
-  /** Derive [[io.scalaland.chimney.Transformer]] and pass transformed value into it */
+  /** Apply configured transformation in-place
+    *
+    * @return transformed value
+    */
   def transform: To =
     macro ChimneyBlackboxMacros.transformImpl[From, To, C]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -11,8 +11,8 @@ import scala.language.experimental.macros
   *
   * @param  source object to transform
   * @param  td     transformer definition
-  * @tparam From   data type that will be used as input
-  * @tparam To     data type that will be used as output
+  * @tparam From   type of input value
+  * @tparam To     type of output value
   * @tparam C      type-level encoded config
   */
 final class TransformerInto[From, To, C <: TransformerCfg](

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
@@ -16,23 +16,23 @@ package object dsl {
   implicit class TransformerOps[From](private val source: From) extends AnyVal {
 
     /** Allows to customize transformer generation to your target type
-     *
-     * @tparam To target type
-     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
-     */
+      *
+      * @tparam To target type
+      * @return [[io.scalaland.chimney.dsl.TransformerInto]]
+      */
     final def into[To]: TransformerInto[From, To, TransformerCfg.Empty] =
       new TransformerInto(source, new TransformerDefinition[From, To, TransformerCfg.Empty](Map.empty, Map.empty))
 
     /** Performs in-place transformation of wrapped source value to target type.
-     *
-     * If you want to customize transformer behavior, consider using
-     * [[io.scalaland.chimney.dsl.TransformerOps#into into]] method.
-     *
-     * @see [[io.scalaland.chimney.Transformer#derive]] for default implicit instance
-     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
-     * @tparam To target type
-     * @return transformed value of target type
-     */
+      *
+      * If you want to customize transformer behavior, consider using
+      * [[io.scalaland.chimney.dsl.TransformerOps#into into]] method.
+      *
+      * @see [[io.scalaland.chimney.Transformer#derive]] for default implicit instance
+      * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
+      * @tparam To target type
+      * @return transformed value of target type
+      */
     final def transformInto[To](implicit transformer: Transformer[From, To]): To =
       transformer.transform(source)
   }
@@ -45,40 +45,40 @@ package object dsl {
   implicit class PatcherOps[T](private val obj: T) extends AnyVal {
 
     /** Allows to customize patcher generation
-     *
-     * @param patch patch object value
-     * @tparam P type of patch object
-     * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
-     */
+      *
+      * @param patch patch object value
+      * @tparam P type of patch object
+      * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
+      */
     final def using[P](patch: P): PatcherUsing[T, P, PatcherCfg.Empty] =
       new PatcherUsing[T, P, PatcherCfg.Empty](obj, patch)
 
     /** Performs in-place patching of wrapped object with provided value.
-     *
-     * If you want to customize patching behavior, consider using
-     * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
-     *
-     * @see [[io.scalaland.chimney.Patcher#derive]] for default implicit instance
-     * @param patch patch object value
-     * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class
-     * @tparam P type of patch object
-     * @return patched value
-     */
+      *
+      * If you want to customize patching behavior, consider using
+      * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
+      *
+      * @see [[io.scalaland.chimney.Patcher#derive]] for default implicit instance
+      * @param patch patch object value
+      * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class
+      * @tparam P type of patch object
+      * @return patched value
+      */
     final def patchUsing[P](patch: P)(implicit patcher: Patcher[T, P]): T =
       patcher.patch(obj, patch)
 
     /** Performs in-place patching of wrapped object with provided value.
-     *
-     * If you want to customize patching behavior, consider using
-     * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
-     *
-     * @deprecated use [[io.scalaland.chimney.dsl.PatcherOps#patchUsing patchUsing]] instead
-     * @see [[io.scalaland.chimney.Patcher#derive]] for default implicit instance
-     * @param patch patch object value
-     * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class
-     * @tparam P type of patch object
-     * @return patched value
-     */
+      *
+      * If you want to customize patching behavior, consider using
+      * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
+      *
+      * @deprecated use [[io.scalaland.chimney.dsl.PatcherOps#patchUsing patchUsing]] instead
+      * @see [[io.scalaland.chimney.Patcher#derive]] for default implicit instance
+      * @param patch patch object value
+      * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class
+      * @tparam P type of patch object
+      * @return patched value
+      */
     @deprecated("please use .patchUsing", "0.4.0")
     final def patchWith[P](patch: P)(implicit patcher: Patcher[T, P]): T =
       obj.patchUsing(patch)

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
@@ -4,25 +4,81 @@ import io.scalaland.chimney.internal.{PatcherCfg, TransformerCfg}
 
 import scala.language.experimental.macros
 
+/** Main object to import in order to use Chimney's features
+  */
 package object dsl {
 
+  /** Provides transformer operations on values of any type
+    *
+    * @param source wrapped source value
+    * @tparam From type of source value
+    */
   implicit class TransformerOps[From](private val source: From) extends AnyVal {
 
+    /** Allows to customize transformer generation to your target type
+     *
+     * @tparam To target type
+     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
+     */
     final def into[To]: TransformerInto[From, To, TransformerCfg.Empty] =
       new TransformerInto(source, new TransformerDefinition[From, To, TransformerCfg.Empty](Map.empty, Map.empty))
 
+    /** Performs in-place transformation of wrapped source value to target type.
+     *
+     * If you want to customize transformer behavior, consider using
+     * [[io.scalaland.chimney.dsl.TransformerOps#into into]] method.
+     *
+     * @see [[io.scalaland.chimney.Transformer#derive]] for default implicit instance
+     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
+     * @tparam To target type
+     * @return transformed value of target type
+     */
     final def transformInto[To](implicit transformer: Transformer[From, To]): To =
       transformer.transform(source)
   }
 
+  /** Provides patcher operations on values of any type
+    *
+    * @param obj wrapped object to patch
+    * @tparam T type of object to patch
+    */
   implicit class PatcherOps[T](private val obj: T) extends AnyVal {
 
+    /** Allows to customize patcher generation
+     *
+     * @param patch patch object value
+     * @tparam P type of patch object
+     * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
+     */
     final def using[P](patch: P): PatcherUsing[T, P, PatcherCfg.Empty] =
       new PatcherUsing[T, P, PatcherCfg.Empty](obj, patch)
 
+    /** Performs in-place patching of wrapped object with provided value.
+     *
+     * If you want to customize patching behavior, consider using
+     * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
+     *
+     * @see [[io.scalaland.chimney.Patcher#derive]] for default implicit instance
+     * @param patch patch object value
+     * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class
+     * @tparam P type of patch object
+     * @return patched value
+     */
     final def patchUsing[P](patch: P)(implicit patcher: Patcher[T, P]): T =
       patcher.patch(obj, patch)
 
+    /** Performs in-place patching of wrapped object with provided value.
+     *
+     * If you want to customize patching behavior, consider using
+     * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
+     *
+     * @deprecated use [[io.scalaland.chimney.dsl.PatcherOps#patchUsing patchUsing]] instead
+     * @see [[io.scalaland.chimney.Patcher#derive]] for default implicit instance
+     * @param patch patch object value
+     * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class
+     * @tparam P type of patch object
+     * @return patched value
+     */
     @deprecated("please use .patchUsing", "0.4.0")
     final def patchWith[P](patch: P)(implicit patcher: Patcher[T, P]): T =
       obj.patchUsing(patch)

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
@@ -26,7 +26,7 @@ package object dsl {
     /** Performs in-place transformation of wrapped source value to target type.
       *
       * If you want to customize transformer behavior, consider using
-      * [[io.scalaland.chimney.dsl.TransformerOps#into into]] method.
+      * [[io.scalaland.chimney.dsl.TransformerOps#into]] method.
       *
       * @see [[io.scalaland.chimney.Transformer#derive]] for default implicit instance
       * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class


### PR DESCRIPTION
Since we decided to add documentation on publicly available nethods and classes to make them more user friendly this PR attempts to add first batch of docs and start the discussion about the best format and conventions we want to follow.

@krzemin you can preview docs with `sbt chimneyJVM/doc` - they are in `chimney/.jvm/target/scala-*/api`