### PR TITLE
Drop support for Scala 2.11 and ScalaJS 0.6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        scala: [2.11.12, 2.12.12, 2.13.3]
+        scala: [2.12.12, 2.13.3]
         jvm: [openjdk@8, openjdk@1.11]
-        scalajs: [0.6.33, 1.2.0]
-        exclude:
-          - scala: 2.11.12
-            scalajs: 1.1.1
-          - scala: 2.13.3
-            scalajs: 0.6.33
       fail-fast: false
 
     steps:
@@ -41,18 +35,8 @@ jobs:
         uses: olafurpg/setup-scala@v5
         with:
           java-version: ${{ matrix.jvm }}
-      - name: Install Scala Native deps (2.11 builds only)
-        if: startsWith(matrix.scala, '2.11' )
-        run: sudo apt-get install -y clang libgc-dev libunwind8-dev libre2-dev
       - name: Clean, Check code formatting, compile, test, generate coverage report
         run: sbt ++${{ matrix.scala }} clean scalafmtCheck test:scalafmtCheck compile chimneyJS/test coverage chimneyJVM/test chimneyJVM/coverageReport
-        env:
-          SCALAJS_VERSION: ${{ matrix.scalajs }}
-      - name: Run Scala Native tests (2.11 builds only)
-        if: startsWith(matrix.scala, '2.11' )
-        run: sbt ++${{ matrix.scala }} chimneyNative/test
-        env:
-          SCALAJS_VERSION: ${{ matrix.scalajs }}
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI build](https://github.com/scalalandio/chimney/workflows/CI%20build/badge.svg)
 [![Maven Central](https://img.shields.io/maven-central/v/io.scalaland/chimney_2.12.svg)](http://search.maven.org/#search%7Cga%7C1%7Cchimney)
-[![Javadocs](https://www.javadoc.io/badge/io.scalaland/chimney_2.11.svg?color=red&label=scaladoc)](https://www.javadoc.io/doc/io.scalaland/chimney_2.11)
+[![Javadocs](https://www.javadoc.io/badge/io.scalaland/chimney_2.13.svg?color=red&label=scaladoc)](https://www.javadoc.io/doc/io.scalaland/chimney_2.13/latest/io/scalaland/chimney/index.html)
 [![codecov.io](http://codecov.io/github/scalalandio/chimney/coverage.svg?branch=master)](http://codecov.io/github/scalalandio/chimney?branch=master)
 [![License](http://img.shields.io/:license-Apache%202-green.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt) [![Join the chat at https://gitter.im/scalalandio/chimney](https://badges.gitter.im/scalalandio/chimney.svg)](https://gitter.im/scalalandio/chimney?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.17.svg)](https://www.scala-js.org)
@@ -66,11 +66,11 @@ To include Chimney to your SBT project, add the following line to your `build.sb
 libraryDependencies += "io.scalaland" %% "chimney" % "0.5.3"
 ```
 
-Library is released for Scala 2.11.x, 2.12.x and 2.13.x.
+Library is released for Scala 2.12.x and 2.13.x.
 
 If you want to use it with Scala.js (or Scala Native), you need to replace `%%` with `%%%`.
 Due to some [compiler bugs](https://issues.scala-lang.org/browse/SI-7046),
-it's recommended to use at least Scala 2.11.9 or 2.12.1.
+it's recommended to use at least Scala 2.12.1.
 
 ### Trying with Ammonite REPL
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Javadocs](https://www.javadoc.io/badge/io.scalaland/chimney_2.13.svg?color=red&label=scaladoc)](https://www.javadoc.io/doc/io.scalaland/chimney_2.13/latest/io/scalaland/chimney/index.html)
 [![codecov.io](http://codecov.io/github/scalalandio/chimney/coverage.svg?branch=master)](http://codecov.io/github/scalalandio/chimney?branch=master)
 [![License](http://img.shields.io/:license-Apache%202-green.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt) [![Join the chat at https://gitter.im/scalalandio/chimney](https://badges.gitter.im/scalalandio/chimney.svg)](https://gitter.im/scalalandio/chimney?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.17.svg)](https://www.scala-js.org)
 [![Scala.js](https://www.scala-js.org/assets/badges/scalajs-1.0.0.svg)](https://www.scala-js.org)
 
 Scala library for boilerplate-free data transformations.
@@ -13,7 +12,7 @@ Scala library for boilerplate-free data transformations.
 In the daily life of a strongly-typed language's programmer sometimes it
 happens we need to transform an object of one type to another object which
 contains a number of the same or similar fields in their definitions.
-      
+
 ```scala
 case class MakeCoffee(id: Int, kind: String, addict: String)
 case class CoffeeMade(id: Int, kind: String, forAddict: String, at: ZonedDateTime)
@@ -68,7 +67,7 @@ libraryDependencies += "io.scalaland" %% "chimney" % "0.5.3"
 
 Library is released for Scala 2.12.x and 2.13.x.
 
-If you want to use it with Scala.js (or Scala Native), you need to replace `%%` with `%%%`.
+If you want to use it with Scala.js, you need to replace `%%` with `%%%`.
 Due to some [compiler bugs](https://issues.scala-lang.org/browse/SI-7046),
 it's recommended to use at least Scala 2.12.1.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 val versions = new {
-  val scala211 = "2.11.12"
   val scala212 = "2.12.12"
   val scala213 = "2.13.3"
 }
@@ -9,9 +8,7 @@ val versions = new {
 val settings = Seq(
   version := "0.5.3",
   scalaVersion := versions.scala213,
-  crossScalaVersions :=
-    (if (scalaJSVersion.startsWith("1.")) Nil else Seq(versions.scala211)) ++
-      Seq(versions.scala212, versions.scala213),
+  crossScalaVersions := Seq(versions.scala212, versions.scala213),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
     "-encoding", "UTF-8",
@@ -33,6 +30,9 @@ val settings = Seq(
     "-Xlint:private-shadow",
     "-Xlint:stars-align",
     "-Xlint:type-parameter-shadow",
+    "-Ywarn-unused:locals",
+    "-Ywarn-macros:after",
+    "-Xfatal-warnings",
     "-language:higherKinds"
   ),
   scalacOptions ++= (
@@ -51,16 +51,6 @@ val settings = Seq(
         "-Xlint:unsound-match",
         "-Xlint:nullary-override"
       )
-    ),
-  scalacOptions ++= (
-    if (scalaVersion.value >= "2.12")
-      Seq(
-        "-Ywarn-unused:locals",
-        "-Ywarn-macros:after",
-        "-Xfatal-warnings"
-      )
-    else
-      Nil
     ),
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
 )
@@ -88,7 +78,7 @@ lazy val root = project
     git.remoteRepo := "git@github.com:scalalandio/chimney.git"
   )
 
-lazy val chimney = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+lazy val chimney = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
   .dependsOn(protos % "test->test")
   .settings(
@@ -101,11 +91,9 @@ lazy val chimney = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(dependencies: _*)
-  .nativeSettings(nativeLinkStubs := true)
 
 lazy val chimneyJVM = chimney.jvm
 lazy val chimneyJS = chimney.js
-lazy val chimneyNative = chimney.native
 
 lazy val chimneyCats = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -120,12 +108,12 @@ lazy val chimneyCats = crossProject(JSPlatform, JVMPlatform)
   .settings(settings: _*)
   .settings(publishSettings: _*)
   .settings(dependencies: _*)
-  .settings(libraryDependencies += "org.typelevel" %%% "cats-core" % (if (scalaBinaryVersion.value == "2.11") "2.0.0" else "2.2.0") % "provided")
+  .settings(libraryDependencies += "org.typelevel" %%% "cats-core" % "2.2.0" % "provided")
 
 lazy val chimneyCatsJVM = chimneyCats.jvm
 lazy val chimneyCatsJS = chimneyCats.js
 
-lazy val protos = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+lazy val protos = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
   .settings(
     moduleName := "chimney-protos",
@@ -136,7 +124,6 @@ lazy val protos = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 
 lazy val protosJVM = protos.jvm
 lazy val protosJS = protos.js
-lazy val protosNative = protos.native
 
 
 lazy val publishSettings = Seq(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -267,14 +267,14 @@ trait TransformerMacros extends TransformerConfiguration with MappingMacros with
     val fnR = Ident(freshTermName("right"))
 
     if (From <:< leftTpe && !(To <:< rightTpe)) {
-      resolveRecursiveTransformerBody(srcPrefixTree.getLeftTree, config.rec)(fromLeftT, toLeftT)
+      resolveRecursiveTransformerBody(q"$srcPrefixTree.value", config.rec)(fromLeftT, toLeftT)
         .mapRight { tbt =>
           mkTransformerBodyTree1(To, Target(fnL.name.toString, toLeftT), tbt, config) { leftArgTree =>
             q"new _root_.scala.util.Left($leftArgTree)"
           }
         }
     } else if (From <:< rightTpe && !(To <:< leftTpe)) {
-      resolveRecursiveTransformerBody(srcPrefixTree.getRightTree, config.rec)(fromRightT, toRightT)
+      resolveRecursiveTransformerBody(q"$srcPrefixTree.value", config.rec)(fromRightT, toRightT)
         .mapRight { tbt =>
           mkTransformerBodyTree1(To, Target(fnR.name.toString, toRightT), tbt, config) { rightArgTree =>
             q"new _root_.scala.util.Right($rightArgTree)"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
@@ -235,22 +235,6 @@ trait MacroUtils extends CompanionUtils {
       }
     }
 
-    def getLeftTree: Tree = {
-      if (scala.util.Properties.versionNumberString >= "2.12") {
-        q"$t.value"
-      } else {
-        q"$t.left.get"
-      }
-    }
-
-    def getRightTree: Tree = {
-      if (scala.util.Properties.versionNumberString >= "2.12") {
-        q"$t.value"
-      } else {
-        q"$t.right.get"
-      }
-    }
-
     def callTransform(input: Tree): Tree = {
       q"$t.transform($input)"
     }

--- a/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
@@ -22,7 +22,7 @@ object DslFSpec extends TestSuite {
       }
 
       "either" - {
-        Person("John", 10, 140).intoF[Either[Vector[String], +*], User].transform ==> Right(User("John", 10, 140))
+        Person("John", 10, 140).transformIntoF[Either[Vector[String], +*], User] ==> Right(User("John", 10, 140))
       }
     }
 
@@ -205,8 +205,7 @@ object DslFSpec extends TestSuite {
       val optFoo: Option[Foo] = Bar(100).transformIntoF[Option, Foo]
       optFoo.get.x ==> 100
 
-      val eitherFoo: Either[Vector[String], Foo] =
-        Bar(200).intoF[Either[Vector[String], +*], Foo].transform
+      val eitherFoo: Either[Vector[String], Foo] = Bar(200).transformIntoF[Either[Vector[String], +*], Foo]
       eitherFoo.getRight.x ==> 200
     }
 
@@ -233,8 +232,8 @@ object DslFSpec extends TestSuite {
         }
 
         "F = Either[List[String], +*]]" - {
-          Option(123).intoF[Either[List[String], +*], Option[String]].transform ==> Right(Some("123"))
-          Option.empty[Int].intoF[Either[List[String], +*], Option[String]].transform ==> Right(None)
+          Option(123).transformIntoF[Either[List[String], +*], Option[String]] ==> Right(Some("123"))
+          Option.empty[Int].transformIntoF[Either[List[String], +*], Option[String]] ==> Right(None)
         }
       }
 
@@ -252,9 +251,9 @@ object DslFSpec extends TestSuite {
           implicit val intParserEither: TransformerF[Either[List[String], +*], String, Int] =
             _.parseInt.toEither("bad int")
 
-          Option("123").intoF[Either[List[String], +*], Option[Int]].transform ==> Right(Some(123))
-          Option("abc").intoF[Either[List[String], +*], Option[Int]].transform ==> Left(List("bad int"))
-          Option.empty[String].intoF[Either[List[String], +*], Option[Int]].transform ==> Right(None)
+          Option("123").transformIntoF[Either[List[String], +*], Option[Int]] ==> Right(Some(123))
+          Option("abc").transformIntoF[Either[List[String], +*], Option[Int]] ==> Left(List("bad int"))
+          Option.empty[String].transformIntoF[Either[List[String], +*], Option[Int]] ==> Right(None)
         }
       }
     }
@@ -271,8 +270,8 @@ object DslFSpec extends TestSuite {
         }
 
         "F = Either[List[String], +*]]" - {
-          10.intoF[Either[List[String], +*], Option[String]].transform ==> Right(Some("10"))
-          (null: String).intoF[Either[List[String], +*], Option[String]].transform ==> Right(None)
+          10.transformIntoF[Either[List[String], +*], Option[String]] ==> Right(Some("10"))
+          (null: String).transformIntoF[Either[List[String], +*], Option[String]] ==> Right(None)
         }
       }
 
@@ -290,9 +289,9 @@ object DslFSpec extends TestSuite {
           implicit val intParserEither: TransformerF[Either[List[String], +*], String, Int] =
             _.parseInt.toEither("bad int")
 
-          "10".intoF[Either[List[String], +*], Option[Int]].transform ==> Right(Some(10))
-          (null: String).intoF[Either[List[String], +*], Option[Int]].transform ==> Right(None)
-          "x".intoF[Either[List[String], +*], Option[Int]].transform ==> Left(List("bad int"))
+          "10".transformIntoF[Either[List[String], +*], Option[Int]] ==> Right(Some(10))
+          (null: String).transformIntoF[Either[List[String], +*], Option[Int]] ==> Right(None)
+          "x".transformIntoF[Either[List[String], +*], Option[Int]] ==> Left(List("bad int"))
         }
       }
     }
@@ -356,9 +355,9 @@ object DslFSpec extends TestSuite {
         }
 
         "F = Either[List[String], +*]]" - {
-          List(123, 456).intoF[Either[List[String], +*], List[String]].transform ==> Right(List("123", "456"))
-          Vector(123, 456).intoF[Either[List[String], +*], Queue[String]].transform ==> Right(Queue("123", "456"))
-          Array.empty[Int].intoF[Either[List[String], +*], Seq[String]].transform ==> Right(Seq.empty[String])
+          List(123, 456).transformIntoF[Either[List[String], +*], List[String]] ==> Right(List("123", "456"))
+          Vector(123, 456).transformIntoF[Either[List[String], +*], Queue[String]] ==> Right(Queue("123", "456"))
+          Array.empty[Int].transformIntoF[Either[List[String], +*], Seq[String]] ==> Right(Seq.empty[String])
         }
       }
 
@@ -382,15 +381,15 @@ object DslFSpec extends TestSuite {
           implicit val intParserEither: TransformerF[Either[List[String], +*], String, Int] =
             _.parseInt.toEither("bad int")
 
-          List("123", "456").intoF[Either[List[String], +*], List[Int]].transform ==> Right(List(123, 456))
-          Vector("123", "456").intoF[Either[List[String], +*], Queue[Int]].transform ==> Right(Queue(123, 456))
-          Array.empty[String].intoF[Either[List[String], +*], Seq[Int]].transform ==> Right(Seq.empty[Int])
-          Set("123", "456").intoF[Either[List[String], +*], Array[Int]].transform.getRight.sorted ==> Array(123, 456)
+          List("123", "456").transformIntoF[Either[List[String], +*], List[Int]] ==> Right(List(123, 456))
+          Vector("123", "456").transformIntoF[Either[List[String], +*], Queue[Int]] ==> Right(Queue(123, 456))
+          Array.empty[String].transformIntoF[Either[List[String], +*], Seq[Int]] ==> Right(Seq.empty[Int])
+          Set("123", "456").transformIntoF[Either[List[String], +*], Array[Int]].getRight.sorted ==> Array(123, 456)
 
-          List("abc", "456").intoF[Either[List[String], +*], List[Int]].transform ==> Left(List("bad int"))
-          Vector("123", "def").intoF[Either[List[String], +*], Queue[Int]].transform ==> Left(List("bad int"))
-          Array("abc", "def").intoF[Either[List[String], +*], Seq[Int]].transform ==> Left(List("bad int", "bad int"))
-          Set("123", "xyz").intoF[Either[List[String], +*], Array[Int]].transform ==> Left(List("bad int"))
+          List("abc", "456").transformIntoF[Either[List[String], +*], List[Int]] ==> Left(List("bad int"))
+          Vector("123", "def").transformIntoF[Either[List[String], +*], Queue[Int]] ==> Left(List("bad int"))
+          Array("abc", "def").transformIntoF[Either[List[String], +*], Seq[Int]] ==> Left(List("bad int", "bad int"))
+          Set("123", "xyz").transformIntoF[Either[List[String], +*], Array[Int]] ==> Left(List("bad int"))
         }
       }
     }
@@ -414,25 +413,25 @@ object DslFSpec extends TestSuite {
         }
 
         "F = Either[List[String], +*]]" - {
-          Map(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Map[String, String]].transform ==>
+          Map(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Map[String, String]] ==>
             Right(Map("1" -> "10", "2" -> "20"))
-          Map(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Map[String, Int]].transform ==>
+          Map(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Map[String, Int]] ==>
             Right(Map("1" -> 10, "2" -> 20))
-          Seq(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Map[String, String]].transform ==>
+          Seq(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Map[String, String]] ==>
             Right(Map("1" -> "10", "2" -> "20"))
-          ArrayBuffer(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Map[Int, String]].transform ==>
+          ArrayBuffer(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Map[Int, String]] ==>
             Right(Map(1 -> "10", 2 -> "20"))
-          Map(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], List[(String, String)]].transform ==>
+          Map(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], List[(String, String)]] ==>
             Right(List("1" -> "10", "2" -> "20"))
-          Map(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Vector[(String, Int)]].transform ==>
+          Map(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Vector[(String, Int)]] ==>
             Right(Vector("1" -> 10, "2" -> 20))
-          Array(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Map[String, String]].transform ==>
+          Array(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Map[String, String]] ==>
             Right(Map("1" -> "10", "2" -> "20"))
-          Array(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Map[Int, String]].transform ==>
+          Array(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Map[Int, String]] ==>
             Right(Map(1 -> "10", 2 -> "20"))
-          Map(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Array[(String, String)]].transform.getRight ==>
+          Map(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Array[(String, String)]].getRight ==>
             Array("1" -> "10", "2" -> "20")
-          Map(1 -> 10, 2 -> 20).intoF[Either[List[String], +*], Array[(String, Int)]].transform.getRight ==>
+          Map(1 -> 10, 2 -> 20).transformIntoF[Either[List[String], +*], Array[(String, Int)]].getRight ==>
             Array("1" -> 10, "2" -> 20)
         }
       }
@@ -471,46 +470,46 @@ object DslFSpec extends TestSuite {
           implicit val intParserEither: TransformerF[Either[List[String], +*], String, Int] =
             _.parseInt.toEither("bad int")
 
-          Map("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Map[Int, Int]].transform ==>
+          Map("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Map[Int, Int]] ==>
             Right(Map(1 -> 10, 2 -> 20))
-          Map("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Map[Int, String]].transform ==>
+          Map("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Map[Int, String]] ==>
             Right(Map(1 -> "10", 2 -> "20"))
-          Seq("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Map[Int, Int]].transform ==>
+          Seq("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Map[Int, Int]] ==>
             Right(Map(1 -> 10, 2 -> 20))
-          ArrayBuffer("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Map[String, Int]].transform ==>
+          ArrayBuffer("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Map[String, Int]] ==>
             Right(Map("1" -> 10, "2" -> 20))
-          Map("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], List[(Int, Int)]].transform ==>
+          Map("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], List[(Int, Int)]] ==>
             Right(List(1 -> 10, 2 -> 20))
-          Map("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Vector[(Int, String)]].transform ==>
+          Map("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Vector[(Int, String)]] ==>
             Right(Vector(1 -> "10", 2 -> "20"))
-          Array("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Map[Int, Int]].transform ==>
+          Array("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Map[Int, Int]] ==>
             Right(Map(1 -> 10, 2 -> 20))
-          Array("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Map[String, Int]].transform ==>
+          Array("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Map[String, Int]] ==>
             Right(Map("1" -> 10, "2" -> 20))
-          Map("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Array[(Int, Int)]].transform.getRight ==>
+          Map("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Array[(Int, Int)]].getRight ==>
             Array(1 -> 10, 2 -> 20)
-          Map("1" -> "10", "2" -> "20").intoF[Either[List[String], +*], Array[(Int, String)]].transform.getRight ==>
+          Map("1" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Array[(Int, String)]].getRight ==>
             Array(1 -> "10", 2 -> "20")
 
-          Map("1" -> "x", "y" -> "20").intoF[Either[List[String], +*], Map[Int, Int]].transform ==>
+          Map("1" -> "x", "y" -> "20").transformIntoF[Either[List[String], +*], Map[Int, Int]] ==>
             Left(List("bad int", "bad int"))
-          Map("x" -> "10", "2" -> "20").intoF[Either[List[String], +*], Map[Int, String]].transform ==>
+          Map("x" -> "10", "2" -> "20").transformIntoF[Either[List[String], +*], Map[Int, String]] ==>
             Left(List("bad int"))
-          Seq("1" -> "10", "2" -> "x").intoF[Either[List[String], +*], Map[Int, Int]].transform ==>
+          Seq("1" -> "10", "2" -> "x").transformIntoF[Either[List[String], +*], Map[Int, Int]] ==>
             Left(List("bad int"))
-          ArrayBuffer("1" -> "x", "2" -> "y").intoF[Either[List[String], +*], Map[String, Int]].transform ==>
+          ArrayBuffer("1" -> "x", "2" -> "y").transformIntoF[Either[List[String], +*], Map[String, Int]] ==>
             Left(List("bad int", "bad int"))
-          Map("x" -> "10", "y" -> "z").intoF[Either[List[String], +*], ArrayBuffer[(Int, Int)]].transform ==>
+          Map("x" -> "10", "y" -> "z").transformIntoF[Either[List[String], +*], ArrayBuffer[(Int, Int)]] ==>
             Left(List("bad int", "bad int", "bad int"))
-          Map("1" -> "10", "x" -> "20").intoF[Either[List[String], +*], Vector[(Int, String)]].transform ==>
+          Map("1" -> "10", "x" -> "20").transformIntoF[Either[List[String], +*], Vector[(Int, String)]] ==>
             Left(List("bad int"))
-          Array("x" -> "y", "z" -> "v").intoF[Either[List[String], +*], Map[Int, Int]].transform ==>
+          Array("x" -> "y", "z" -> "v").transformIntoF[Either[List[String], +*], Map[Int, Int]] ==>
             Left(List("bad int", "bad int", "bad int", "bad int"))
-          Array("1" -> "x", "2" -> "y").intoF[Either[List[String], +*], Map[String, Int]].transform ==>
+          Array("1" -> "x", "2" -> "y").transformIntoF[Either[List[String], +*], Map[String, Int]] ==>
             Left(List("bad int", "bad int"))
-          Map("1" -> "10", "x" -> "20").intoF[Either[List[String], +*], Array[(Int, Int)]].transform ==>
+          Map("1" -> "10", "x" -> "20").transformIntoF[Either[List[String], +*], Array[(Int, Int)]] ==>
             Left(List("bad int"))
-          Map("x" -> "10", "y" -> "20").intoF[Either[List[String], +*], Array[(Int, String)]].transform ==>
+          Map("x" -> "10", "y" -> "20").transformIntoF[Either[List[String], +*], Array[(Int, String)]] ==>
             Left(List("bad int", "bad int"))
         }
       }
@@ -534,14 +533,14 @@ object DslFSpec extends TestSuite {
 
         "F = Either[List[String], +*]]" - {
 
-          (Left(1): Either[Int, Int]).intoF[Either[List[String], +*], Either[String, String]].transform ==>
+          (Left(1): Either[Int, Int]).transformIntoF[Either[List[String], +*], Either[String, String]] ==>
             Right(Left("1"))
-          (Right(1): Either[Int, Int]).intoF[Either[List[String], +*], Either[String, String]].transform ==>
+          (Right(1): Either[Int, Int]).transformIntoF[Either[List[String], +*], Either[String, String]] ==>
             Right(Right("1"))
-          Left(1).intoF[Either[List[String], +*], Either[String, String]].transform ==> Right(Left("1"))
-          Right(1).intoF[Either[List[String], +*], Either[String, String]].transform ==> Right(Right("1"))
-          Left(1).intoF[Either[List[String], +*], Left[String, String]].transform ==> Right(Left("1"))
-          Right(1).intoF[Either[List[String], +*], Right[String, String]].transform ==> Right(Right("1"))
+          Left(1).transformIntoF[Either[List[String], +*], Either[String, String]] ==> Right(Left("1"))
+          Right(1).transformIntoF[Either[List[String], +*], Either[String, String]] ==> Right(Right("1"))
+          Left(1).transformIntoF[Either[List[String], +*], Left[String, String]] ==> Right(Left("1"))
+          Right(1).transformIntoF[Either[List[String], +*], Right[String, String]] ==> Right(Right("1"))
         }
       }
 
@@ -569,23 +568,23 @@ object DslFSpec extends TestSuite {
           implicit val intParserEither: TransformerF[Either[List[String], +*], String, Int] =
             _.parseInt.toEither("bad int")
 
-          (Left("1"): Either[String, String]).intoF[Either[List[String], +*], Either[Int, Int]].transform ==>
+          (Left("1"): Either[String, String]).transformIntoF[Either[List[String], +*], Either[Int, Int]] ==>
             Right(Left(1))
-          (Right("1"): Either[String, String]).intoF[Either[List[String], +*], Either[Int, Int]].transform ==>
+          (Right("1"): Either[String, String]).transformIntoF[Either[List[String], +*], Either[Int, Int]] ==>
             Right(Right(1))
-          Left("1").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Right(Left(1))
-          Right("1").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Right(Right(1))
-          Left("1").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Right(Left(1))
-          Right("1").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Right(Right(1))
+          Left("1").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Right(Left(1))
+          Right("1").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Right(Right(1))
+          Left("1").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Right(Left(1))
+          Right("1").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Right(Right(1))
 
-          (Left("x"): Either[String, String]).intoF[Either[List[String], +*], Either[Int, Int]].transform ==>
+          (Left("x"): Either[String, String]).transformIntoF[Either[List[String], +*], Either[Int, Int]] ==>
             Left(List("bad int"))
-          (Right("x"): Either[String, String]).intoF[Either[List[String], +*], Either[Int, Int]].transform ==>
+          (Right("x"): Either[String, String]).transformIntoF[Either[List[String], +*], Either[Int, Int]] ==>
             Left(List("bad int"))
-          Left("x").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Left(List("bad int"))
-          Right("x").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Left(List("bad int"))
-          Left("x").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Left(List("bad int"))
-          Right("x").intoF[Either[List[String], +*], Either[Int, Int]].transform ==> Left(List("bad int"))
+          Left("x").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Left(List("bad int"))
+          Right("x").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Left(List("bad int"))
+          Left("x").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Left(List("bad int"))
+          Right("x").transformIntoF[Either[List[String], +*], Either[Int, Int]] ==> Left(List("bad int"))
         }
       }
 
@@ -611,18 +610,18 @@ object DslFSpec extends TestSuite {
           implicit val intParserEither: TransformerF[Either[List[String], +*], String, Int] =
             _.parseInt.toEither("bad int")
 
-          (Left("1"): Either[String, Int]).intoF[Either[List[String], +*], Either[Int, String]].transform ==>
+          (Left("1"): Either[String, Int]).transformIntoF[Either[List[String], +*], Either[Int, String]] ==>
             Right(Left(1))
-          (Left("x"): Either[String, Int]).intoF[Either[List[String], +*], Either[Int, String]].transform ==>
+          (Left("x"): Either[String, Int]).transformIntoF[Either[List[String], +*], Either[Int, String]] ==>
             Left(List("bad int"))
-          (Right(100): Either[String, Int]).intoF[Either[List[String], +*], Either[Int, String]].transform ==>
+          (Right(100): Either[String, Int]).transformIntoF[Either[List[String], +*], Either[Int, String]] ==>
             Right(Right("100"))
 
-          (Left(100): Either[Int, String]).intoF[Either[List[String], +*], Either[String, Int]].transform ==>
+          (Left(100): Either[Int, String]).transformIntoF[Either[List[String], +*], Either[String, Int]] ==>
             Right(Left("100"))
-          (Right("1"): Either[Int, String]).intoF[Either[List[String], +*], Either[String, Int]].transform ==>
+          (Right("1"): Either[Int, String]).transformIntoF[Either[List[String], +*], Either[String, Int]] ==>
             Right(Right(1))
-          (Right("x"): Either[Int, String]).intoF[Either[List[String], +*], Either[String, Int]].transform ==>
+          (Right("x"): Either[Int, String]).transformIntoF[Either[List[String], +*], Either[String, Int]] ==>
             Left(List("bad int"))
         }
       }
@@ -649,23 +648,16 @@ object DslFSpec extends TestSuite {
         }
 
         "F = Either[List[String], +*]]" - {
-          // without this specific instantiation on 2.11 shortToLongPureInner is not picked correctly
-          implicit val workaround
-              : TransformerF[Either[List[String], +*], short.NumScale[Int, Nothing], long.NumScale[String]] =
-            ScalesTransformer.shortToLongPureInner[Either[List[String], +*], Int, String]
+          import ScalesTransformer.shortToLongPureInner
 
           (short.Zero: short.NumScale[Int, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[String]]
-            .transform ==> Right(long.Zero)
+            .transformIntoF[Either[List[String], +*], long.NumScale[String]] ==> Right(long.Zero)
           (short.Million(4): short.NumScale[Int, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[String]]
-            .transform ==> Right(long.Million("4"))
+            .transformIntoF[Either[List[String], +*], long.NumScale[String]] ==> Right(long.Million("4"))
           (short.Billion(2): short.NumScale[Int, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[String]]
-            .transform ==> Right(long.Milliard("2"))
+            .transformIntoF[Either[List[String], +*], long.NumScale[String]] ==> Right(long.Milliard("2"))
           (short.Trillion(100): short.NumScale[Int, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[String]]
-            .transform ==> Right(long.Billion("100"))
+            .transformIntoF[Either[List[String], +*], long.NumScale[String]] ==> Right(long.Billion("100"))
         }
       }
 
@@ -697,33 +689,23 @@ object DslFSpec extends TestSuite {
           implicit val intParserEither: TransformerF[Either[List[String], +*], String, Int] =
             _.parseInt.toEither("bad int")
 
-          // without this specific instantiation on 2.11 shortToLongWrappedInner is not picked correctly
-          implicit val workaround
-              : TransformerF[Either[List[String], +*], short.NumScale[String, Nothing], long.NumScale[Int]] =
-            ScalesTransformer.shortToLongWrappedInner[Either[List[String], +*], String, Int]
+          import ScalesTransformer.shortToLongWrappedInner
 
           (short.Zero: short.NumScale[String, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[Int]]
-            .transform ==> Right(long.Zero)
+            .transformIntoF[Either[List[String], +*], long.NumScale[Int]] ==> Right(long.Zero)
           (short.Million("4"): short.NumScale[String, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[Int]]
-            .transform ==> Right(long.Million(4))
+            .transformIntoF[Either[List[String], +*], long.NumScale[Int]] ==> Right(long.Million(4))
           (short.Billion("2"): short.NumScale[String, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[Int]]
-            .transform ==> Right(long.Milliard(2))
+            .transformIntoF[Either[List[String], +*], long.NumScale[Int]] ==> Right(long.Milliard(2))
           (short.Trillion("100"): short.NumScale[String, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[Int]]
-            .transform ==> Right(long.Billion(100))
+            .transformIntoF[Either[List[String], +*], long.NumScale[Int]] ==> Right(long.Billion(100))
 
           (short.Million("x"): short.NumScale[String, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[Int]]
-            .transform ==> Left(List("bad int"))
+            .transformIntoF[Either[List[String], +*], long.NumScale[Int]] ==> Left(List("bad int"))
           (short.Billion("x"): short.NumScale[String, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[Int]]
-            .transform ==> Left(List("bad int"))
+            .transformIntoF[Either[List[String], +*], long.NumScale[Int]] ==> Left(List("bad int"))
           (short.Trillion("x"): short.NumScale[String, Nothing])
-            .intoF[Either[List[String], +*], long.NumScale[Int]]
-            .transform ==> Left(List("bad int"))
+            .transformIntoF[Either[List[String], +*], long.NumScale[Int]] ==> Left(List("bad int"))
         }
       }
     }
@@ -746,15 +728,11 @@ object DslFSpec extends TestSuite {
 
         compileError("""
           type EitherListStr[+X] = Either[List[String], X]
-          OuterIn(InnerIn("test"))
-            .intoF[EitherListStr, OuterOut]
-            .transform
+          OuterIn(InnerIn("test")).transformIntoF[EitherListStr, OuterOut]
           """)
           .check(
             "",
             "Ambiguous implicits while resolving Chimney recursive transformation",
-            "TransformerF[EitherListStr, InnerIn, InnerOut]: liftedTransformer",
-            "Transformer[InnerIn, InnerOut]: pureTransformer",
             "Please eliminate ambiguity from implicit scope or use withFieldComputed/withFieldComputedF to decide which one should be used"
           )
       }

--- a/chimneyCats/src/test/scala/io/scalaland/chimney/cats/CatsValidatedSpec.scala
+++ b/chimneyCats/src/test/scala/io/scalaland/chimney/cats/CatsValidatedSpec.scala
@@ -18,8 +18,7 @@ object CatsValidatedSpec extends TestSuite {
 
     "transform always succeeds" - {
 
-      Person("John", 10, 140).intoF[ValidatedNec[String, +*], User].transform ==> Validated.valid(User("John", 10, 140))
-      // .transformIntoF doesn't work with Scala 2.11
+      Person("John", 10, 140).transformIntoF[ValidatedNec[String, +*], User] ==> Validated.valid(User("John", 10, 140))
 
       Person("John", 10, 140).intoF[ValidatedNel[String, +*], User].transform ==> Validated.valid(User("John", 10, 140))
     }
@@ -390,10 +389,7 @@ object CatsValidatedSpec extends TestSuite {
 
         implicit val intPrinter: Transformer[Int, String] = _.toString
 
-        // without this specific instantiation on 2.11 shortToLongPureInner is not picked correctly
-        implicit val workaround
-            : TransformerF[ValidatedNec[String, +*], short.NumScale[Int, Nothing], long.NumScale[String]] =
-          ScalesTransformer.shortToLongPureInner[ValidatedNec[String, +*], Int, String]
+        import ScalesTransformer.shortToLongPureInner
 
         (short.Zero: short.NumScale[Int, Nothing])
           .intoF[ValidatedNec[String, +*], long.NumScale[String]]
@@ -414,10 +410,7 @@ object CatsValidatedSpec extends TestSuite {
         implicit val intParserValidated: TransformerF[ValidatedNec[String, +*], String, Int] =
           _.parseInt.toValidatedNec("bad int")
 
-        // without this specific instantiation on 2.11 shortToLongWrappedInner is not picked correctly
-        implicit val workaround
-            : TransformerF[ValidatedNec[String, +*], short.NumScale[String, Nothing], long.NumScale[Int]] =
-          ScalesTransformer.shortToLongWrappedInner[ValidatedNec[String, +*], String, Int]
+        import ScalesTransformer.shortToLongWrappedInner
 
         (short.Zero: short.NumScale[String, Nothing])
           .intoF[ValidatedNec[String, +*], long.NumScale[Int]]

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -12,11 +12,11 @@ to your ``build.sbt``:
   libraryDependencies += "io.scalaland" %% "chimney" % "|version|"
 
 
-Library is released for Scala 2.11.x, 2.12.x and 2.13.x. If you want to
+Library is released for Scala 2.12.x and 2.13.x. If you want to
 use it with Scala.js (or Scala Native), you need to replace ``%%`` with ``%%%``.
 
 .. warning:: Due to some `compiler bugs <https://issues.scala-lang.org/browse/SI-7046>`_,
-  it's recommended to use at least Scala 2.11.9 or 2.12.1.
+  it's recommended to use at least Scala 2.12.1.
 
 Using Ammonite
 --------------

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -13,7 +13,7 @@ to your ``build.sbt``:
 
 
 Library is released for Scala 2.12.x and 2.13.x. If you want to
-use it with Scala.js (or Scala Native), you need to replace ``%%`` with ``%%%``.
+use it with Scala.js, you need to replace ``%%`` with ``%%%``.
 
 .. warning:: Due to some `compiler bugs <https://issues.scala-lang.org/browse/SI-7046>`_,
   it's recommended to use at least Scala 2.12.1.

--- a/docs/source/transformers/cats-integration.rst
+++ b/docs/source/transformers/cats-integration.rst
@@ -10,7 +10,7 @@ To include it to your SBT project, add the following line to your ``build.sbt``:
 
   libraryDependencies += "io.scalaland" %% "chimney-cats" % "|version|"
 
-The module is released for Scala 2.11.x, 2.12.x and 2.13.x and cats 2.0.0.
+The module is released for Scala 2.12.x and 2.13.x and cats 2.2.0.
 If you want to use it with Scala.js, you need to replace ``%%`` with ``%%%``.
 
 The module provides package ``io.scalaland.chimney.cats`` with all the goodies

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
 import scala.util.Properties._
 
-val scalaJSVersion = envOrElse("SCALAJS_VERSION", "1.2.0")
-
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,7 @@ import scala.util.Properties._
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 


### PR DESCRIPTION
It also drops support for ScalaJS 0.6.x and Scala Native (as it's currently only available for 2.11).
At the moment when Scala Native is available for 2.12/2.13, I'm happy to bring the support back.
