### PR TITLE
Fix deriving wrapped transformer directly from pure

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -85,9 +85,8 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
     val To = weakTypeOf[To]
 
     val srcName = freshTermName(From)
-    val srcPrefixTree = Ident(TermName(srcName.decodedName.toString))
 
-    expandTransformerTree(srcPrefixTree, config)(From, To) match {
+    genTransformerTree(srcName, config)(From, To) match {
 
       case Right(transformerTree) =>
         config.wrapperType match {
@@ -123,12 +122,25 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
     }
   }
 
+  def genTransformerTree(
+      srcName: TermName,
+      config: TransformerConfig
+  )(From: Type, To: Type): Either[Seq[DerivationError], Tree] = {
+    val srcPrefixTree = Ident(TermName(srcName.decodedName.toString))
+
+    resolveTransformerBody(srcPrefixTree, config)(From, To).map {
+      case TransformerBodyTree(tree, false) if config.wrapperType.isDefined =>
+        q"${config.wrapperSupportInstance}.pure[$To]($tree)"
+      case TransformerBodyTree(tree, _) => tree
+    }
+  }
+
   def expandTransformerTree(
       srcPrefixTree: Tree,
       config: TransformerConfig
   )(From: Type, To: Type): Either[Seq[DerivationError], Tree] = {
 
-    resolveImplicitTransformer(srcPrefixTree, config)(From, To)
+    resolveImplicitTransformer(config)(From, To)
       .map(localImplicitTree => Right(localImplicitTree.callTransform(srcPrefixTree)))
       .getOrElse {
         deriveTransformerTree(srcPrefixTree, config)(From, To)
@@ -742,44 +754,44 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
       srcPrefixTree: Tree,
       config: TransformerConfig
   )(From: Type, To: Type): Either[Seq[DerivationError], TransformerBodyTree] = {
+    resolveTransformerBody(srcPrefixTree, config.rec)(From, To)
+  }
 
-    val recConfig = config.rec
-    val recConfigNoWrapper = recConfig.copy(wrapperType = None)
-
+  def resolveTransformerBody(
+      srcPrefixTree: Tree,
+      config: TransformerConfig
+  )(From: Type, To: Type): Either[Seq[DerivationError], TransformerBodyTree] = {
     if (config.wrapperType.isDefined) {
-      val implicitTransformerF = resolveImplicitTransformer(srcPrefixTree, recConfig)(From, To)
-      val implicitTransformer = resolveImplicitTransformer(srcPrefixTree, recConfigNoWrapper)(From, To)
+      val implicitTransformerF = resolveImplicitTransformer(config)(From, To)
+      val implicitTransformer = findLocalImplicitTransformer(From, To, None)
 
       (implicitTransformerF, implicitTransformer) match {
         case (Some(localImplicitTreeF), Some(localImplicitTree)) =>
           c.abort(
             c.enclosingPosition,
             s"""Ambiguous implicits while resolving Chimney recursive transformation:
-              |
-              |TransformerF[${config.wrapperType.get}, $From, $To]: $localImplicitTreeF
-              |Transformer[$From, $To]: $localImplicitTree
-              |
-              |Please eliminate ambiguity from implicit scope or use withFieldComputed/withFieldComputedF to decide which one should be used
-              |""".stripMargin
+               |
+               |TransformerF[${config.wrapperType.get}, $From, $To]: $localImplicitTreeF
+               |Transformer[$From, $To]: $localImplicitTree
+               |
+               |Please eliminate ambiguity from implicit scope or use withFieldComputed/withFieldComputedF to decide which one should be used
+               |""".stripMargin
           )
         case (Some(localImplicitTreeF), None) =>
           Right(TransformerBodyTree(localImplicitTreeF.callTransform(srcPrefixTree), isWrapped = true))
         case (None, Some(localImplicitTree)) =>
           Right(TransformerBodyTree(localImplicitTree.callTransform(srcPrefixTree), isWrapped = false))
         case (None, None) =>
-          deriveTransformerTree(srcPrefixTree, recConfig)(From, To)
+          deriveTransformerTree(srcPrefixTree, config)(From, To)
             .map(tree => TransformerBodyTree(tree, isWrapped = true))
       }
     } else {
-      expandTransformerTree(srcPrefixTree, recConfig)(From, To)
+      expandTransformerTree(srcPrefixTree, config)(From, To)
         .map(tree => TransformerBodyTree(tree, isWrapped = false))
     }
   }
 
-  def resolveImplicitTransformer(
-      srcPrefixTree: Tree,
-      config: TransformerConfig
-  )(From: Type, To: Type): Option[Tree] = {
+  def resolveImplicitTransformer(config: TransformerConfig)(From: Type, To: Type): Option[Tree] = {
     if (config.definitionScope.contains((From, To))) {
       None
     } else {

--- a/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslFSpec.scala
@@ -868,5 +868,16 @@ object DslFSpec extends TestSuite {
 
       fooToBar.transform(Foo("1")) ==> Right(Bar(1))
     }
+
+    "support deriving wrapped transformer from pure" - {
+      case class Foo(str: String)
+
+      case class Bar(str: String, other: String)
+
+      implicit val fooToBar: Transformer[Foo, Bar] =
+        Transformer.define[Foo, Bar].withFieldConst(_.other, "other").buildTransformer
+
+      Foo("str").transformIntoF[Option, Bar] ==> Some(Bar("str", "other"))
+    }
   }
 }


### PR DESCRIPTION
If we have some Transformer[A, B] and want to use directly (not for subfields of something) TransformerF[F, A, B], it will failed with compilation error, cause it doesn't derive by TransformerF.derive 

```
case class Foo(str: String)

case class Bar(str: String, other: String)

implicit val fooToBar: Transformer[Foo, Bar] =
  Transformer.define[Foo, Bar].withFieldConst(_.other, "other").buildTransformer

Foo("str").transformIntoF[Option, Bar]
```

This will fix it