### PR TITLE
Small code readability improvements to kick off refactoring of whole codebase

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
+import io.scalaland.chimney.internal.macros.dsl.PatcherBlackboxMacros
 
 import scala.language.experimental.macros
 
@@ -23,5 +23,5 @@ object Patcher {
     * @return [[io.scalaland.chimney.Patcher]] type class instance
     */
   implicit def derive[T, Patch]: Patcher[T, Patch] =
-    macro ChimneyBlackboxMacros.derivePatcherImpl[T, Patch]
+    macro PatcherBlackboxMacros.derivePatcherImpl[T, Patch]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -1,8 +1,8 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
-import io.scalaland.chimney.dsl.{TransformerDefinition, TransformerFDefinition}
-import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
+import io.scalaland.chimney.internal.{ TransformerCfg, TransformerFlags }
+import io.scalaland.chimney.dsl.{ TransformerDefinition, TransformerFDefinition }
+import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 
 import scala.language.experimental.macros
 
@@ -27,7 +27,7 @@ object Transformer {
     * @return [[io.scalaland.chimney.Transformer]] type class definition
     */
   implicit def derive[From, To]: Transformer[From, To] =
-    macro ChimneyBlackboxMacros.deriveTransformerImpl[From, To]
+    macro TransformerBlackboxMacros.deriveTransformerImpl[From, To]
 
   /** Creates an empty [[io.scalaland.chimney.dsl.TransformerDefinition]] that
     * you can customize to derive [[io.scalaland.chimney.Transformer]].

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.{ TransformerCfg, TransformerFlags }
-import io.scalaland.chimney.dsl.{ TransformerDefinition, TransformerFDefinition }
+import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.dsl.{TransformerDefinition, TransformerFDefinition}
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 
 import scala.language.experimental.macros

--- a/chimney/src/main/scala/io/scalaland/chimney/TransformerF.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/TransformerF.scala
@@ -1,8 +1,8 @@
 package io.scalaland.chimney
 
 import io.scalaland.chimney.dsl.TransformerFDefinition
-import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
-import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
+import io.scalaland.chimney.internal.{ TransformerCfg, TransformerFlags }
+import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 
 import scala.language.experimental.macros
 
@@ -35,7 +35,7 @@ object TransformerF {
     * @return [[io.scalaland.chimney.TransformerF]] type class definition
     */
   implicit def derive[F[+_], From, To](implicit tfs: TransformerFSupport[F]): TransformerF[F, From, To] =
-    macro ChimneyBlackboxMacros.deriveTransformerFImpl[F, From, To]
+    macro TransformerBlackboxMacros.deriveTransformerFImpl[F, From, To]
 
   /** Creates an empty [[io.scalaland.chimney.dsl.TransformerFDefinition]] that
     * you can customize to derive [[io.scalaland.chimney.TransformerF]].

--- a/chimney/src/main/scala/io/scalaland/chimney/TransformerF.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/TransformerF.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney
 
 import io.scalaland.chimney.dsl.TransformerFDefinition
-import io.scalaland.chimney.internal.{ TransformerCfg, TransformerFlags }
+import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 
 import scala.language.experimental.macros

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherUsing.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.PatcherCfg
 import io.scalaland.chimney.internal.PatcherCfg.{IgnoreNoneInPatch, IgnoreRedundantPatcherFields}
-import io.scalaland.chimney.internal.macros.ChimneyBlackboxMacros
+import io.scalaland.chimney.internal.macros.dsl.PatcherBlackboxMacros
 
 import scala.language.experimental.macros
 
@@ -48,5 +48,5 @@ class PatcherUsing[T, P, C <: PatcherCfg](val obj: T, val objPatch: P) {
     *
     * @return patched value
     */
-  def patch: T = macro ChimneyBlackboxMacros.patchImpl[T, P, C]
+  def patch: T = macro PatcherBlackboxMacros.patchImpl[T, P, C]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.internal.TransformerCfg._
 import io.scalaland.chimney.internal._
-import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerDefinitionWhiteboxMacros }
+import io.scalaland.chimney.internal.macros.dsl.{TransformerBlackboxMacros, TransformerDefinitionWhiteboxMacros}
 
 import scala.language.experimental.macros
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.internal.TransformerCfg._
 import io.scalaland.chimney.internal._
-import io.scalaland.chimney.internal.macros.{ChimneyBlackboxMacros, TransformerDefinitionWhiteboxMacros}
+import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerDefinitionWhiteboxMacros }
 
 import scala.language.experimental.macros
 
