### PR TITLE
Eliminate local TransformerDefinition allocation in code generation when it's not used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         scala:
           - 2.11.12
-          - 2.12.8
+          - 2.12.10
           - 2.13.1
         jvm:
           - openjdk@8

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val settings = Seq(
     "-feature",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-//    "-Xfatal-warnings",
+    "-Xfatal-warnings",
     "-Xlint:adapted-args",
     "-Xlint:delayedinit-select",
     "-Xlint:doc-detached",
@@ -45,6 +45,13 @@ val settings = Seq(
         "-Ywarn-nullary-unit",
         "-Xlint:by-name-right-associative",
         "-Xlint:unsound-match"
+      ) ++ (
+      if (scalaVersion.value >= "2.12")
+        Seq(
+          "-Ywarn-unused:locals",
+          "-Ywarn-macros:after"
+        ) else
+      Nil
       )
     ),
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
@@ -46,6 +46,10 @@ trait TransformerConfiguration extends MacroUtils {
         renamedFields = Map.empty,
         definitionScope = None
       )
+
+    def valueLevelAccessNeeded: Boolean = {
+      constFields.nonEmpty || computedFields.nonEmpty || coproductInstances.nonEmpty
+    }
   }
 
   def captureTransformerConfig(cfgTpe: Type, config: TransformerConfig = TransformerConfig()): TransformerConfig = {

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -36,7 +36,6 @@ object DslSpec extends TestSuite {
       case class Foo(x: Int, y: String, z: (Double, Double))
       case class Bar(x: Int, z: (Double, Double))
       case class HaveY(y: String)
-      val haveY = HaveY("")
 
       "field is dropped - the target" - {
         Foo(3, "pi", (3.14, 3.14)).transformInto[Bar] ==> Bar(3, (3.14, 3.14))
@@ -84,7 +83,9 @@ object DslSpec extends TestSuite {
                 """)
               .check("", "Invalid selector!")
 
-            compileError("""Bar(3, (3.14, 3.14))
+            compileError("""
+                val haveY = HaveY("")
+                Bar(3, (3.14, 3.14))
                   .into[Foo]
                   .withFieldConst(cc => haveY.y, "pi")
                   .transform
@@ -168,7 +169,9 @@ object DslSpec extends TestSuite {
                 """)
               .check("", "Invalid selector!")
 
-            compileError("""Bar(3, (3.14, 3.14))
+            compileError("""
+                val haveY = HaveY("")
+                Bar(3, (3.14, 3.14))
                   .into[Foo]
                   .withFieldComputed(cc => haveY.y, _.x.toString)
                   .transform
@@ -298,9 +301,8 @@ object DslSpec extends TestSuite {
       }
 
       "between different types: without implicit" - {
-        val user: User = User(1, "Kuba", None)
-        val userPl = UserPL(1, "Kuba", Left(()))
         compileError("""
+            val user: User = User(1, "Kuba", None)
             user.into[UserPL].withFieldRenamed(_.name, _.imie)
                 .withFieldRenamed(_.age, _.wiek)
                 .transform
@@ -314,10 +316,7 @@ object DslSpec extends TestSuite {
       case class Foo(x: Int, y: String)
       case class Bar(x: Int, z: String)
       case class HaveY(y: String)
-
-      val haveY = HaveY("")
       case class HaveZ(z: String)
-      val haveZ = HaveZ("")
 
       "not compile if relabelling modifier is not provided" - {
 
@@ -344,6 +343,7 @@ object DslSpec extends TestSuite {
           .check("", "Selector of type Foo => String is not valid")
 
         compileError("""
+            val haveY = HaveY("")
             Foo(10, "something")
               .into[Bar]
               .withFieldRenamed(cc => haveY.y, _.z)
@@ -360,6 +360,7 @@ object DslSpec extends TestSuite {
           .check("", "Selector of type Bar => String is not valid")
 
         compileError("""
+            val haveZ = HaveZ("")
             Foo(10, "something")
               .into[Bar]
               .withFieldRenamed(_.y, cc => haveZ.z)
@@ -376,6 +377,8 @@ object DslSpec extends TestSuite {
           .check("", "Selector of type Bar => String is not valid")
 
         compileError("""
+            val haveY = HaveY("")
+            val haveZ = HaveZ("")
             Foo(10, "something")
               .into[Bar]
               .withFieldRenamed(cc => haveY.y, cc => haveZ.z)

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -233,9 +233,7 @@ object IssuesSpec extends TestSuite {
       case class BarNested(num: String)
       case class Bar(maybeString: scala.collection.immutable.Seq[String], nested: BarNested)
 
-      val foo = Foo(None, FooNested(None))
-
-      compileError("foo.into[Bar].transform")
+      compileError("Foo(None, FooNested(None)).into[Bar].transform")
         .check(
           "",
           "derivation from foo.maybeString: scala.Option to scala.collection.immutable.Seq is not supported in Chimney!",
@@ -254,6 +252,14 @@ object IssuesSpec extends TestSuite {
       val inputStrings = Strings(Set("one", "two", "three"))
       val lengths = inputStrings.into[Lengths].transform
       lengths.elems.size ==> 3
+    }
+
+    "fix issue #139" - {
+      case class WithoutOption(i: Int)
+      case class WithOption(i: Option[Int])
+
+      // this should compile without warning
+      Transformer.define[WithOption, WithoutOption].enableUnsafeOption.buildTransformer
     }
   }
 }


### PR DESCRIPTION
This PR brings solution for #139.

So far, using TransformerDefinition DSL, following part of code was always generated on invocation of `buildTransformer`:

```
val td$macro$xxx = new TransformerDefinition(...).operations...
// actual Transformer code
```
However, local value `td$macro$xxx` was not always used by actual Transformer code, which led to compiler warning (as shown in #139).

Good news is that we can specify and detect when value-level access to `TransformerDefinition` object is required; namely: only when at least one of `{withFieldConst, withFieldComputed, withCoproductInstance}` was used. Thus, with this PR simpler version of code, containing only actual `Transformer` code is generated, when it's safe.