### PR TITLE
Extract internal *Definition methods to common trait

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -16,7 +16,8 @@ import scala.language.experimental.macros
 final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: TransformerFlags](
     val overrides: Map[String, Any],
     val instances: Map[(String, String), Any]
-) extends FlagsDsl[Lambda[`F1 <: TransformerFlags` => TransformerDefinition[From, To, C, F1]], Flags] {
+) extends FlagsDsl[Lambda[`F1 <: TransformerFlags` => TransformerDefinition[From, To, C, F1]], Flags]
+    with TransformerDefinitionCommons[Lambda[`C1 <: TransformerCfg` => TransformerDefinition[From, To, C1, Flags]]] {
 
   /** Lifts current transformer definition with provided type constructor `F`.
     *
@@ -143,19 +144,6 @@ final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: Transf
   ): Transformer[From, To] =
     macro TransformerBlackboxMacros.buildTransformerImpl[From, To, C, Flags, ScopeFlags]
 
-  /** Used internally by macro. Please don't use in your code.
-    */
-  def __refineConfig[C1 <: TransformerCfg]: TransformerDefinition[From, To, C1, Flags] =
-    this.asInstanceOf[TransformerDefinition[From, To, C1, Flags]]
-
-  /** Used internally by macro. Please don't use in your code.
-    */
-  def __addOverride(key: String, value: Any): TransformerDefinition[From, To, C, Flags] =
-    new TransformerDefinition(overrides.updated(key, value), instances)
-
-  /** Used internally by macro. Please don't use in your code.
-    */
-  def __addInstance(from: String, to: String, value: Any): TransformerDefinition[From, To, C, Flags] =
-    new TransformerDefinition(overrides, instances.updated((from, to), value))
-
+  override protected def updated(newOverrides: Map[String, Any], newInstances: Map[(String, String), Any]): this.type =
+    new TransformerDefinition(newOverrides, newInstances).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.TransformerCfg
 
-trait TransformerDefinitionCommons[ChangeCfg[_ <: TransformerCfg]] {
+trait TransformerDefinitionCommons[UpdateCfg[_ <: TransformerCfg]] {
 
   val overrides: Map[String, Any]
   val instances: Map[(String, String), Any]
@@ -13,8 +13,8 @@ trait TransformerDefinitionCommons[ChangeCfg[_ <: TransformerCfg]] {
 
   /** Used internally by macro. Please don't use in your code.
     */
-  def __refineConfig[C1 <: TransformerCfg]: ChangeCfg[C1] =
-    this.asInstanceOf[ChangeCfg[C1]]
+  def __refineConfig[C1 <: TransformerCfg]: UpdateCfg[C1] =
+    this.asInstanceOf[UpdateCfg[C1]]
 
   /** Used internally by macro. Please don't use in your code.
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -1,0 +1,28 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.TransformerCfg
+
+trait TransformerDefinitionCommons[ChangeCfg[_ <: TransformerCfg]] {
+
+  val overrides: Map[String, Any]
+  val instances: Map[(String, String), Any]
+
+  protected def updated(newOverrides: Map[String, Any], newInstances: Map[(String, String), Any]): this.type
+
+  // used by generated code to help debugging
+
+  /** Used internally by macro. Please don't use in your code.
+    */
+  def __refineConfig[C1 <: TransformerCfg]: ChangeCfg[C1] =
+    this.asInstanceOf[ChangeCfg[C1]]
+
+  /** Used internally by macro. Please don't use in your code.
+    */
+  def __addOverride(key: String, value: Any): this.type =
+    updated(overrides.updated(key, value), instances)
+
+  /** Used internally by macro. Please don't use in your code.
+    */
+  def __addInstance(from: String, to: String, value: Any): this.type =
+    updated(overrides, instances.updated((from, to), value))
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
@@ -16,7 +16,8 @@ import scala.language.experimental.macros
 final class TransformerFDefinition[F[+_], From, To, C <: TransformerCfg, Flags <: TransformerFlags](
     val overrides: Map[String, Any],
     val instances: Map[(String, String), Any]
-) extends FlagsDsl[Lambda[`F1 <: TransformerFlags` => TransformerFDefinition[F, From, To, C, F1]], Flags] {
+) extends FlagsDsl[Lambda[`F1 <: TransformerFlags` => TransformerFDefinition[F, From, To, C, F1]], Flags]
+    with TransformerDefinitionCommons[Lambda[`C1 <: TransformerCfg` => TransformerFDefinition[F, From, To, C1, Flags]]] {
 
   /** Use `value` provided here for field picked using `selector`.
     *
@@ -140,18 +141,6 @@ final class TransformerFDefinition[F[+_], From, To, C <: TransformerCfg, Flags <
   ): TransformerF[F, From, To] =
     macro TransformerBlackboxMacros.buildTransformerFImpl[F, From, To, C, Flags, ScopeFlags]
 
-  /** Used internally by macro. Please don't use in your code.
-    */
-  def __refineConfig[C1 <: TransformerCfg]: TransformerFDefinition[F, From, To, C1, Flags] =
-    this.asInstanceOf[TransformerFDefinition[F, From, To, C1, Flags]]
-
-  /** Used internally by macro. Please don't use in your code.
-    */
-  def __addOverride(key: String, value: Any): TransformerFDefinition[F, From, To, C, Flags] =
-    new TransformerFDefinition(overrides.updated(key, value), instances)
-
-  /** Used internally by macro. Please don't use in your code.
-    */
-  def __addInstance(from: String, to: String, value: Any): TransformerFDefinition[F, From, To, C, Flags] =
-    new TransformerFDefinition(overrides, instances.updated((from, to), value))
+  override protected def updated(newOverrides: Map[String, Any], newInstances: Map[(String, String), Any]): this.type =
+    new TransformerFDefinition(newOverrides, newInstances).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -78,6 +78,9 @@ trait TransformerConfigSupport extends MacroUtils {
 
     import io.scalaland.chimney.internal.TransformerCfg._
 
+    // We cannot get typeOf[HigherKind] directly, but we can get the typeOf[ExistentialType]
+    // and extract type constructor out of it.
+
     val emptyT: Type = typeOf[Empty]
     val fieldConstT: Type = typeOf[FieldConst[_, _]].typeConstructor
     val fieldConstFT: Type = typeOf[FieldConstF[_, _]].typeConstructor


### PR DESCRIPTION
Extract internal `Definition` methods used by macros to a separate trait.