### PR TITLE
Transformer config refactor

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
@@ -132,7 +132,7 @@ trait TransformerConfiguration extends MacroUtils {
       val fieldNameFrom = fieldNameFromT.singletonString
       val fieldNameTo = fieldNameToT.singletonString
       captureTransformerConfig(rest)
-        .fieldOverride(fieldNameTo, FieldOverride.RenamedFrom(fieldNameFrom)) // renameField(fieldNameTo, fieldNameFrom)
+        .fieldOverride(fieldNameTo, FieldOverride.RenamedFrom(fieldNameFrom))
     } else if (cfgTpe.typeConstructor =:= coproductInstanceT) {
       val List(instanceType, targetType, rest) = cfgTpe.typeArgs
       captureTransformerConfig(rest).coproductInstance(instanceType, targetType)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
@@ -16,13 +16,13 @@ object TransformerCfg {
   final class EnableUnsafeOption[C <: TransformerCfg] extends TransformerCfg
   final class EnableMethodAccessors[C <: TransformerCfg] extends TransformerCfg
   final class FieldConst[Name <: String, C <: TransformerCfg] extends TransformerCfg
+  final class FieldConstF[Name <: String, C <: TransformerCfg] extends TransformerCfg
   final class FieldComputed[Name <: String, C <: TransformerCfg] extends TransformerCfg
+  final class FieldComputedF[Name <: String, C <: TransformerCfg] extends TransformerCfg
   final class FieldRelabelled[FromName <: String, ToName <: String, C <: TransformerCfg] extends TransformerCfg
   final class CoproductInstance[InstType, TargetType, C <: TransformerCfg] extends TransformerCfg
-  final class WrapperType[F[+_], C <: TransformerCfg] extends TransformerCfg
-  final class FieldConstF[Name <: String, C <: TransformerCfg] extends TransformerCfg
-  final class FieldComputedF[Name <: String, C <: TransformerCfg] extends TransformerCfg
   final class CoproductInstanceF[InstType, TargetType, C <: TransformerCfg] extends TransformerCfg
+  final class WrapperType[F[+_], C <: TransformerCfg] extends TransformerCfg
 }
 
 trait TransformerConfiguration extends MacroUtils {
@@ -32,6 +32,7 @@ trait TransformerConfiguration extends MacroUtils {
   import c.universe._
 
   sealed abstract class FieldOverride(val needValueLevelAccess: Boolean)
+
   object FieldOverride {
     case object Const extends FieldOverride(true)
     case object ConstF extends FieldOverride(true)
@@ -92,13 +93,13 @@ trait TransformerConfiguration extends MacroUtils {
     val enableUnsafeOption = typeOf[EnableUnsafeOption[_]].typeConstructor
     val enableMethodAccessors = typeOf[EnableMethodAccessors[_]].typeConstructor
     val fieldConstT = typeOf[FieldConst[_, _]].typeConstructor
+    val fieldConstFT = typeOf[FieldConstF[_, _]].typeConstructor
     val fieldComputedT = typeOf[FieldComputed[_, _]].typeConstructor
+    val fieldComputedFT = typeOf[FieldComputedF[_, _]].typeConstructor
     val fieldRelabelledT = typeOf[FieldRelabelled[_, _, _]].typeConstructor
     val coproductInstanceT = typeOf[CoproductInstance[_, _, _]].typeConstructor
-    val wrapperTypeT = typeOf[WrapperType[F, _] forSome { type F[+_] }].typeConstructor
-    val fieldConstFT = typeOf[FieldConstF[_, _]].typeConstructor
-    val fieldComputedFT = typeOf[FieldComputedF[_, _]].typeConstructor
     val coproductInstanceFT = typeOf[CoproductInstanceF[_, _, _]].typeConstructor
+    val wrapperTypeT = typeOf[WrapperType[F, _] forSome { type F[+_] }].typeConstructor
   }
 
   def captureTransformerConfig(cfgTpe: Type): TransformerConfig = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
@@ -259,6 +259,23 @@ trait MacroUtils extends CompanionUtils {
 
   implicit class TransformerDefinitionTreeOps(td: Tree) {
 
+    def accessConst(name: String, targetTpe: Type): Tree = {
+      q"""
+        $td
+          .overrides($name)
+          .asInstanceOf[$targetTpe]
+      """
+    }
+
+    def accessComputed(name: String, srcPrefixTree: Tree, fromTpe: Type, targetTpe: Type): Tree = {
+      q"""
+        $td
+          .overrides($name)
+          .asInstanceOf[$fromTpe => $targetTpe]
+          .apply($srcPrefixTree)
+      """
+    }
+
     def addOverride(fieldName: Name, value: Tree): Tree = {
       q"$td.__addOverride(${fieldName.toNameLiteral}, $value)"
     }


### PR DESCRIPTION
This PR brings a refactor in internal transformer config used during macro expansion.

It also eliminates one `.asInstanceOf` from generated code.
