### PR TITLE
Add support for Scala.js 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
         jvm:
           - openjdk@8
           - openjdk@1.11
+        scalajs:
+          - 0.6.32
+          - 1.0.1
+        exclude:
+          - scala: 2.11.12
+          - scalajs: 1.0.1
       fail-fast: false
 
     steps:
@@ -41,6 +47,8 @@ jobs:
         run: sudo apt-get install -y clang libgc-dev libunwind8-dev libre2-dev
       - name: Clean, Check code formatting, compile, test, generate coverage report
         run: sbt ++${{ matrix.scala }} clean scalafmtCheck test:scalafmtCheck compile chimneyJS/test coverage chimneyJVM/test coverageReport
+        env:
+          SCALAJS_VERSION: ${{ matrix.scalajs }}
       - name: Run Scala Native tests (2.11 builds only)
         if: startsWith(matrix.scala, '2.11' )
         run: sbt ++${{ matrix.scala }} chimneyNative/test

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,11 @@ val versions = new {
 val settings = Seq(
   version := "0.5.1",
   scalaVersion := versions.scalaVersion,
-  crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.1"),
+  crossScalaVersions :=
+    (if (scalaJSVersion.startsWith("1."))
+      Seq("2.12.11", "2.13.1")
+     else
+       Seq("2.11.12", "2.12.11", "2.13.1")),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
     "-encoding", "UTF-8",
@@ -116,7 +120,7 @@ lazy val chimneyCats = crossProject(JSPlatform, JVMPlatform)
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(dependencies: _*)
-  .settings(libraryDependencies += "org.typelevel" %%% "cats-core" % "2.0.0" % "provided")
+  .settings(libraryDependencies += "org.typelevel" %%% "cats-core" % (if (scalaBinaryVersion.value == "2.11") "2.0.0" else "2.1.1") % "provided")
 
 lazy val chimneyCatsJVM = chimneyCats.jvm
 lazy val chimneyCatsJS = chimneyCats.js

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,12 @@
+import scala.util.Properties._
+
+val scalaJSVersion = envOrElse("SCALAJS_VERSION", "1.0.1")
+
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.2")
 


### PR DESCRIPTION
Scala 2.11 with .js 1.0 is excluded because cats and utest are not available for that combination.