@@ -141,7 +141,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: Transf
   def buildTransformer[ScopeFlags <: TransformerFlags](
       implicit tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
   ): Transformer[From, To] =
-    macro ChimneyBlackboxMacros.buildTransformerImpl[From, To, C, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.buildTransformerImpl[From, To, C, Flags, ScopeFlags]
 
   /** Used internally by macro. Please don't use in your code.
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
@@ -1,8 +1,8 @@
 package io.scalaland.chimney.dsl
 
-import io.scalaland.chimney.{TransformerF, TransformerFSupport}
+import io.scalaland.chimney.{ TransformerF, TransformerFSupport }
 import io.scalaland.chimney.internal._
-import io.scalaland.chimney.internal.macros.{ChimneyBlackboxMacros, TransformerFDefinitionWhiteboxMacros}
+import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerFDefinitionWhiteboxMacros }
 
 import scala.language.experimental.macros
 
@@ -138,7 +138,7 @@ final class TransformerFDefinition[F[+_], From, To, C <: TransformerCfg, Flags <
       implicit tfs: TransformerFSupport[F],
       tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
   ): TransformerF[F, From, To] =
-    macro ChimneyBlackboxMacros.buildTransformerFImpl[F, From, To, C, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.buildTransformerFImpl[F, From, To, C, Flags, ScopeFlags]
 
   /** Used internally by macro. Please don't use in your code.
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
@@ -1,8 +1,8 @@
 package io.scalaland.chimney.dsl
 
-import io.scalaland.chimney.{ TransformerF, TransformerFSupport }
+import io.scalaland.chimney.{TransformerF, TransformerFSupport}
 import io.scalaland.chimney.internal._
-import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerFDefinitionWhiteboxMacros }
+import io.scalaland.chimney.internal.macros.dsl.{TransformerBlackboxMacros, TransformerFDefinitionWhiteboxMacros}
 
 import scala.language.experimental.macros
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFInto.scala
@@ -1,8 +1,8 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.TransformerFSupport
-import io.scalaland.chimney.internal.{ TransformerCfg, TransformerFlags }
-import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerFIntoWhiteboxMacros }
+import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.macros.dsl.{TransformerBlackboxMacros, TransformerFIntoWhiteboxMacros}
 
 import scala.language.experimental.macros
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFInto.scala
@@ -1,8 +1,8 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.TransformerFSupport
-import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
-import io.scalaland.chimney.internal.macros.{ChimneyBlackboxMacros, TransformerFIntoWhiteboxMacros}
+import io.scalaland.chimney.internal.{ TransformerCfg, TransformerFlags }
+import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerFIntoWhiteboxMacros }
 
 import scala.language.experimental.macros
 
@@ -124,7 +124,7 @@ final class TransformerFInto[F[+_], From, To, C <: TransformerCfg, Flags <: Tran
       implicit tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags],
       tfs: TransformerFSupport[F]
   ): F[To] =
-    macro ChimneyBlackboxMacros.transformFImpl[F, From, To, C, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.transformFImpl[F, From, To, C, Flags, ScopeFlags]
 
   /** Used internally by macro. Please don't use in your code.
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.TransformerCfg._
 import io.scalaland.chimney.internal._
-import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerIntoWhiteboxMacros }
+import io.scalaland.chimney.internal.macros.dsl.{TransformerBlackboxMacros, TransformerIntoWhiteboxMacros}
 
 import scala.language.experimental.macros
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.TransformerCfg._
 import io.scalaland.chimney.internal._
-import io.scalaland.chimney.internal.macros.{ChimneyBlackboxMacros, TransformerIntoWhiteboxMacros}
+import io.scalaland.chimney.internal.macros.dsl.{ TransformerBlackboxMacros, TransformerIntoWhiteboxMacros }
 
 import scala.language.experimental.macros
 
@@ -140,7 +140,7 @@ final class TransformerInto[From, To, C <: TransformerCfg, Flags <: TransformerF
   def transform[ScopeFlags <: TransformerFlags](
       implicit tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
   ): To =
-    macro ChimneyBlackboxMacros.transformImpl[From, To, C, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.transformImpl[From, To, C, Flags, ScopeFlags]
 
   /** Used internally by macro. Please don't use in your code.
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -11,6 +11,22 @@ trait TransformerConfigSupport extends MacroUtils {
 
   import c.universe._
 
+  def readConfig[C: WeakTypeTag, Flags: WeakTypeTag, ScopeFlags: WeakTypeTag](
+      wrapperSupportInstance: Tree
+  ): TransformerConfig = {
+    val C = weakTypeOf[C]
+    val Flags = weakTypeOf[Flags]
+    val ScopeFlags = weakTypeOf[ScopeFlags]
+
+    val scopeFlags = captureTransformerFlags(ScopeFlags)
+    val instanceFlags = captureTransformerFlags(Flags, scopeFlags)
+
+    captureTransformerConfig(C).copy(
+      flags = instanceFlags,
+      wrapperSupportInstance = wrapperSupportInstance
+    )
+  }
+
   sealed abstract class FieldOverride(val needValueLevelAccess: Boolean)
 
   object FieldOverride {
@@ -59,6 +75,7 @@ trait TransformerConfigSupport extends MacroUtils {
   }
 
   object CfgTpes {
+
     import io.scalaland.chimney.internal.TransformerCfg._
 
     val emptyT: Type = typeOf[Empty]
@@ -69,7 +86,7 @@ trait TransformerConfigSupport extends MacroUtils {
     val fieldRelabelledT: Type = typeOf[FieldRelabelled[_, _, _]].typeConstructor
     val coproductInstanceT: Type = typeOf[CoproductInstance[_, _, _]].typeConstructor
     val coproductInstanceFT: Type = typeOf[CoproductInstanceF[_, _, _]].typeConstructor
-    val wrapperTypeT: Type = typeOf[WrapperType[F, _] forSome { type F[+_] }].typeConstructor
+    val wrapperTypeT: Type = typeOf[WrapperType[F, _] forSome { type F[+ _] }].typeConstructor
   }
 
   def captureTransformerConfig(rawCfgTpe: Type): TransformerConfig = {
@@ -148,6 +165,7 @@ trait TransformerConfigSupport extends MacroUtils {
   }
 
   object FlagsTpes {
+
     import io.scalaland.chimney.internal.TransformerFlags._
 
     val defaultT: Type = typeOf[Default]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -11,18 +11,18 @@ trait TransformerConfigSupport extends MacroUtils {
 
   import c.universe._
 
-  def readConfig[C: WeakTypeTag, Flags: WeakTypeTag, ScopeFlags: WeakTypeTag](
+  def readConfig[C: WeakTypeTag, InstanceFlags: WeakTypeTag, ScopeFlags: WeakTypeTag](
       wrapperSupportInstance: Tree
   ): TransformerConfig = {
     val C = weakTypeOf[C]
-    val Flags = weakTypeOf[Flags]
+    val InstanceFlags = weakTypeOf[InstanceFlags]
     val ScopeFlags = weakTypeOf[ScopeFlags]
 
     val scopeFlags = captureTransformerFlags(ScopeFlags)
-    val instanceFlags = captureTransformerFlags(Flags, scopeFlags)
+    val combinedFlags = captureTransformerFlags(InstanceFlags, scopeFlags)
 
     captureTransformerConfig(C).copy(
-      flags = instanceFlags,
+      flags = combinedFlags,
       wrapperSupportInstance = wrapperSupportInstance
     )
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -86,7 +86,7 @@ trait TransformerConfigSupport extends MacroUtils {
     val fieldRelabelledT: Type = typeOf[FieldRelabelled[_, _, _]].typeConstructor
     val coproductInstanceT: Type = typeOf[CoproductInstance[_, _, _]].typeConstructor
     val coproductInstanceFT: Type = typeOf[CoproductInstanceF[_, _, _]].typeConstructor
-    val wrapperTypeT: Type = typeOf[WrapperType[F, _] forSome { type F[+ _] }].typeConstructor
+    val wrapperTypeT: Type = typeOf[WrapperType[F, _] forSome { type F[+_] }].typeConstructor
   }
 
   def captureTransformerConfig(rawCfgTpe: Type): TransformerConfig = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -16,13 +16,13 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
-      Flags: WeakTypeTag,
+      InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
   ](
       tfsTree: Tree = EmptyTree,
       wrapperType: Option[Type] = None
   ): Tree = {
-    val config = readConfig[C, Flags, ScopeFlags](tfsTree).copy(
+    val config = readConfig[C, InstanceFlags, ScopeFlags](tfsTree).copy(
       definitionScope = Some((weakTypeOf[From], weakTypeOf[To])),
       wrapperErrorPathSupportInstance = findTransformerErrorPathSupport(wrapperType)
     )
@@ -40,14 +40,14 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
     }
   }
 
-  def expandTransform[From: WeakTypeTag, To: WeakTypeTag, C: WeakTypeTag, Flags: WeakTypeTag, ScopeFlags: WeakTypeTag](
+  def expandTransform[From: WeakTypeTag, To: WeakTypeTag, C: WeakTypeTag, InstanceFlags: WeakTypeTag, ScopeFlags: WeakTypeTag](
       tcTree: Tree,
       tfsTree: Tree = EmptyTree,
       wrapperType: Option[Type] = None
   ): Tree = {
     val tiName = TermName(c.freshName("ti"))
 
-    val config = readConfig[C, Flags, ScopeFlags](tfsTree).copy(
+    val config = readConfig[C, InstanceFlags, ScopeFlags](tfsTree).copy(
       transformerDefinitionPrefix = q"$tiName.td",
       wrapperErrorPathSupportInstance = findTransformerErrorPathSupport(wrapperType)
     )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -40,7 +40,13 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
     }
   }
 
-  def expandTransform[From: WeakTypeTag, To: WeakTypeTag, C: WeakTypeTag, InstanceFlags: WeakTypeTag, ScopeFlags: WeakTypeTag](
+  def expandTransform[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      C: WeakTypeTag,
+      InstanceFlags: WeakTypeTag,
+      ScopeFlags: WeakTypeTag
+  ](
       tcTree: Tree,
       tfsTree: Tree = EmptyTree,
       wrapperType: Option[Type] = None

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -61,22 +61,6 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
     """
   }
 
-  def readConfig[C: WeakTypeTag, Flags: WeakTypeTag, ScopeFlags: WeakTypeTag](
-      wrapperSupportInstance: Tree
-  ): TransformerConfig = {
-    val C = weakTypeOf[C]
-    val Flags = weakTypeOf[Flags]
-    val ScopeFlags = weakTypeOf[ScopeFlags]
-
-    val scopeFlags = captureTransformerFlags(ScopeFlags)
-    val instanceFlags = captureTransformerFlags(Flags, scopeFlags)
-
-    captureTransformerConfig(C).copy(
-      flags = instanceFlags,
-      wrapperSupportInstance = wrapperSupportInstance
-    )
-  }
-
   def genTransformer[From: WeakTypeTag, To: WeakTypeTag](
       config: TransformerConfig
   ): Tree = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/PatcherBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/PatcherBlackboxMacros.scala
@@ -1,0 +1,25 @@
+package io.scalaland.chimney.internal.macros.dsl
+
+import io.scalaland.chimney.Patcher
+import io.scalaland.chimney.internal.macros.{PatcherMacros, TransformerMacros}
+import io.scalaland.chimney.internal.utils.{DerivationGuards, EitherUtils, MacroUtils}
+
+import scala.reflect.macros.blackbox
+
+class PatcherBlackboxMacros(val c: blackbox.Context)
+    extends PatcherMacros
+    with TransformerMacros
+    with DerivationGuards
+    with MacroUtils
+    with EitherUtils {
+
+  import c.universe._
+
+  def patchImpl[T: WeakTypeTag, Patch: WeakTypeTag, C: WeakTypeTag]: c.Expr[T] = {
+    c.Expr[T](expandPatch[T, Patch, C])
+  }
+
+  def derivePatcherImpl[T: WeakTypeTag, Patch: WeakTypeTag]: c.Expr[Patcher[T, Patch]] = {
+    genPatcher[T, Patch](PatcherConfig())
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
@@ -1,14 +1,14 @@
-package io.scalaland.chimney.internal.macros
+package io.scalaland.chimney.internal.macros.dsl
 
 import io.scalaland.chimney
+import io.scalaland.chimney.{TransformerF, TransformerFSupport}
+import io.scalaland.chimney.internal.macros.TransformerMacros
 import io.scalaland.chimney.internal.utils.{DerivationGuards, EitherUtils, MacroUtils}
-import io.scalaland.chimney.{Patcher, TransformerF, TransformerFSupport}
 
 import scala.reflect.macros.blackbox
 
-class ChimneyBlackboxMacros(val c: blackbox.Context)
-    extends PatcherMacros
-    with TransformerMacros
+class TransformerBlackboxMacros(val c: blackbox.Context)
+    extends TransformerMacros
     with DerivationGuards
     with MacroUtils
     with EitherUtils {
@@ -26,7 +26,7 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
   }
 
   def buildTransformerFImpl[
-      F[+_]: TypeConstructorTag,
+      F[+ _]: TypeConstructorTag,
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
@@ -52,7 +52,7 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
   }
 
   def transformFImpl[
-      F[+_]: TypeConstructorTag,
+      F[+ _]: TypeConstructorTag,
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
@@ -84,7 +84,7 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
     }
   }
 
-  def deriveTransformerFImpl[F[+_]: TypeConstructorTag, From: WeakTypeTag, To: WeakTypeTag](
+  def deriveTransformerFImpl[F[+ _]: TypeConstructorTag, From: WeakTypeTag, To: WeakTypeTag](
       tfs: c.Expr[TransformerFSupport[F]]
   ): c.Expr[TransformerF[F, From, To]] = {
 
@@ -108,13 +108,5 @@ class ChimneyBlackboxMacros(val c: blackbox.Context)
         $transformerTree
       }"""
     }
-  }
-
-  def patchImpl[T: WeakTypeTag, Patch: WeakTypeTag, C: WeakTypeTag]: c.Expr[T] = {
-    c.Expr[T](expandPatch[T, Patch, C])
-  }
-
-  def derivePatcherImpl[T: WeakTypeTag, Patch: WeakTypeTag]: c.Expr[Patcher[T, Patch]] = {
-    genPatcher[T, Patch](PatcherConfig())
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
@@ -26,7 +26,7 @@ class TransformerBlackboxMacros(val c: blackbox.Context)
   }
 
   def buildTransformerFImpl[
-      F[+ _]: TypeConstructorTag,
+      F[+_]: TypeConstructorTag,
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
@@ -52,7 +52,7 @@ class TransformerBlackboxMacros(val c: blackbox.Context)
   }
 
   def transformFImpl[
-      F[+ _]: TypeConstructorTag,
+      F[+_]: TypeConstructorTag,
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
@@ -84,7 +84,7 @@ class TransformerBlackboxMacros(val c: blackbox.Context)
     }
   }
 
-  def deriveTransformerFImpl[F[+ _]: TypeConstructorTag, From: WeakTypeTag, To: WeakTypeTag](
+  def deriveTransformerFImpl[F[+_]: TypeConstructorTag, From: WeakTypeTag, To: WeakTypeTag](
       tfs: c.Expr[TransformerFSupport[F]]
   ): c.Expr[TransformerF[F, From, To]] = {
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
@@ -30,14 +30,14 @@ class TransformerBlackboxMacros(val c: blackbox.Context)
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
-      Flags: WeakTypeTag,
+      InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
   ](
       tfs: c.Expr[TransformerFSupport[F]],
       tc: c.Tree
   ): c.Expr[TransformerF[F, From, To]] = {
     c.Expr[TransformerF[F, From, To]](
-      buildDefinedTransformer[From, To, C, Flags, ScopeFlags](tfs.tree, Some(TypeConstructorTag[F]))
+      buildDefinedTransformer[From, To, C, InstanceFlags, ScopeFlags](tfs.tree, Some(TypeConstructorTag[F]))
     )
   }
 
@@ -45,10 +45,10 @@ class TransformerBlackboxMacros(val c: blackbox.Context)
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
-      Flags: WeakTypeTag,
+      InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
   ](tc: c.Tree): c.Expr[To] = {
-    c.Expr[To](expandTransform[From, To, C, Flags, ScopeFlags](tc))
+    c.Expr[To](expandTransform[From, To, C, InstanceFlags, ScopeFlags](tc))
   }
 
   def transformFImpl[
@@ -56,13 +56,13 @@ class TransformerBlackboxMacros(val c: blackbox.Context)
       From: WeakTypeTag,
       To: WeakTypeTag,
       C: WeakTypeTag,
-      Flags: WeakTypeTag,
+      InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
   ](
       tc: c.Tree,
       tfs: c.Expr[TransformerFSupport[F]]
   ): c.Expr[F[To]] = {
-    c.Expr[F[To]](expandTransform[From, To, C, Flags, ScopeFlags](tc, tfs.tree, Some(TypeConstructorTag[F])))
+    c.Expr[F[To]](expandTransform[From, To, C, InstanceFlags, ScopeFlags](tc, tfs.tree, Some(TypeConstructorTag[F])))
   }
 
   def deriveTransformerImpl[From: WeakTypeTag, To: WeakTypeTag]: c.Expr[chimney.Transformer[From, To]] = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerDefinitionWhiteboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerDefinitionWhiteboxMacros.scala
@@ -1,10 +1,11 @@
-package io.scalaland.chimney.internal.macros
+package io.scalaland.chimney.internal.macros.dsl
 
+import io.scalaland.chimney.internal.macros.TransformerConfigSupport
 import io.scalaland.chimney.internal.utils.MacroUtils
 
 import scala.reflect.macros.whitebox
 
-class TransformerFDefinitionWhiteboxMacros(val c: whitebox.Context) extends MacroUtils with TransformerConfigSupport {
+class TransformerDefinitionWhiteboxMacros(val c: whitebox.Context) extends MacroUtils with TransformerConfigSupport {
 
   import c.universe._
   import CfgTpes._
@@ -33,32 +34,8 @@ class TransformerFDefinitionWhiteboxMacros(val c: whitebox.Context) extends Macr
     }
   }
 
-  def withFieldConstFImpl[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      T: WeakTypeTag,
-      U: WeakTypeTag,
-      C: WeakTypeTag,
-      F[_]
-  ](selector: Tree, value: Tree)(implicit F: WeakTypeTag[F[_]]): Tree = {
-    val fieldName = selector.extractSelectorFieldName
-
-    if (!(weakTypeOf[U] <:< weakTypeOf[T])) {
-      val FT = F.tpe.applyTypeArg(weakTypeOf[T])
-      val FU = F.tpe.applyTypeArg(weakTypeOf[U])
-      val msg =
-        s"""Type mismatch!
-           |Value passed to `withFieldConstF` is of type: $FU
-           |Type required by '$fieldName' field: $FT
-           |${weakTypeOf[U]} is not subtype of ${weakTypeOf[T]}!
-         """.stripMargin
-
-      c.abort(c.enclosingPosition, msg)
-    } else {
-      c.prefix.tree
-        .addOverride(fieldName, value)
-        .refineConfig(fieldConstFT.applyTypeArgs(fieldName.toSingletonTpe, weakTypeOf[C]))
-    }
+  def withFieldConstFImpl[F[+_]](selector: Tree, value: Tree)(implicit F: WeakTypeTag[F[_]]): Tree = {
+    q"${c.prefix}.lift[$F].withFieldConstF($selector, $value)"
   }
 
   def withFieldComputedImpl[
@@ -85,33 +62,8 @@ class TransformerFDefinitionWhiteboxMacros(val c: whitebox.Context) extends Macr
     }
   }
 
-  def withFieldComputedFImpl[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      T: WeakTypeTag,
-      U: WeakTypeTag,
-      C: WeakTypeTag,
-      F[+_]
-  ](selector: Tree, map: Tree)(implicit F: WeakTypeTag[F[_]]): Tree = {
-    val fieldName = selector.extractSelectorFieldName
-
-    if (!(weakTypeOf[U] <:< weakTypeOf[T])) {
-      val FT = F.tpe.applyTypeArg(weakTypeOf[T])
-      val FU = F.tpe.applyTypeArg(weakTypeOf[U])
-
-      val msg =
-        s"""Type mismatch!
-           |Function passed to `withFieldComputedF` returns type: $FU
-           |Type required by '$fieldName' field: $FT
-           |${weakTypeOf[U]} is not subtype of ${weakTypeOf[T]}!
-         """.stripMargin
-
-      c.abort(c.enclosingPosition, msg)
-    } else {
-      c.prefix.tree
-        .addOverride(fieldName, map)
-        .refineConfig(fieldComputedFT.applyTypeArgs(fieldName.toSingletonTpe, weakTypeOf[C]))
-    }
+  def withFieldComputedFImpl[F[+_]](selector: Tree, map: Tree)(implicit F: WeakTypeTag[F[_]]): Tree = {
+    q"${c.prefix}.lift[$F].withFieldComputedF($selector, $map)"
   }
 
   def withFieldRenamedImpl[
@@ -156,16 +108,13 @@ class TransformerFDefinitionWhiteboxMacros(val c: whitebox.Context) extends Macr
   }
 
   def withCoproductInstanceFImpl[
+      F[+_],
       From: WeakTypeTag,
       To: WeakTypeTag,
       Inst: WeakTypeTag,
       C: WeakTypeTag
-  ](f: Tree): Tree = {
-    val To = weakTypeOf[To]
-    val Inst = weakTypeOf[Inst]
-    c.prefix.tree
-      .addInstance(Inst.typeSymbol.fullName.toString, To.typeSymbol.fullName.toString, f)
-      .refineConfig(coproductInstanceFT.applyTypeArgs(Inst, To, weakTypeOf[C]))
+  ](f: Tree)(implicit F: WeakTypeTag[F[_]]): Tree = {
+    q"${c.prefix}.lift[$F].withCoproductInstanceF($f)"
   }
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerFIntoWhiteboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerFIntoWhiteboxMacros.scala
@@ -1,4 +1,4 @@
-package io.scalaland.chimney.internal.macros
+package io.scalaland.chimney.internal.macros.dsl
 
 import io.scalaland.chimney.internal.utils.MacroUtils
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerIntoWhiteboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerIntoWhiteboxMacros.scala
@@ -1,4 +1,4 @@
-package io.scalaland.chimney.internal.macros
+package io.scalaland.chimney.internal.macros.dsl
 
 import io.scalaland.chimney.internal.utils.MacroUtils
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
@@ -296,8 +296,10 @@ trait MacroUtils extends CompanionUtils {
       q"$td.__refineTransformerDefinition($definitionRefinementFn)"
     }
 
-    def refineTransformerDefinition_Hack(definitionRefinementFn: Map[String, Tree] => Tree,
-                                         valTree: (String, Tree)): Tree = {
+    def refineTransformerDefinition_Hack(
+        definitionRefinementFn: Map[String, Tree] => Tree,
+        valTree: (String, Tree)
+    ): Tree = {
       // normally, we would like to use refineTransformerDefinition, which works well on Scala 2.11
       // in few cases on Scala 2.12+ it ends up as 'Error while emitting XXX.scala' compiler error
       // with this hack, we can work around scalac bugs


### PR DESCRIPTION
* moved DSL-related macros to a separated pacakge
* moved `readConfig` macro utility to `TransformerConfigSupport`
* rename `Flags` to `InstanceFlags` where distinction from `ScopeFlags` is needed
* renamed arguments and refactored body of `refineTransformerDefinition` methods