### PR TITLE
Enable support of macro-dependent implicit transformers

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -687,13 +687,26 @@ trait TransformerMacros extends TransformerConfiguration with MappingMacros with
       silent = true,
       mode = c.TYPEmode,
       withImplicitViewsDisabled = true,
-      withMacrosDisabled = true
+      withMacrosDisabled = false
     )
 
     scala.util
-      .Try(c.inferImplicitValue(tpeTree.tpe, silent = true, withMacrosDisabled = true))
+      .Try(c.inferImplicitValue(tpeTree.tpe, silent = true, withMacrosDisabled = false))
       .toOption
-      .filterNot(_ == EmptyTree)
+      .filterNot { tree =>
+        tree == EmptyTree ||
+        isDeriving(tree)
+      }
+  }
+
+  private def isDeriving(tree: Tree): Boolean = {
+    tree match {
+      case TypeApply(Select(qualifier, name), _) =>
+        qualifier.tpe =:= weakTypeOf[io.scalaland.chimney.Transformer.type] && name.toString == "derive"
+      case Apply(TypeApply(Select(qualifier, name), _), _) =>
+        qualifier.tpe =:= weakTypeOf[io.scalaland.chimney.TransformerF.type] && name.toString == "derive"
+      case _ => false
+    }
   }
 
   private def notSupportedDerivation(

--- a/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
@@ -786,5 +786,35 @@ object DslFSpec extends TestSuite {
           .transform ==> Right(OuterOut(InnerOut("pure: test")))
       }
     }
+
+    "safe option unwrapping" - {
+      type F[+A] = Either[List[String], A]
+
+      implicit val intParserEither: TransformerF[F, String, Int] =
+        _.parseInt.toEither("bad int")
+
+      implicit def optionUnwrapping[A, B](implicit underlying: TransformerF[F, A, B]): TransformerF[F, Option[A], B] = {
+        case Some(value) => underlying.transform(value)
+        case None        => Left(List("Expected value, got none"))
+      }
+
+      // Raw domain
+      case class RawData(id: Option[String], inner: Option[RawInner])
+
+      case class RawInner(id: Option[Int], str: Option[String])
+
+      // Domain
+      case class Data(id: Int, inner: Inner)
+
+      case class Inner(id: Int, str: String)
+
+      RawData(Some("1"), Some(RawInner(Some(2), Some("str")))).transformIntoF[F, Data] ==> Right(
+        Data(1, Inner(2, "str"))
+      )
+
+      RawData(Some("a"), Some(RawInner(None, None))).transformIntoF[F, Data] ==> Left(
+        List("bad int", "Expected value, got none", "Expected value, got none")
+      )
+    }
   }
 }


### PR DESCRIPTION
Use inferImplicitValue with option withMacrosDisabled = false. To avoid recursive deriving it's check that strings "Transformer.derive" and "TransformerF.derive" is not in found tree. Maybe there is more elegant way to check usage of this methods, but it works too.

It will resolve #158 and similar issues, when we try to use implicit transformer dependent of other, witch should be derived by macro.