### PR TITLE
WIP Add support of injection custom derivation rules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,8 +75,8 @@ lazy val root = project
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(noPublishSettings: _*)
-  .aggregate(chimneyJVM, chimneyJS, chimneyCatsJVM, chimneyCatsJS)
-  .dependsOn(chimneyJVM, chimneyJS, chimneyCatsJVM, chimneyCatsJS)
+  .aggregate(chimneyJVM, chimneyJS, chimneyCatsJVM, chimneyCatsJS, customRulesJVM, customRulesJS)
+  .dependsOn(chimneyJVM, chimneyJS, chimneyCatsJVM, chimneyCatsJS, customRulesJVM, customRulesJS)
   .enablePlugins(SphinxPlugin, GhpagesPlugin)
   .settings(
     Sphinx / version := version.value,
@@ -133,6 +133,22 @@ lazy val protos = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 lazy val protosJVM = protos.jvm
 lazy val protosJS = protos.js
 lazy val protosNative = protos.native
+
+lazy val customRules = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .dependsOn(chimney % "test->test;compile->compile")
+  .settings(
+    moduleName := "chimney-custom-rules",
+    name := "chimney-custom-rules",
+    testFrameworks += new TestFramework("utest.runner.Framework")
+  )
+  .settings(settings: _*)
+  .settings(dependencies: _*)
+  .settings(noPublishSettings: _*)
+
+lazy val customRulesJVM = customRules.jvm
+lazy val customRulesJS = customRules.js
+lazy val customRulesNative = customRules.native
 
 
 lazy val publishSettings = Seq(

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -13,7 +13,7 @@ import scala.language.experimental.macros
   * @tparam To   type of output value
   * @tparam C    type-level encoded config
   */
-final class TransformerDefinition[From, To, C <: TransformerCfg](
+class TransformerDefinition[From, To, C <: TransformerCfg](
     val overrides: Map[String, Any],
     val instances: Map[(String, String), Any]
 ) extends ConfigDsl[Lambda[`C1 <: TransformerCfg` => TransformerDefinition[From, To, C1]], C] {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/ChimneyBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/ChimneyBlackboxMacros.scala
@@ -39,7 +39,7 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
   def deriveTransformerImpl[From: WeakTypeTag, To: WeakTypeTag]: c.Expr[chimney.Transformer[From, To]] = {
     c.Expr[chimney.Transformer[From, To]](
       genTransformer[From, To](
-        TransformerConfig(
+        defaultConfig.copy(
           definitionScope = Some((weakTypeOf[From], weakTypeOf[To]))
         )
       )
@@ -53,7 +53,7 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
   ): c.Expr[TransformerF[F, From, To]] = {
     c.Expr[TransformerF[F, From, To]](
       genTransformer[From, To](
-        TransformerConfig(
+        defaultConfig.copy(
           definitionScope = Some((weakTypeOf[From], weakTypeOf[To])),
           wrapperType = Some(F.tpe),
           wrapperSupportInstance = tfs.tree

--- a/customRules/src/main/scala/io/scalaland/chimney/custom/OptFlatteningChimneyBlackboxMacros.scala
+++ b/customRules/src/main/scala/io/scalaland/chimney/custom/OptFlatteningChimneyBlackboxMacros.scala
@@ -1,0 +1,52 @@
+package io.scalaland.chimney.custom
+
+import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
+
+import scala.reflect.macros.blackbox
+
+class OptFlatteningChimneyBlackboxMacros(override val c: blackbox.Context) extends ChimneyBlackboxMacros(c) {
+  import c.universe._
+
+  def optIterableOrArray(t: Type): Boolean = {
+    isOption(t) && (t <:< noneTpe || iterableOrArray(t.typeArgs.head))
+  }
+
+  override def defaultConfig: TransformerConfig = {
+    val optFlattening = TransformationRule(
+      fromCondition = optIterableOrArray,
+      toCondition = iterableOrArray,
+      derivation = expandOptCollectionFlattening
+    )
+
+    TransformerConfig(customRules = List(optFlattening))
+  }
+
+  def expandOptCollectionFlattening(srcPrefixTree: Tree, config: TransformerConfig)(
+      From: Type,
+      To: Type
+  ): TransformationResult = {
+    val ToInnerT = To.collectionInnerTpe
+
+    val emptyTree = mkTransformerBodyTree0(config)(
+      q"_root_.scala.collection.immutable.List.empty[$ToInnerT]".convertCollection(To, ToInnerT)
+    )
+
+    if (From <:< noneTpe) {
+      Right(emptyTree)
+    } else {
+      val FromCollectionT = From.typeArgs.head
+      val fn = Ident(freshTermName(srcPrefixTree))
+
+      resolveRecursiveTransformerBody(fn, config.rec)(FromCollectionT, To).mapRight { nonEmptyT =>
+        val nonEmptyTree =
+          if (nonEmptyT.isWrapped)
+            nonEmptyT.tree
+          else mkTransformerBodyTree0(config)(nonEmptyT.tree)
+
+        val outTpe = config.wrapperType.fold(To)(_.applyTypeArg(To))
+
+        q"$srcPrefixTree.fold[$outTpe]($emptyTree)(($fn: $FromCollectionT) => $nonEmptyTree)"
+      }
+    }
+  }
+}

--- a/customRules/src/main/scala/io/scalaland/chimney/custom/OptFlatteningTransformerDerivation.scala
+++ b/customRules/src/main/scala/io/scalaland/chimney/custom/OptFlatteningTransformerDerivation.scala
@@ -1,0 +1,10 @@
+package io.scalaland.chimney.custom
+
+import io.scalaland.chimney.Transformer
+
+import scala.language.experimental.macros
+
+object OptFlatteningTransformerDerivation {
+  implicit def derive[From, To]: Transformer[From, To] =
+    macro OptFlatteningChimneyBlackboxMacros.deriveTransformerImpl[From, To]
+}

--- a/customRules/src/test/scala/io/scalaland/chimney/custom/OptFlatteningTransformerTest.scala
+++ b/customRules/src/test/scala/io/scalaland/chimney/custom/OptFlatteningTransformerTest.scala
@@ -1,0 +1,21 @@
+package io.scalaland.chimney.custom
+
+import utest._
+import OptFlatteningTransformerDerivation._
+import io.scalaland.chimney.Transformer
+import io.scalaland.chimney.dsl._
+
+object OptFlatteningTransformerTest extends TestSuite {
+  val tests = Tests {
+    "support of opt rule" - {
+      case class ClassA(a: Option[Seq[Int]])
+      case class ClassB(a: Seq[String])
+
+      implicit val intToString: Transformer[Int, String] = _.toString
+
+      ClassA(Some(Seq.empty)).transformInto[ClassB] ==> ClassB(Seq.empty)
+
+      ClassA(Some(Seq(1))).transformInto[ClassB] ==> ClassB(Seq("1"))
+    }
+  }
+}


### PR DESCRIPTION
Sometimes user needs to add custom transformer rules, which cannot be defined by implicit level. For example, Option[List[A]] -> List[B], or customize library order of transformation rules. This solution will allow users to customize it by adding their own rules. Users, who use their own forks with changed rules, will be able migrate to upstream and add their own rules into their projects. 

WDYT, @krzemin?