### PR TITLE
Safe option unwrapping support

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/TransformationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/TransformationError.scala
@@ -1,0 +1,9 @@
+package io.scalaland.chimney
+
+sealed trait TransformationError[+M]
+
+object TransformationError {
+  case object OptionUnwrappingError extends TransformationError[Nothing]
+
+  case class WithMessage[+M](message: M) extends TransformationError[M]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/TransformerFFromOptionSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/TransformerFFromOptionSupport.scala
@@ -1,0 +1,35 @@
+package io.scalaland.chimney
+
+import scala.collection.compat._
+
+trait TransformerFFromOptionSupport[F[+_]] {
+
+  /** Create F[B] from Option[A]
+    *
+    * @tparam A type of wrapped value
+    * @param opt wrapped in option value
+    * @param trans wrapped transformation function from A to B in F
+    * @return wrapped in F result of transformation option unwrapping
+    */
+  def fromOption[A, B](opt: Option[A], trans: A => F[B]): F[B]
+}
+
+object TransformerFFromOptionSupport {
+  implicit val OptionInstance: TransformerFFromOptionSupport[Option] = new TransformerFFromOptionSupport[Option] {
+    override def fromOption[A, B](opt: Option[A], trans: A => Option[B]): Option[B] =
+      opt.flatMap(trans)
+  }
+
+  implicit def EitherStringInstance[C[X] <: IterableOnce[X], M](
+      implicit ef: Factory[TransformationError[M], C[TransformationError[M]]]
+  ): TransformerFFromOptionSupport[Either[C[TransformationError[M]], +*]] =
+    new TransformerFFromOptionSupport[Either[C[TransformationError[M]], +*]] {
+      override def fromOption[A, B](
+          opt: Option[A],
+          trans: A => Either[C[TransformationError[M]], B]
+      ): Either[C[TransformationError[M]], B] =
+        opt.fold[Either[C[TransformationError[M]], B]](
+          Left(ef.fromSpecific(List(TransformationError.OptionUnwrappingError)))
+        )(trans)
+    }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerCfg.scala
@@ -54,6 +54,7 @@ trait TransformerConfiguration extends MacroUtils {
       definitionScope: Option[(Type, Type)] = None,
       wrapperType: Option[Type] = None,
       wrapperSupportInstance: Tree = EmptyTree,
+      wrapperFromOptionInstance: Option[Tree] = None,
       coproductInstancesF: Set[(Symbol, Type)] = Set.empty // pair: inst type, target type
   ) {
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/ChimneyBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/ChimneyBlackboxMacros.scala
@@ -56,7 +56,8 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
         TransformerConfig(
           definitionScope = Some((weakTypeOf[From], weakTypeOf[To])),
           wrapperType = Some(F.tpe),
-          wrapperSupportInstance = tfs.tree
+          wrapperSupportInstance = tfs.tree,
+          wrapperFromOptionInstance = findFromOptionSupport(Some(F.tpe))
         )
       )
     )


### PR DESCRIPTION
While writing docs for #154, I discovered that one of the main case for error path - option unwrapping doesn't work. And I can't define something like this
```
implicit def optUnwrap[A, B](implicit underlying: Transforner[A, B]): TransformerF[V, A, B] = ???
```
Only if explicitly define it for each pairs of types.

I think we should add type class provides auto safe option unwrapping.
Maybe union it with error path support type class and think about name, something like `TransformerFErrorSupport`

TransformationError in this PR can merge TransformationError in #154 and obtain path.

 WDYT, @krzemin?