### PR TITLE
fix issue #173

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -466,7 +466,7 @@ trait TransformerMacros extends TransformerConfiguration with MappingMacros with
             srcPrefixTree,
             From.typeSymbol,
             To,
-            config.wrapperType
+            None
           )
         }
       )

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -394,6 +394,18 @@ object IssuesSpec extends TestSuite {
         (Bar: Foo).transformIntoF[Option, Foo2] ==> Some(Bar2)
         (Baz: Foo).transformIntoF[Option, Foo2] ==> Some(Baz2)
       }
+
+      "withCoproductInstanceF followed by withCoproductInstance" - {
+        implicit val fooFoo2TransformerF: TransformerF[Option, Foo, Foo2] =
+          TransformerF
+            .define[Option, Foo, Foo2]
+            .withCoproductInstanceF((_: Bar.type) => Some(Bar2))
+            .withCoproductInstance((_: Baz.type) => Baz2)
+            .buildTransformer
+
+        (Bar: Foo).transformIntoF[Option, Foo2] ==> Some(Bar2)
+        (Baz: Foo).transformIntoF[Option, Foo2] ==> Some(Baz2)
+      }
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -361,6 +361,40 @@ object IssuesSpec extends TestSuite {
         v2 ==> Instance2(5, 5)
       }
     }
+
+    "fix issue #173" - {
+      sealed trait Foo
+      case object Bar extends Foo
+      case object Baz extends Foo
+
+      sealed trait Foo2
+      case object Bar2 extends Foo2
+      case object Baz2 extends Foo2
+
+      "withCoproductInstanceF twice" - {
+        implicit val fooFoo2TransformerF: TransformerF[Option, Foo, Foo2] =
+          TransformerF
+            .define[Option, Foo, Foo2]
+            .withCoproductInstanceF((_: Bar.type) => Some(Bar2))
+            .withCoproductInstanceF((_: Baz.type) => Some(Baz2))
+            .buildTransformer
+
+        (Bar: Foo).transformIntoF[Option, Foo2] ==> Some(Bar2)
+        (Baz: Foo).transformIntoF[Option, Foo2] ==> Some(Baz2)
+      }
+
+      "withCoproductInstance followed by withCoproductInstanceF" - {
+        implicit val fooFoo2TransformerF: TransformerF[Option, Foo, Foo2] =
+          TransformerF
+            .define[Option, Foo, Foo2]
+            .withCoproductInstance((_: Bar.type) => Bar2)
+            .withCoproductInstanceF((_: Baz.type) => Some(Baz2))
+            .buildTransformer
+
+        (Bar: Foo).transformIntoF[Option, Foo2] ==> Some(Bar2)
+        (Baz: Foo).transformIntoF[Option, Foo2] ==> Some(Baz2)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
As reported in #173, library generated incorrect code when transforming coproducts (`withCoproductInstance`) mixed with wrapped transformers. The fix was to omit explicit cast when accessing non-wrapped function provided by the user. Original example from #173 is included as a new test.