### PR TITLE
Add a short-circuiting version of TransformerFSupport for Either

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/TransformerFSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/TransformerFSupport.scala
@@ -102,6 +102,8 @@ object TransformerFSupport {
 
   /** `TransformerFSupport` instance for `Either[C[E], +*]`.
     *
+    * For a short-circuiting instance see [[failfast.TransformerFEitherShortCircuitingSupport]]
+    *
     * @param ef factory for error accumulator collection
     * @tparam E error type
     * @tparam C error accumulator type constructor

--- a/chimney/src/main/scala/io/scalaland/chimney/failfast.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/failfast.scala
@@ -1,0 +1,40 @@
+package io.scalaland.chimney
+
+import scala.collection.compat.Factory
+
+object failfast {
+
+  /** `TransformerFSupport` instance for `Either[E, +*]` that fails with first encountered error instead of accumulating like
+    * [[TransformerFSupport.TransformerFEitherErrorAccumulatingSupport]] does.
+    *
+    * @tparam E error type
+    */
+  implicit def TransformerFEitherShortCircuitingSupport[E]: TransformerFSupport[Either[E, +*]] =
+    new TransformerFSupport[Either[E, +*]] {
+
+      override def pure[A](value: A): Either[E, A] = Right(value)
+
+      override def product[A, B](fa: Either[E, A], fb: => Either[E, B]): Either[E, (A, B)] = {
+        fa.flatMap(a => fb.map((a, _)))
+      }
+
+      override def map[A, B](fa: Either[E, A], f: A => B): Either[E, B] = {
+        fa.map(f)
+      }
+
+      override def traverse[M, A, B](it: Iterator[A], f: A => Either[E, B])(
+          implicit fac: Factory[B, M]
+      ): Either[E, M] = {
+        val bs = fac.newBuilder
+        while (it.hasNext) {
+          f(it.next()) match {
+            case Left(err) => return Left(err)
+            case Right(b) =>
+              bs += b
+          }
+        }
+        Right(bs.result())
+      }
+    }
+
+}


### PR DESCRIPTION
A short-circuiting version of `TransformerFSupport[Either[E, +*]]` can be very useful and convenient if your code doesn't particularly care what exactly happened and just needs to know if the conversion failed or not. 

I put it in a separate object, so this is a compatible change and requires the user to opt-in via an import.