### PR TITLE
Make Transformer auto-derivation pluggable via import

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ rules and transform your objects with as little boilerplate as possible.
 
 ```scala
 import io.scalaland.chimney.dsl._
+import io.scalaland.chimney.derivation.auto._
 
 val event = command.into[CoffeeMade]
   .withFieldComputed(_.at, _ => ZonedDateTime.now)

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -18,17 +18,6 @@ trait Transformer[From, To] {
 
 object Transformer {
 
-  /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
-    *
-    * When transformation can't be derived, it results with compilation error.
-    *
-    * @tparam From type of input value
-    * @tparam To type of output value
-    * @return [[io.scalaland.chimney.Transformer]] type class definition
-    */
-  implicit def derive[From, To]: Transformer[From, To] =
-    macro ChimneyBlackboxMacros.deriveTransformerImpl[From, To]
-
   /** Creates an empty [[io.scalaland.chimney.dsl.TransformerDefinition]] that
     * you can customize to derive [[io.scalaland.chimney.Transformer]].
     *
@@ -54,4 +43,22 @@ object Transformer {
   def defineF[F[+_], From, To]
       : TransformerFDefinition[F, From, To, TransformerCfg.WrapperType[F, TransformerCfg.Empty]] =
     TransformerF.define[F, From, To]
+}
+
+trait TransformerDerivation {
+  /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
+   *
+   * When transformation can't be derived, it results with compilation error.
+   *
+   * @tparam From type of input value
+   * @tparam To type of output value
+   * @return [[io.scalaland.chimney.Transformer]] type class definition
+   */
+  final def derive[From, To]: Transformer[From, To] =
+  macro ChimneyBlackboxMacros.deriveTransformerImpl[From, To]
+}
+
+trait TransformerAutoDerivation extends TransformerDerivation {
+  implicit def autoderive[From, To]: Transformer[From, To] =
+  macro ChimneyBlackboxMacros.deriveTransformerImpl[From, To]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/derivation/auto/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/derivation/auto/package.scala
@@ -1,0 +1,5 @@
+package io.scalaland.chimney.derivation
+
+import io.scalaland.chimney.TransformerAutoDerivation
+
+package object auto extends TransformerAutoDerivation

--- a/chimney/src/main/scala/io/scalaland/chimney/derivation/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/derivation/package.scala
@@ -1,0 +1,5 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.TransformerDerivation
+
+package object derivation extends TransformerDerivation

--- a/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney
 
 import io.scalaland.chimney.dsl._
+import io.scalaland.chimney.derivation.auto._
 import io.scalaland.chimney.examples._
 import io.scalaland.chimney.examples.trip._
 import io.scalaland.chimney.internal.utils.EitherUtils._

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney
 
 import io.scalaland.chimney.dsl._
+import io.scalaland.chimney.derivation.auto._
 import io.scalaland.chimney.examples._
 import utest._
 
@@ -915,7 +916,7 @@ object DslSpec extends TestSuite {
       }
 
       "generated automatically" - {
-        implicit def fooToBarTransformer: Transformer[Foo, Bar] = Transformer.derive[Foo, Bar]
+        implicit def fooToBarTransformer: Transformer[Foo, Bar] = derive[Foo, Bar]
 
         Foo(Some(Foo(None))).transformInto[Bar] ==> Bar(Some(Bar(None)))
       }
@@ -926,7 +927,7 @@ object DslSpec extends TestSuite {
         case class Bar1(x: Int, foo: Baz[Bar1])
         case class Bar2(foo: Baz[Bar2])
 
-        implicit def bar1ToBar2Transformer: Transformer[Bar1, Bar2] = Transformer.derive[Bar1, Bar2]
+        implicit def bar1ToBar2Transformer: Transformer[Bar1, Bar2] = derive[Bar1, Bar2]
 
         Bar1(1, Baz(Some(Bar1(2, Baz(None))))).transformInto[Bar2] ==> Bar2(Baz(Some(Bar2(Baz(None)))))
       }

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -5,6 +5,7 @@ import utest._
 object IssuesSpec extends TestSuite {
 
   import dsl._
+  import derivation.auto._
 
   // Compilation fails when moved inside the Tests block
   object Issue108 {
@@ -179,7 +180,7 @@ object IssuesSpec extends TestSuite {
       "fix 'wrong forward reference' when assigning .derive to local transformer instance" - {
         case class Bar(a: String, b: Int)
 
-        implicit val fooBarTransformer: Transformer[Foo, Bar] = Transformer.derive[Foo, Bar]
+        implicit val fooBarTransformer: Transformer[Foo, Bar] = derive[Foo, Bar]
 
         Foo("a", 1, 3).transformInto[Bar] ==> Bar("a", 1)
       }
@@ -189,7 +190,7 @@ object IssuesSpec extends TestSuite {
 
         object TransformerInstances {
           implicit val fooBarTransformer: Transformer[Foo, Bar] =
-            Transformer.derive[Foo, Bar]
+            derive[Foo, Bar]
         }
 
         import TransformerInstances._

--- a/chimney/src/test/scala/io/scalaland/chimney/JavaBeansSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/JavaBeansSpec.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney
 
 import utest._
 import io.scalaland.chimney.dsl._
+import io.scalaland.chimney.derivation.auto._
 
 object JavaBeansSpec extends TestSuite {
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -8,6 +8,7 @@ import io.scalaland.chimney.examples.pb
 object PBTransformationSpec extends TestSuite {
 
   import dsl._
+  import derivation.auto._
 
   val tests = Tests {
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney
 
 import io.scalaland.chimney.dsl._
+import io.scalaland.chimney.derivation.auto._
 import utest._
 
 object PatcherSpec extends TestSuite {

--- a/try-chimney.sh
+++ b/try-chimney.sh
@@ -7,4 +7,4 @@ test -e ~/.coursier/coursier || \
   org.typelevel:cats-core_2.13:2.1.1 \
   io.scalaland:chimney_2.13:0.5.3 \
   io.scalaland:chimney-cats_2.13:0.5.3 \
-  -- --predef-code 'import $plugin.$ivy.`org.typelevel:kind-projector_2.13.1:0.11.0`;import io.scalaland.chimney.dsl._;import io.scalaland.chimney.cats._' < /dev/tty
+  -- --predef-code 'import $plugin.$ivy.`org.typelevel:kind-projector_2.13.1:0.11.0`;import io.scalaland.chimney.dsl._;import io.scalaland.chimney.cats._;import io.scalaland.chimney.derivation.auto._' < /dev/tty


### PR DESCRIPTION
This is breaking, but IMO required, change providing fine-grained control over `Transformer` derivation.
The problem stated in the issue https://github.com/scalalandio/chimney/issues/166

What do you think of it? Should I make a separate section in the docs if it's applicable?  