### PR TITLE
Enable library to work seamlessly with "-Wunused:patvars" flag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ val settings = Seq(
   ),
   scalacOptions ++= (
     if (scalaVersion.value >= "2.13")
-      Nil
+      Seq("-Wunused:patvars")
     else
       Seq(
         "-Xfuture",

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -397,8 +397,7 @@ trait TransformerMacros extends TransformerConfiguration with MappingMacros with
 
           resolveCoproductInstance(srcPrefixTree, instTpe, To, config)
             .map { instanceTree =>
-              val fn = freshTermName(instName)
-              Right(cq"$fn: $instTpe => $instanceTree")
+              Right(cq"_: $instTpe => $instanceTree")
             }
             .getOrElse {
               val instSymbol = instTpe.typeSymbol
@@ -420,8 +419,8 @@ trait TransformerMacros extends TransformerConfiguration with MappingMacros with
                     Seq(
                       CantFindCoproductInstanceTransformer(
                         instSymbol.fullName,
-                        From.typeSymbol.fullName.toString,
-                        To.typeSymbol.fullName.toString
+                        From.typeSymbol.fullName,
+                        To.typeSymbol.fullName
                       )
                     )
                   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -584,7 +584,7 @@ trait TransformerMacros extends TransformerConfiguration with MappingMacros with
       } else {
         val errors = unresolvedTargets.flatMap { target =>
           accessorsMapping(target) match {
-            case AccessorResolution.Resolved(symbol: MethodSymbol, wasRenamed: Boolean) =>
+            case AccessorResolution.Resolved(symbol: MethodSymbol, _) =>
               erroredTargets(target) :+ MissingTransformer(
                 fieldName = target.name,
                 sourceFieldTypeName = symbol.resultTypeIn(From).typeSymbol.fullName,

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -324,6 +324,43 @@ object IssuesSpec extends TestSuite {
       event.venue.into[dto.Venue].enableMethodAccessors.transform ==> dto.Venue("Venue Name")
       (venue: internal.Venue).into[dto.Venue].enableMethodAccessors.transform ==> dto.Venue("Venue Name")
     }
+
+    "fix issue #168" - {
+
+      "objects case" - {
+        sealed trait Version1
+        final case object Instance1 extends Version1
+        sealed trait Version2
+        final case object Instance2 extends Version2
+
+        val v1: Version1 = Instance1
+        val v2: Version2 = v1
+          .into[Version2]
+          .withCoproductInstance { (_: Instance1.type) =>
+            Instance2
+          }
+          .transform
+
+        v2 ==> Instance2
+      }
+
+      "classes case" - {
+        sealed trait Version1
+        final case class Instance1(p: Int) extends Version1
+        sealed trait Version2
+        final case class Instance2(p1: Int, p2: Int) extends Version2
+
+        val v1: Version1 = Instance1(10)
+        val v2: Version2 = v1
+          .into[Version2]
+          .withCoproductInstance { (i: Instance1) =>
+            Instance2(i.p / 2, i.p / 2)
+          }
+          .transform
+
+        v2 ==> Instance2(5, 5)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #168 by avoiding introducing fresh term name for pattern generated for `withCoproductInstance` usage.