### PR TITLE
Refactor: explicit derivation target ADT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ val settings = Seq(
     "-Xlint:stars-align",
     "-Xlint:type-parameter-shadow",
     "-Ywarn-unused:locals",
+    "-Ywarn-unused:imports",
     "-Ywarn-macros:after",
     "-Xfatal-warnings",
     "-language:higherKinds"

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
@@ -2,8 +2,6 @@ package io.scalaland.chimney
 
 import io.scalaland.chimney.internal.{PatcherCfg, TransformerCfg, TransformerFlags}
 
-import scala.language.experimental.macros
-
 /** Main object to import in order to use Chimney's features
   */
 package object dsl {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
@@ -78,15 +78,15 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils {
           Some {
             target -> TransformerBodyTree(
               config.transformerDefinitionPrefix.accessOverriddenConstValue(target.name, target.tpe),
-              isWrapped = false
+              DerivationTarget.TotalTransformer
             )
           }
-        case Some(FieldOverride.ConstF) if config.wrapperType.isDefined =>
-          val fTargetTpe = config.wrapperType.get.applyTypeArg(target.tpe)
+        case Some(FieldOverride.ConstF) if config.derivationTarget.isInstanceOf[DerivationTarget.LiftedTransformer] =>
+          val fTargetTpe = config.derivationTarget.targetType(target.tpe)
           Some {
             target -> TransformerBodyTree(
               config.transformerDefinitionPrefix.accessOverriddenConstValue(target.name, fTargetTpe),
-              isWrapped = true
+              config.derivationTarget
             )
           }
         case Some(FieldOverride.Computed) =>
@@ -95,17 +95,18 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils {
               config.transformerDefinitionPrefix
                 .accessOverriddenComputedFunction(target.name, From, target.tpe)
                 .callUnaryApply(srcPrefixTree),
-              isWrapped = false
+              DerivationTarget.TotalTransformer
             )
           }
-        case Some(FieldOverride.ComputedF) if config.wrapperType.isDefined =>
-          val fTargetTpe = config.wrapperType.get.applyTypeArg(target.tpe)
+        case Some(FieldOverride.ComputedF)
+            if config.derivationTarget.isInstanceOf[DerivationTarget.LiftedTransformer] =>
+          val fTargetTpe = config.derivationTarget.targetType(target.tpe)
           Some {
             target -> TransformerBodyTree(
               config.transformerDefinitionPrefix
                 .accessOverriddenComputedFunction(target.name, From, fTargetTpe)
                 .callUnaryApply(srcPrefixTree),
-              isWrapped = true
+              config.derivationTarget
             )
           }
         case _ =>
@@ -127,21 +128,21 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils {
         if (config.flags.processDefaultValues && To.isCaseClass) {
           targetCaseClassDefaults
             .get(target.name)
-            .map(defaultValueTree => target -> TransformerBodyTree(defaultValueTree, isWrapped = false))
+            .map(defaultValueTree => target -> TransformerBodyTree(defaultValueTree, DerivationTarget.TotalTransformer))
         } else {
           None
         }
 
       def optionNoneFallback =
         if (config.flags.optionDefaultsToNone && isOption(target.tpe)) {
-          Some(target -> TransformerBodyTree(q"_root_.scala.None", isWrapped = false))
+          Some(target -> TransformerBodyTree(q"_root_.scala.None", DerivationTarget.TotalTransformer))
         } else {
           None
         }
 
       def unitFallback =
         if (isUnit(target.tpe)) {
-          Some(target -> TransformerBodyTree(q"()", isWrapped = false))
+          Some(target -> TransformerBodyTree(q"()", DerivationTarget.TotalTransformer))
         } else {
           None
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
@@ -57,9 +57,7 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils {
           fromGetters
             .map(lookupAccessor(config, lookupName, wasRenamed, From))
             .find(_ != AccessorResolution.NotFound)
-            .headOption
             .getOrElse(AccessorResolution.NotFound)
-
         }
       }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/Model.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/Model.scala
@@ -17,7 +17,10 @@ trait Model extends TransformerConfigSupport {
       Target(ms.canonicalName, ms.resultTypeIn(site))
   }
 
-  case class TransformerBodyTree(tree: Tree, isWrapped: Boolean)
+  case class TransformerBodyTree(tree: Tree, target: DerivationTarget) {
+    def isTotalTarget: Boolean = target == DerivationTarget.TotalTransformer
+    def isLiftedTarget: Boolean = target.isInstanceOf[DerivationTarget.LiftedTransformer]
+  }
 
   sealed trait AccessorResolution extends Product with Serializable {
     def isResolved: Boolean

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/PatcherMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/PatcherMacros.scala
@@ -12,7 +12,7 @@ trait PatcherMacros extends PatcherConfiguration with TransformerMacros {
 
   def expandPatch[T: WeakTypeTag, Patch: WeakTypeTag, C: WeakTypeTag]: Tree = {
     val C = weakTypeOf[C]
-    val piName = TermName(c.freshName("pi"))
+    val piName = freshTermName("pi")
     val config = capturePatcherConfig(C)
 
     val derivedPatcherTree = genPatcher[T, Patch](config).tree

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
@@ -14,7 +14,7 @@ trait TargetConstructorMacros extends Model {
 
   def mkNewJavaBean(classTpe: Type, argsMapping: Iterable[(Target, Tree)]): Tree = {
 
-    val fn = TermName(c.freshName(classTpe.typeSymbol.name.decodedName.toString.toLowerCase))
+    val fn = freshTermName(classTpe)
 
     val objCreation = q"val $fn = new $classTpe"
     val setterInvocations = argsMapping.map {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -2,7 +2,6 @@ package io.scalaland.chimney.internal.macros
 
 import io.scalaland.chimney.internal.utils.MacroUtils
 
-import scala.language.existentials
 import scala.reflect.macros.blackbox
 
 trait TransformerConfigSupport extends MacroUtils {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -3,7 +3,6 @@ package io.scalaland.chimney.internal.macros
 import io.scalaland.chimney.internal._
 import io.scalaland.chimney.internal.utils.EitherUtils
 
-import scala.annotation.unused
 import scala.reflect.macros.blackbox
 
 trait TransformerMacros extends MappingMacros with TargetConstructorMacros with EitherUtils {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -42,7 +42,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](@unused tcTree: Tree, derivationTarget: DerivationTarget): Tree = {
+  ](derivationTarget: DerivationTarget): Tree = {
     val tiName = freshTermName("ti")
 
     val config = readConfig[C, InstanceFlags, ScopeFlags]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -25,8 +25,8 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     if (!config.valueLevelAccessNeeded) {
       genTransformer[From, To](config)
     } else {
-      val tdName = TermName(c.freshName("td"))
-      val derivedTransformer = genTransformer[From, To](config.copy(transformerDefinitionPrefix = q"$tdName"))
+      val tdName = freshTermName("td")
+      val derivedTransformer = genTransformer[From, To](config.withTransformerDefinitionPrefix(q"$tdName"))
 
       q"""
         val $tdName = ${c.prefix.tree}
@@ -42,7 +42,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
   ](tcTree: Tree, derivationTarget: DerivationTarget): Tree = {
-    val tiName = TermName(c.freshName("ti"))
+    val tiName = freshTermName("ti")
 
     val config = readConfig[C, InstanceFlags, ScopeFlags]
       .withTransformerDefinitionPrefix(q"$tiName.td")

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -823,10 +823,6 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     inferImplicitTpe(searchTypeTree, macrosDisabled = false).filterNot(isDeriving)
   }
 
-  def findTransformerErrorPathSupportOpt(wrapperType: Option[Type]): Option[Tree] = {
-    wrapperType.flatMap(findTransformerErrorPathSupport)
-  }
-
   def findTransformerErrorPathSupport(wrapperType: Type): Option[Tree] = {
     inferImplicitTpe(tq"_root_.io.scalaland.chimney.TransformerFErrorPathSupport[$wrapperType]", macrosDisabled = true)
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -3,6 +3,7 @@ package io.scalaland.chimney.internal.macros
 import io.scalaland.chimney.internal._
 import io.scalaland.chimney.internal.utils.EitherUtils
 
+import scala.annotation.unused
 import scala.reflect.macros.blackbox
 
 trait TransformerMacros extends MappingMacros with TargetConstructorMacros with EitherUtils {
@@ -41,7 +42,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](tcTree: Tree, derivationTarget: DerivationTarget): Tree = {
+  ](@unused tcTree: Tree, derivationTarget: DerivationTarget): Tree = {
     val tiName = freshTermName("ti")
 
     val config = readConfig[C, InstanceFlags, ScopeFlags]
@@ -51,7 +52,6 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     val derivedTransformerTree = genTransformer[From, To](config)
 
     q"""
-       val _ = $tcTree // hack to avoid unused warnings
        val $tiName = ${c.prefix.tree}
        ${derivedTransformerTree.callTransform(q"$tiName.source")}
     """

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -865,8 +865,8 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       Seq(
         NotSupportedTransformerDerivation(
           toFieldName(srcPrefixTree),
-          fromTpe.typeSymbol.fullName.toString,
-          toTpe.typeSymbol.fullName.toString
+          fromTpe.typeSymbol.fullName,
+          toTpe.typeSymbol.fullName
         )
       )
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -17,14 +17,10 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](
-      tfsTree: Tree = EmptyTree,
-      wrapperType: Option[Type] = None
-  ): Tree = {
-    val config = readConfig[C, InstanceFlags, ScopeFlags](tfsTree).copy(
-      definitionScope = Some((weakTypeOf[From], weakTypeOf[To])),
-      wrapperErrorPathSupportInstance = findTransformerErrorPathSupport(wrapperType)
-    )
+  ](derivationTarget: DerivationTarget): Tree = {
+    val config = readConfig[C, InstanceFlags, ScopeFlags]
+      .withDefinitionScope(weakTypeOf[From], weakTypeOf[To])
+      .withDerivationTarget(derivationTarget)
 
     if (!config.valueLevelAccessNeeded) {
       genTransformer[From, To](config)
@@ -45,17 +41,12 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](
-      tcTree: Tree,
-      tfsTree: Tree = EmptyTree,
-      wrapperType: Option[Type] = None
-  ): Tree = {
+  ](tcTree: Tree, derivationTarget: DerivationTarget): Tree = {
     val tiName = TermName(c.freshName("ti"))
 
-    val config = readConfig[C, InstanceFlags, ScopeFlags](tfsTree).copy(
-      transformerDefinitionPrefix = q"$tiName.td",
-      wrapperErrorPathSupportInstance = findTransformerErrorPathSupport(wrapperType)
-    )
+    val config = readConfig[C, InstanceFlags, ScopeFlags]
+      .withTransformerDefinitionPrefix(q"$tiName.td")
+      .withDerivationTarget(derivationTarget)
 
     val derivedTransformerTree = genTransformer[From, To](config)
 
@@ -78,8 +69,8 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     genTransformerTree(srcName, config)(From, To) match {
 
       case Right(transformerTree) =>
-        config.wrapperType match {
-          case Some(f) =>
+        config.derivationTarget match {
+          case DerivationTarget.LiftedTransformer(f, _, _) =>
             q"""
                new _root_.io.scalaland.chimney.TransformerF[$f, $From, $To] {
                  def transform($srcName: $From): ${f.applyTypeArg(To)} = {
@@ -88,7 +79,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
                }
             """
 
-          case None =>
+          case DerivationTarget.TotalTransformer =>
             q"""
                new _root_.io.scalaland.chimney.Transformer[$From, $To] {
                  def transform($srcName: $From): $To = {
@@ -118,9 +109,13 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     val srcPrefixTree = Ident(TermName(srcName.decodedName.toString))
 
     resolveTransformerBody(srcPrefixTree, config)(From, To).map {
-      case TransformerBodyTree(tree, false) if config.wrapperType.isDefined =>
-        q"${config.wrapperSupportInstance}.pure[$To]($tree)"
-      case TransformerBodyTree(tree, _) => tree
+      case TransformerBodyTree(tree, derivedTarget) =>
+        (config.derivationTarget, derivedTarget) match {
+          case (DerivationTarget.LiftedTransformer(_, wrapperSupportInstance, _), DerivationTarget.TotalTransformer) =>
+            q"${wrapperSupportInstance}.pure[$To]($tree)"
+          case _ =>
+            tree
+        }
     }
   }
 
@@ -177,7 +172,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       config: TransformerConfig
   ): Either[Seq[TransformerDerivationError], Tree] = {
     Right {
-      mkTransformerBodyTree0(config)(srcPrefixTree)
+      mkTransformerBodyTree0(config.derivationTarget)(srcPrefixTree)
     }
   }
 
@@ -192,7 +187,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     From.valueClassMember
       .map { member =>
         Right {
-          mkTransformerBodyTree0(config) {
+          mkTransformerBodyTree0(config.derivationTarget) {
             q"$srcPrefixTree.${member.name}"
           }
         }
@@ -214,7 +209,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       To: Type
   ): Either[Seq[TransformerDerivationError], Tree] = {
     Right {
-      mkTransformerBodyTree0(config) {
+      mkTransformerBodyTree0(config.derivationTarget) {
         q"new $To($srcPrefixTree)"
       }
     }
@@ -244,7 +239,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       resolveRecursiveTransformerBody(innerSrcPrefix, config.rec)(fromInnerT, To)
         .map { innerTransformerBody =>
           val fn = freshTermName(innerSrcPrefix).toString
-          mkTransformerBodyTree1(To, Target(fn, To), innerTransformerBody, config) { tree =>
+          mkTransformerBodyTree1(To, Target(fn, To), innerTransformerBody, config.derivationTarget) { tree =>
             q"($tree)"
           }
         }
@@ -265,17 +260,20 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       val fn = Ident(freshTermName(srcPrefixTree))
       resolveRecursiveTransformerBody(fn, config.rec)(fromInnerT, toInnerT)
         .map {
-          case TransformerBodyTree(innerTree, false) =>
-            mkTransformerBodyTree0(config) {
+          case TransformerBodyTree(innerTree, DerivationTarget.TotalTransformer) =>
+            mkTransformerBodyTree0(config.derivationTarget) {
               q"$srcPrefixTree.map(($fn: $fromInnerT) => $innerTree)"
             }
 
-          case TransformerBodyTree(innerTree, true) =>
+          case TransformerBodyTree(
+              innerTree,
+              DerivationTarget.LiftedTransformer(wrapperType, wrapperSupportInstance, _)
+              ) =>
             q"""
-              $srcPrefixTree.fold[${config.wrapperType.get.applyTypeArg(To)}](
-                ${config.wrapperSupportInstance}.pure(Option.empty[$toInnerT])
+              $srcPrefixTree.fold[${wrapperType.applyTypeArg(To)}](
+                ${wrapperSupportInstance}.pure(Option.empty[$toInnerT])
               )(
-                ($fn: $fromInnerT) => ${config.wrapperSupportInstance}.map($innerTree, Option.apply[$toInnerT])
+                ($fn: $fromInnerT) => ${wrapperSupportInstance}.map($innerTree, Option.apply[$toInnerT])
               )
             """
         }
@@ -296,15 +294,16 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     if (From <:< leftTpe && !(To <:< rightTpe)) {
       resolveRecursiveTransformerBody(q"$srcPrefixTree.value", config.rec)(fromLeftT, toLeftT)
         .map { tbt =>
-          mkTransformerBodyTree1(To, Target(fnL.name.toString, toLeftT), tbt, config) { leftArgTree =>
+          mkTransformerBodyTree1(To, Target(fnL.name.toString, toLeftT), tbt, config.derivationTarget) { leftArgTree =>
             q"new _root_.scala.util.Left($leftArgTree)"
           }
         }
     } else if (From <:< rightTpe && !(To <:< leftTpe)) {
       resolveRecursiveTransformerBody(q"$srcPrefixTree.value", config.rec)(fromRightT, toRightT)
         .map { tbt =>
-          mkTransformerBodyTree1(To, Target(fnR.name.toString, toRightT), tbt, config) { rightArgTree =>
-            q"new _root_.scala.util.Right($rightArgTree)"
+          mkTransformerBodyTree1(To, Target(fnR.name.toString, toRightT), tbt, config.derivationTarget) {
+            rightArgTree =>
+              q"new _root_.scala.util.Right($rightArgTree)"
           }
         }
     } else if (!(To <:< leftTpe) && !(To <:< rightTpe)) {
@@ -313,18 +312,20 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
 
       (leftTransformerE, rightTransformerE) match {
         case (Right(leftTbt), Right(rightTbt)) =>
-          val targetTpe = config.wrapperType.map(_.applyTypeArg(To)).getOrElse(To)
+          val targetTpe = config.derivationTarget.targetType(To)
           val leftN = freshTermName("left")
           val rightN = freshTermName("right")
 
-          val leftBody = mkTransformerBodyTree1(To, Target(leftN.toString, toLeftT), leftTbt, config) { leftArgTree =>
-            q"new _root_.scala.util.Left($leftArgTree)"
+          val leftBody = mkTransformerBodyTree1(To, Target(leftN.toString, toLeftT), leftTbt, config.derivationTarget) {
+            leftArgTree =>
+              q"new _root_.scala.util.Left($leftArgTree)"
           }
 
-          val rightBody = mkTransformerBodyTree1(To, Target(rightN.toString, toRightT), rightTbt, config) {
-            rightArgTree =>
-              q"new _root_.scala.util.Right($rightArgTree)"
-          }
+          val rightBody =
+            mkTransformerBodyTree1(To, Target(rightN.toString, toRightT), rightTbt, config.derivationTarget) {
+              rightArgTree =>
+                q"new _root_.scala.util.Right($rightArgTree)"
+            }
 
           Right {
             q"""
@@ -348,8 +349,15 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   )(From: Type, To: Type): Either[Seq[TransformerDerivationError], Tree] = {
     val ToInnerT = To.collectionInnerTpe
 
-    (config.wrapperErrorPathSupportInstance, config.wrapperType, ToInnerT.caseClassParams.map(_.resultTypeIn(ToInnerT))) match {
-      case (Some(errorPathSupport), Some(f), List(toKeyT, toValueT)) =>
+    (config.derivationTarget, ToInnerT.caseClassParams.map(_.resultTypeIn(ToInnerT))) match {
+      case (
+          DerivationTarget.LiftedTransformer(
+            wrapperType,
+            wrapperSupportInstance,
+            Some(wrapperErrorPathSupportInstance)
+          ),
+          List(toKeyT, toValueT)
+          ) =>
         val List(fromKeyT, fromValueT) = From.typeArgs
 
         val fnK = Ident(freshTermName("k"))
@@ -360,30 +368,35 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
 
         (keyTransformerE, valueTransformerE) match {
           case (Right(keyTransformer), Right(valueTransformer)) =>
-            val wrapper = config.wrapperSupportInstance
-            val WrappedToInnerT = f.applyTypeArg(ToInnerT)
+            val WrappedToInnerT = wrapperType.applyTypeArg(ToInnerT)
 
             val keyTransformerWithPath =
-              if (keyTransformer.isWrapped)
-                q"""$errorPathSupport.addPath[$toKeyT](
-                   ${keyTransformer.tree},
-                   _root_.io.scalaland.chimney.ErrorPathNode.MapKey($fnK)
-                 )"""
-              else q"$wrapper.pure[$toKeyT](${keyTransformer.tree})"
+              keyTransformer.target match {
+                case DerivationTarget.LiftedTransformer(_, _, _) =>
+                  q"""${wrapperErrorPathSupportInstance}.addPath[$toKeyT](
+                     ${keyTransformer.tree},
+                     _root_.io.scalaland.chimney.ErrorPathNode.MapKey($fnK)
+                   )"""
+                case DerivationTarget.TotalTransformer =>
+                  q"${wrapperSupportInstance}.pure[$toKeyT](${keyTransformer.tree})"
+              }
 
             val valueTransformerWithPath =
-              if (valueTransformer.isWrapped)
-                q"""$errorPathSupport.addPath[$toValueT](
-                    ${valueTransformer.tree},
-                    _root_.io.scalaland.chimney.ErrorPathNode.MapValue($fnK)
-                 )"""
-              else q"$wrapper.pure[$toValueT](${valueTransformer.tree})"
+              valueTransformer.target match {
+                case DerivationTarget.LiftedTransformer(_, _, _) =>
+                  q"""${wrapperErrorPathSupportInstance}.addPath[$toValueT](
+                      ${valueTransformer.tree},
+                      _root_.io.scalaland.chimney.ErrorPathNode.MapValue($fnK)
+                   )"""
+                case DerivationTarget.TotalTransformer =>
+                  q"${wrapperSupportInstance}.pure[$toValueT](${valueTransformer.tree})"
+              }
 
             Right(
-              q"""$wrapper.traverse[$To, $WrappedToInnerT, $ToInnerT](
+              q"""${wrapperSupportInstance}.traverse[$To, $WrappedToInnerT, $ToInnerT](
                   $srcPrefixTree.iterator.map[$WrappedToInnerT] {
                     case (${fnK.name}: $fromKeyT, ${fnV.name}: $fromValueT) =>
-                      $wrapper.product[$toKeyT, $toValueT](
+                      ${wrapperSupportInstance}.product[$toKeyT, $toValueT](
                         $keyTransformerWithPath,
                         $valueTransformerWithPath
                       )
@@ -395,8 +408,8 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
           case _ =>
             Left(keyTransformerE.left.getOrElse(Nil) ++ valueTransformerE.left.getOrElse(Nil))
         }
-
-      case _ => expandIterableOrArray(srcPrefixTree, config)(From, To)
+      case _ =>
+        expandIterableOrArray(srcPrefixTree, config)(From, To)
     }
   }
 
@@ -412,39 +425,32 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
 
     resolveRecursiveTransformerBody(fn, config.rec)(FromInnerT, ToInnerT)
       .map {
-        case TransformerBodyTree(innerTransformerTree, true) =>
-          if (config.wrapperType.isDefined) {
-            config.wrapperErrorPathSupportInstance match {
-              case Some(errorPathSupport) =>
-                val idx = Ident(freshTermName("idx"))
+        case TransformerBodyTree(
+            innerTransformerTree,
+            DerivationTarget.LiftedTransformer(_, wrapperSupportInstance, Some(wrapperErrorPathSupportInstance))
+            ) =>
+          val idx = Ident(freshTermName("idx"))
 
-                q"""${config.wrapperSupportInstance}.traverse[$To, ($FromInnerT, _root_.scala.Int), $ToInnerT](
-                  $srcPrefixTree.iterator.zipWithIndex,
-                  { case (${fn.name}: $FromInnerT, ${idx.name}: _root_.scala.Int) =>
-                    $errorPathSupport.addPath[$ToInnerT](
-                      $innerTransformerTree,
-                      _root_.io.scalaland.chimney.ErrorPathNode.Index($idx)
-                    )
-                  }
-                )
-              """
-              case None =>
-                q"""${config.wrapperSupportInstance}.traverse[$To, $FromInnerT, $ToInnerT](
-                  $srcPrefixTree.iterator,
-                  ($fn: $FromInnerT) => $innerTransformerTree
-                )
-              """
+          q"""${wrapperSupportInstance}.traverse[$To, ($FromInnerT, _root_.scala.Int), $ToInnerT](
+            $srcPrefixTree.iterator.zipWithIndex,
+            { case (${fn.name}: $FromInnerT, ${idx.name}: _root_.scala.Int) =>
+              ${wrapperErrorPathSupportInstance}.addPath[$ToInnerT](
+                $innerTransformerTree,
+                _root_.io.scalaland.chimney.ErrorPathNode.Index($idx)
+              )
             }
-
-          } else {
-            // this case is not possible due to resolveRecursiveTransformerBody semantics: it will not
-            // even search for lifted inner transformer when wrapper type is not requested
-            // $COVERAGE-OFF$
-            c.abort(c.enclosingPosition, "Impossible case!")
-            // $COVERAGE-ON$
-          }
-
-        case TransformerBodyTree(innerTransformerTree, false) =>
+          )
+          """
+        case TransformerBodyTree(
+            innerTransformerTree,
+            DerivationTarget.LiftedTransformer(_, wrapperSupportInstance, None)
+            ) =>
+          q"""${wrapperSupportInstance}.traverse[$To, $FromInnerT, $ToInnerT](
+            $srcPrefixTree.iterator,
+            ($fn: $FromInnerT) => $innerTransformerTree
+          )
+          """
+        case TransformerBodyTree(innerTransformerTree, DerivationTarget.TotalTransformer) =>
           def isTransformationIdentity = fn == innerTransformerTree
           def sameCollectionTypes = From.typeConstructor =:= To.typeConstructor
 
@@ -466,10 +472,11 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
                 .convertCollection(To, ToInnerT)
           }
 
-          if (config.wrapperType.isDefined) {
-            q"${config.wrapperSupportInstance}.pure($transformedCollectionTree)"
-          } else {
-            transformedCollectionTree
+          config.derivationTarget match {
+            case DerivationTarget.LiftedTransformer(_, wrapperSupportInstance, _) =>
+              q"${wrapperSupportInstance}.pure($transformedCollectionTree)"
+            case DerivationTarget.TotalTransformer =>
+              transformedCollectionTree
           }
       }
   }
@@ -504,7 +511,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
               targetNamedInstances.getOrElse(instName, Nil) match {
                 case List(matchingTargetTpe)
                     if (instSymbol.isModuleClass || instSymbol.isCaseClass) && matchingTargetTpe.typeSymbol.isModuleClass =>
-                  val tree = mkTransformerBodyTree0(config) {
+                  val tree = mkTransformerBodyTree0(config.derivationTarget) {
                     q"${matchingTargetTpe.typeSymbol.asClass.module}"
                   }
                   Right(cq"_: ${instSymbol.asType} => $tree")
@@ -558,30 +565,32 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       To: Type,
       config: TransformerConfig
   ): Option[Tree] = {
-    if (config.wrapperType.isDefined && config.coproductInstancesF.contains((From.typeSymbol, To))) {
-      Some(
-        mkCoproductInstance(
-          config.transformerDefinitionPrefix,
-          srcPrefixTree,
-          From.typeSymbol,
-          To,
-          config.wrapperType
-        )
-      )
-    } else if (config.coproductInstances.contains((From.typeSymbol, To))) {
-      Some(
-        mkTransformerBodyTree0(config) {
+    config.derivationTarget match {
+      case DerivationTarget.LiftedTransformer(_, _, _) if config.coproductInstancesF.contains((From.typeSymbol, To)) =>
+        Some(
           mkCoproductInstance(
             config.transformerDefinitionPrefix,
             srcPrefixTree,
             From.typeSymbol,
             To,
-            None
+            config.derivationTarget
           )
-        }
-      )
-    } else {
-      None
+        )
+
+      case _ if config.coproductInstances.contains((From.typeSymbol, To)) =>
+        Some(
+          mkTransformerBodyTree0(config.derivationTarget) {
+            mkCoproductInstance(
+              config.transformerDefinitionPrefix,
+              srcPrefixTree,
+              From.typeSymbol,
+              To,
+              DerivationTarget.TotalTransformer
+            )
+          }
+        )
+      case _ =>
+        None
     }
   }
 
@@ -598,7 +607,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
         val targets = To.caseClassParams.map(Target.fromField(_, To))
         val bodyTreeArgs = targets.map(target => transformerBodyPerTarget(target))
 
-        mkTransformerBodyTree(To, targets, bodyTreeArgs, config) { args =>
+        mkTransformerBodyTree(To, targets, bodyTreeArgs, config.derivationTarget) { args =>
           mkNewClass(To, args)
         }
       }
@@ -627,7 +636,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     targetTransformerBodiesMapping.map { transformerBodyPerTarget =>
       val bodyTreeArgs = targets.map(target => transformerBodyPerTarget(target))
 
-      mkTransformerBodyTree(To, targets, bodyTreeArgs, config) { args =>
+      mkTransformerBodyTree(To, targets, bodyTreeArgs, config.derivationTarget) { args =>
         mkNewClass(To, args)
       }
     }
@@ -646,7 +655,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     resolveTransformerBodyTreeFromAccessorsMapping(srcPrefixTree, accessorsMapping, From, To, config)
       .map { transformerBodyPerTarget =>
         val bodyTreeArgs = targets.map(target => transformerBodyPerTarget(target))
-        mkTransformerBodyTree(To, targets, bodyTreeArgs, config) { args =>
+        mkTransformerBodyTree(To, targets, bodyTreeArgs, config.derivationTarget) { args =>
           mkNewJavaBean(To, targets zip args)
         }
       }
@@ -724,15 +733,16 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       target.tpe
     )
 
-    (resolved, config.wrapperErrorPathSupportInstance) match {
-      case (Right(bodyTree), Some(errorPathSupport)) if bodyTree.isWrapped =>
+    (resolved, config.derivationTarget) match {
+      case (Right(bodyTree), DerivationTarget.LiftedTransformer(_, _, Some(errorPathSupport)))
+          if bodyTree.isLiftedTarget =>
         Right {
           TransformerBodyTree(
             q"""$errorPathSupport.addPath[${target.tpe}](
                  ${bodyTree.tree},
                  _root_.io.scalaland.chimney.ErrorPathNode.Accessor(${accessor.symbol.name.toString})
                )""",
-            isWrapped = true
+            config.derivationTarget
           )
         }
       case _ => resolved
@@ -750,33 +760,36 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       srcPrefixTree: Tree,
       config: TransformerConfig
   )(From: Type, To: Type): Either[Seq[TransformerDerivationError], TransformerBodyTree] = {
-    if (config.wrapperType.isDefined) {
-      val implicitTransformerF = resolveImplicitTransformer(config)(From, To)
-      val implicitTransformer = findLocalImplicitTransformer(From, To, None)
+    config.derivationTarget match {
+      case DerivationTarget.LiftedTransformer(wrapperType, _, _) =>
+        val implicitTransformerF = resolveImplicitTransformer(config)(From, To)
+        val implicitTransformer = findLocalImplicitTransformer(From, To, DerivationTarget.TotalTransformer)
 
-      (implicitTransformerF, implicitTransformer) match {
-        case (Some(localImplicitTreeF), Some(localImplicitTree)) =>
-          c.abort(
-            c.enclosingPosition,
-            s"""Ambiguous implicits while resolving Chimney recursive transformation:
-               |
-               |TransformerF[${config.wrapperType.get}, $From, $To]: $localImplicitTreeF
-               |Transformer[$From, $To]: $localImplicitTree
-               |
-               |Please eliminate ambiguity from implicit scope or use withFieldComputed/withFieldComputedF to decide which one should be used
-               |""".stripMargin
-          )
-        case (Some(localImplicitTreeF), None) =>
-          Right(TransformerBodyTree(localImplicitTreeF.callTransform(srcPrefixTree), isWrapped = true))
-        case (None, Some(localImplicitTree)) =>
-          Right(TransformerBodyTree(localImplicitTree.callTransform(srcPrefixTree), isWrapped = false))
-        case (None, None) =>
-          deriveTransformerTree(srcPrefixTree, config)(From, To)
-            .map(tree => TransformerBodyTree(tree, isWrapped = true))
-      }
-    } else {
-      expandTransformerTree(srcPrefixTree, config)(From, To)
-        .map(tree => TransformerBodyTree(tree, isWrapped = false))
+        (implicitTransformerF, implicitTransformer) match {
+          case (Some(localImplicitTreeF), Some(localImplicitTree)) =>
+            c.abort(
+              c.enclosingPosition,
+              s"""Ambiguous implicits while resolving Chimney recursive transformation:
+                 |
+                 |TransformerF[${wrapperType}, $From, $To]: $localImplicitTreeF
+                 |Transformer[$From, $To]: $localImplicitTree
+                 |
+                 |Please eliminate ambiguity from implicit scope or use withFieldComputed/withFieldComputedF to decide which one should be used
+                 |""".stripMargin
+            )
+          case (Some(localImplicitTreeF), None) =>
+            Right(TransformerBodyTree(localImplicitTreeF.callTransform(srcPrefixTree), config.derivationTarget))
+          case (None, Some(localImplicitTree)) =>
+            Right(
+              TransformerBodyTree(localImplicitTree.callTransform(srcPrefixTree), DerivationTarget.TotalTransformer)
+            )
+          case (None, None) =>
+            deriveTransformerTree(srcPrefixTree, config)(From, To)
+              .map(tree => TransformerBodyTree(tree, config.derivationTarget))
+        }
+      case DerivationTarget.TotalTransformer =>
+        expandTransformerTree(srcPrefixTree, config)(From, To)
+          .map(tree => TransformerBodyTree(tree, config.derivationTarget))
     }
   }
 
@@ -784,7 +797,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     if (config.definitionScope.contains((From, To))) {
       None
     } else {
-      findLocalImplicitTransformer(From, To, config.wrapperType)
+      findLocalImplicitTransformer(From, To, config.derivationTarget)
     }
   }
 
@@ -799,21 +812,23 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       }
   }
 
-  private def findLocalImplicitTransformer(From: Type, To: Type, wrapperType: Option[Type]): Option[Tree] = {
-    val searchTypeTree: Tree = wrapperType match {
-      case Some(f) =>
+  private def findLocalImplicitTransformer(From: Type, To: Type, derivationTarget: DerivationTarget): Option[Tree] = {
+    val searchTypeTree: Tree = derivationTarget match {
+      case DerivationTarget.LiftedTransformer(f, _, _) =>
         tq"_root_.io.scalaland.chimney.TransformerF[$f, $From, $To]"
-      case None =>
+      case DerivationTarget.TotalTransformer =>
         tq"_root_.io.scalaland.chimney.Transformer[$From, $To]"
     }
 
     inferImplicitTpe(searchTypeTree, macrosDisabled = false).filterNot(isDeriving)
   }
 
-  def findTransformerErrorPathSupport(wrapperType: Option[Type]): Option[Tree] = {
-    wrapperType.flatMap(tpe =>
-      inferImplicitTpe(tq"_root_.io.scalaland.chimney.TransformerFErrorPathSupport[$tpe]", macrosDisabled = true)
-    )
+  def findTransformerErrorPathSupportOpt(wrapperType: Option[Type]): Option[Tree] = {
+    wrapperType.flatMap(findTransformerErrorPathSupport)
+  }
+
+  def findTransformerErrorPathSupport(wrapperType: Type): Option[Tree] = {
+    inferImplicitTpe(tq"_root_.io.scalaland.chimney.TransformerFErrorPathSupport[$wrapperType]", macrosDisabled = true)
   }
 
   private def inferImplicitTpe(tpeTree: Tree, macrosDisabled: Boolean): Option[Tree] = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney
 import io.scalaland.chimney.internal.macros.TransformerMacros
 import io.scalaland.chimney.{TransformerF, TransformerFSupport}
 
+import scala.annotation.unused
 import scala.reflect.macros.blackbox
 
 class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacros {
@@ -16,7 +17,7 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       C: WeakTypeTag,
       Flags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](tc: c.Tree): c.Expr[chimney.Transformer[From, To]] = {
+  ](@unused tc: c.Tree): c.Expr[chimney.Transformer[From, To]] = {
     c.Expr[chimney.Transformer[From, To]](
       buildDefinedTransformer[From, To, C, Flags, ScopeFlags](DerivationTarget.TotalTransformer)
     )
@@ -31,7 +32,7 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       ScopeFlags: WeakTypeTag
   ](
       tfs: c.Expr[TransformerFSupport[F]],
-      tc: c.Tree
+      @unused tc: c.Tree
   ): c.Expr[TransformerF[F, From, To]] = {
     val wrapperType = extractWrapperType(weakTypeOf[C])
     val derivationTarget =
@@ -59,7 +60,7 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
   ](
-      tc: c.Tree,
+      @unused tc: c.Tree,
       tfs: c.Expr[TransformerFSupport[F]]
   ): c.Expr[F[To]] = {
     val wrapperType = extractWrapperType(weakTypeOf[C])

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
@@ -48,8 +48,8 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](tc: c.Tree): c.Expr[To] = {
-    c.Expr[To](expandTransform[From, To, C, InstanceFlags, ScopeFlags](tc, DerivationTarget.TotalTransformer))
+  ](@unused tc: c.Tree): c.Expr[To] = {
+    c.Expr[To](expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.TotalTransformer))
   }
 
   def transformFImpl[
@@ -66,7 +66,7 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
     val wrapperType = extractWrapperType(weakTypeOf[C])
     val derivationTarget =
       DerivationTarget.LiftedTransformer(wrapperType, tfs.tree, findTransformerErrorPathSupport(wrapperType))
-    c.Expr[F[To]](expandTransform[From, To, C, InstanceFlags, ScopeFlags](tc, derivationTarget))
+    c.Expr[F[To]](expandTransform[From, To, C, InstanceFlags, ScopeFlags](derivationTarget))
   }
 
   def deriveTransformerImpl[From: WeakTypeTag, To: WeakTypeTag]: c.Expr[chimney.Transformer[From, To]] = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/DslMacroUtils.scala
@@ -62,7 +62,7 @@ trait DslMacroUtils extends MacroUtils with TransformerConfigSupport {
       // with this hack, we can work around scalac bugs
 
       val (name, tree) = valTree
-      val fnTermName = TermName(c.freshName(name))
+      val fnTermName = freshTermName(name)
       val fnMapTree = Map(name -> Ident(fnTermName))
       q"""
         {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
@@ -34,14 +34,6 @@ trait MacroUtils extends CompanionUtils {
     def toSingletonTpe: ConstantType = c.internal.constantType(toNameConstant)
   }
 
-  type TypeConstructorTag[F[_]] = WeakTypeTag[F[Unit]]
-
-  object TypeConstructorTag {
-    def apply[F[_]: TypeConstructorTag]: Type = {
-      weakTypeOf[F[Unit]].typeConstructor
-    }
-  }
-
   implicit class TypeOps(t: Type) {
 
     def applyTypeArg(arg: Type): Type = {

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -264,7 +264,6 @@ object IssuesSpec extends TestSuite {
     }
 
     "fix issue #149" - {
-      import language.higherKinds
 
       "example 1" - {
         case class EntryId(id: Int)


### PR DESCRIPTION
This PR brings improved compile-time configuration management using explicit ADT that precisely defines whether which transformer target we're expanding (total `Transformer` or lifted `TransformerF`).

It should not bring any functional changes, but rather open a way for further refactors and code modularization & simplification.