### PR TITLE
Fix config type-aliasing

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -72,9 +72,11 @@ trait TransformerConfigSupport extends MacroUtils {
     val wrapperTypeT: Type = typeOf[WrapperType[F, _] forSome { type F[+_] }].typeConstructor
   }
 
-  def captureTransformerConfig(cfgTpe: Type): TransformerConfig = {
+  def captureTransformerConfig(rawCfgTpe: Type): TransformerConfig = {
 
     import CfgTpes._
+
+    val cfgTpe = rawCfgTpe.dealias
 
     if (cfgTpe =:= emptyT) {
       TransformerConfig()


### PR DESCRIPTION
If you try to define your own type-aliases for transformers config, for example
```
type VTransformer[A, B] =
  io.scalaland.chimney.TransformerF[VTransformer.F, A, B]

object VTransformer {
  import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}

  type F[+A] = Either[List[String], A]
  type DefaultCfg = TransformerCfg.WrapperType[F, TransformerCfg.Empty]
  type Definition[From, To] = TransformerFDefinition[F, From, To, DefaultCfg, TransformerFlags.Default]

  def define[From, To]: Definition[From, To] = io.scalaland.chimney.TransformerF.define[F, From, To]
}

case class Foo(foo: String)

case class Bar(bar: Int)

implicit val fooToBar: VTransformer[Foo, Bar] =
  VTransformer.define[Foo, Bar].withFieldRenamed(_.foo, _.bar).buildTransformer

```

There will error "Bad internal transformer config type shape!" compilation error.

This PR fix it by adding dealias of captured cfg type 