### PR TITLE
WIP Resolving TransformerF and Transformer ambiguity

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerFlags.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/TransformerFlags.scala
@@ -13,4 +13,5 @@ object TransformerFlags {
   final class BeanGetters extends Flag
   final class OptionDefaultsToNone extends Flag
   final class UnsafeOption extends Flag
+  final class PreferPureTransformer extends Flag
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -141,7 +141,8 @@ trait TransformerConfigSupport extends MacroUtils {
       beanSetters: Boolean = false,
       beanGetters: Boolean = false,
       optionDefaultsToNone: Boolean = false,
-      unsafeOption: Boolean = false
+      unsafeOption: Boolean = false,
+      preferPureTransformer: Boolean = false
   ) {
     def setFlag(flagTpe: Type, value: Boolean): TransformerFlags = {
       if (flagTpe =:= FlagsTpes.methodAccessorsT) {
@@ -156,6 +157,8 @@ trait TransformerConfigSupport extends MacroUtils {
         copy(optionDefaultsToNone = value)
       } else if (flagTpe =:= FlagsTpes.unsafeOptionT) {
         copy(unsafeOption = value)
+      } else if (flagTpe =:= FlagsTpes.preferPureTransformerT) {
+        copy(preferPureTransformer = value)
       } else {
         // $COVERAGE-OFF$
         c.abort(c.enclosingPosition, s"Invalid transformer flag type: $flagTpe!")
@@ -178,6 +181,7 @@ trait TransformerConfigSupport extends MacroUtils {
     val beanGettersT: Type = typeOf[BeanGetters]
     val optionDefaultsToNoneT: Type = typeOf[OptionDefaultsToNone]
     val unsafeOptionT: Type = typeOf[UnsafeOption]
+    val preferPureTransformerT: Type = typeOf[PreferPureTransformer]
   }
 
   def captureTransformerFlags(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -757,16 +757,19 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
 
       (implicitTransformerF, implicitTransformer) match {
         case (Some(localImplicitTreeF), Some(localImplicitTree)) =>
-          c.abort(
-            c.enclosingPosition,
-            s"""Ambiguous implicits while resolving Chimney recursive transformation:
+          if (config.flags.preferPureTransformer)
+            Right(TransformerBodyTree(localImplicitTree.callTransform(srcPrefixTree), isWrapped = false))
+          else
+            c.abort(
+              c.enclosingPosition,
+              s"""Ambiguous implicits while resolving Chimney recursive transformation:
                |
                |TransformerF[${config.wrapperType.get}, $From, $To]: $localImplicitTreeF
                |Transformer[$From, $To]: $localImplicitTree
                |
                |Please eliminate ambiguity from implicit scope or use withFieldComputed/withFieldComputedF to decide which one should be used
                |""".stripMargin
-          )
+            )
         case (Some(localImplicitTreeF), None) =>
           Right(TransformerBodyTree(localImplicitTreeF.callTransform(srcPrefixTree), isWrapped = true))
         case (None, Some(localImplicitTree)) =>


### PR DESCRIPTION
Sometimes there is necessary to define TransformerF and Transformer rules that have intersected signatures. Current mechanism of TransformerF try to find both Transformer and TransformerF instances and it's not able to define priority using common Scala implicit priority hacks. It seems logical to me to choose Transformer instance as more priority and don't fail with compilation error on ambiguity. but if it's not possible because it breaks backward compatibility, maybe we can define special flag for this (but I'm not sure about adding this flag to FlagsDsl, because it can be used only for intoF).

Example of ambiguity is presented in tests, Coercible is analog of type class from newtype lib.

WDYT, @krzemin ?