### PR TITLE
Simple first implementation for issue #89 to support case conversions

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/ConfigDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/ConfigDsl.scala
@@ -62,4 +62,8 @@ trait ConfigDsl[CC[_ <: TransformerCfg], C <: TransformerCfg] {
   def enableUnsafeOption: CC[EnableUnsafeOption[C]] =
     this.asInstanceOf[CC[EnableUnsafeOption[C]]]
 
+  def enableSnakeToCamel: CC[EnableSnakeToCamel[C]] = this.asInstanceOf[CC[EnableSnakeToCamel[C]]]
+
+  def enableCamelToSnake: CC[EnableCamelToSnake[C]] = this.asInstanceOf[CC[EnableCamelToSnake[C]]]
+
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
@@ -146,7 +146,8 @@ trait MappingMacros extends Model with TransformerConfiguration {
       wasRenamed: Boolean,
       From: Type
   )(ms: MethodSymbol): Boolean = {
-    val sourceName = ms.name.decodedName.toString
+    
+    val sourceName = config.namingConventions._1(ms.name.decodedName.toString)
     if (config.enableBeanGetters) {
       val lookupNameCapitalized = lookupName.capitalize
       sourceName == lookupName ||
@@ -154,7 +155,7 @@ trait MappingMacros extends Model with TransformerConfiguration {
       (sourceName == s"is$lookupNameCapitalized" && ms.resultTypeIn(From) == typeOf[Boolean])
     } else {
       (ms.isStable || wasRenamed || config.enableMethodAccessors) && // isStable means or val/lazy val
-      sourceName == lookupName
+      sourceName == config.namingConventions._2(lookupName)
     }
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/NamingConventionsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/NamingConventionsSpec.scala
@@ -1,0 +1,34 @@
+package io.scalaland.chimney
+
+import utest._
+import io.scalaland.chimney.dsl._
+
+object NamingConventionsSpec extends TestSuite {
+    
+    val tests = Tests {
+        "reading snake case objects" - {
+            "should remap fields in snake case to camel case equivalent" - {
+                val source = SnakeItem("test", 42)
+                
+                val target = source.into[CamelItem].enableSnakeToCamel.transform
+
+                target.simpleField ==> source.simple_field
+                target.other ==> source.other
+            }
+        }
+
+        "reading camel case objects" - {
+            "should remap fields in camel case to snake case equivalent" - {
+                val source = CamelItem("test", 42)
+                val target = source.into[SnakeItem].enableCamelToSnake.transform
+                
+                target.simple_field ==> source.simpleField
+                target.other ==> source.other
+
+            }
+        }
+    }
+}
+
+case class SnakeItem(simple_field: String, other: Int)
+case class CamelItem(simpleField: String, other: Int)


### PR DESCRIPTION
I started to implement a solution for this. I think it could be better, using the `.withNamingConvention(s, t)` as mentioned in the issue, but I have no idea how to forward the Naming object to the configuration. 