### PR TITLE
Prefer TransformerF derivation in lifted transformations

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -644,15 +644,8 @@ trait TransformerMacros extends TransformerConfiguration with MappingMacros with
         case (None, Some(localImplicitTree)) =>
           Right(TransformerBodyTree(localImplicitTree.callTransform(srcPrefixTree), isWrapped = false))
         case (None, None) =>
-          def deriveTransformer =
-            deriveTransformerTree(srcPrefixTree, recConfigNoWrapper)(From, To)
-              .mapRight(tree => TransformerBodyTree(tree, isWrapped = false))
-
-          def deriveTransformerF =
-            deriveTransformerTree(srcPrefixTree, recConfig)(From, To)
-              .mapRight(tree => TransformerBodyTree(tree, isWrapped = true))
-
-          deriveTransformer rightOrElse deriveTransformerF
+          deriveTransformerTree(srcPrefixTree, recConfig)(From, To)
+            .mapRight(tree => TransformerBodyTree(tree, isWrapped = true))
       }
     } else {
       expandTransformerTree(srcPrefixTree, recConfig)(From, To)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/EitherUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/EitherUtils.scala
@@ -47,13 +47,6 @@ trait EitherUtils {
       }
     }
 
-    def rightOrElse[A1 >: A, B1 >: B](or: => Either[A1, B1]): Either[A1, B1] = {
-      either match {
-        case Right(_) => either
-        case _        => or
-      }
-    }
-
   }
 
   implicit class MapOps[K, E, V](map: Map[K, Either[E, V]]) {

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -407,6 +407,19 @@ object IssuesSpec extends TestSuite {
         (Baz: Foo).transformIntoF[Option, Foo2] ==> Some(Baz2)
       }
     }
+
+    "fix issue #177" - {
+      case class Foo(x: Int)
+      case class Bar(x: Int)
+      case class FooW(a: Option[Foo])
+      case class BarW(a: Option[Bar])
+
+      // this should be used and shouldn't trip the unused warning
+      implicit val fooToBarTransformerF: TransformerF[Option, Foo, Bar] =
+        f => Some(Bar(f.x + 10))
+
+      FooW(Some(Foo(1))).transformIntoF[Option, BarW] ==> Some(BarW(Some(Bar(11))))
+    }
   }
 }
 


### PR DESCRIPTION
Resolves #177 

Changes lifted transformation to recursively derive a `TransformerF` instances.

This fixes the case where a type that can be derived as a `Transformer` has a member which is also derivable as a `Transformer`, but has an implicit `TransformerF` instance available. In such a case the containing type will short circuit to the non-lifted variant and prevent that sub-tree from using its implicit lifted instance since derivation will no longer use the wrapper type.