### PR TITLE
Default values usage require explicit enabling (changed default setting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ sbt makeSite
 
 HTML Documentation should be generated at `target/sphinx/html/index.html`.
 
+Alternatively use Docker:
+
+```bash
+docker run --rm -v ./docs:/docs sphinxdoc/sphinx:3.2.1 bash -c "pip install sphinx-rtd-theme && make html"
+```
 
 ## Thanks
 

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/FlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/FlagsDsl.scala
@@ -23,16 +23,16 @@ trait FlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags <: TransformerFlags] {
 
   /** Enable fallback to default case class values in `To` type.
     *
-    * @see [[https://scalalandio.github.io/chimney/transformers/default-values.html#disabling-default-values-in-generated-transformer]] for more details
+    * By default in such case derivation will fail. By enabling this flag, derivation will fallback to default value.
+    *
+    * @see [[https://scalalandio.github.io/chimney/transformers/default-values.html#enabling-default-values-in-generated-transformer]] for more details
     */
   def enableDefaultValues: UpdateFlag[Enable[DefaultValues, Flags]] =
     enableFlag[DefaultValues]
 
   /** Fail derivation if `From` type is missing field even if `To` has default value for it.
     *
-    * By default in such case derivation will fallback to default values.
-    *
-    * @see [[https://scalalandio.github.io/chimney/transformers/default-values.html#disabling-default-values-in-generated-transformer]] for more details
+    * @see [[https://scalalandio.github.io/chimney/transformers/default-values.html#enabling-default-values-in-generated-transformer]] for more details
     */
   def disableDefaultValues: UpdateFlag[Disable[DefaultValues, Flags]] =
     disableFlag[DefaultValues]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -174,7 +174,7 @@ trait TransformerConfigSupport extends MacroUtils {
 
   case class TransformerFlags(
       methodAccessors: Boolean = false,
-      processDefaultValues: Boolean = true,
+      processDefaultValues: Boolean = false,
       beanSetters: Boolean = false,
       beanGetters: Boolean = false,
       optionDefaultsToNone: Boolean = false,

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -114,8 +114,11 @@ object DslSpec extends TestSuite {
           }
 
           "not use None as default when other default value is set" - {
-            SomeFoo("foo").into[Foobar2].transform ==> Foobar2("foo", Some(42))
-            SomeFoo("foo").into[Foobar2].enableOptionDefaultsToNone.transform ==> Foobar2("foo", Some(42))
+            SomeFoo("foo").into[Foobar2].enableDefaultValues.transform ==> Foobar2("foo", Some(42))
+            SomeFoo("foo").into[Foobar2].enableDefaultValues.enableOptionDefaultsToNone.transform ==> Foobar2(
+              "foo",
+              Some(42)
+            )
           }
 
           "not compile if default value is missing and no .enableOptionDefaultsToNone" - {
@@ -199,6 +202,7 @@ object DslSpec extends TestSuite {
       case class Baahr(x: Int, y: Bar)
 
       "use default parameter value" - {
+        implicit val cfg = TransformerConfiguration.default.enableDefaultValues
 
         "field does not exists - the source" - {
           Foo(10).transformInto[Bar] ==> Bar(10, 30L)

--- a/docs/source/transformers/default-values.rst
+++ b/docs/source/transformers/default-values.rst
@@ -30,17 +30,17 @@ Providing the value manually has always a priority over the default.
   // Butterfly(5, "Steve", "yellow")
 
 
-Disabling default values in generated transformer
+Enabling default values in generated transformer
 -------------------------------------------------
 
-Using ``.disableDefaultValues`` operation it's possible to disable
-lookup for default values and require them always to be passed explicitly.
+Using ``.enableDefaultValues`` operation it's possible to enable
+lookup for default values and fallback to default when there is no transformer
+or config setting the value for field.
 
 .. code-block:: scala
 
   val steve = stevie
     .into[Butterfly]
-    .disableDefaultValues
     .transform
   // error: Chimney can't derive transformation from Catterpillar to Butterfly
   //
@@ -52,6 +52,11 @@ lookup for default values and require them always to be passed explicitly.
   //            .transform
   //            ^
 
+  // this one will succeed
+  val steve = stevie
+    .into[Butterfly]
+    .enableDefaultValues
+    .transform
 
 Default values for ``Option`` fields
 ------------------------------------

--- a/docs/source/transformers/default-values.rst
+++ b/docs/source/transformers/default-values.rst
@@ -7,6 +7,11 @@ field value source.
 Enabling default values in generated transformer
 ------------------------------------------------
 
+.. warning::
+
+  Before 0.7.0 default values was enabled by default. Due to feedback it was
+  changed to disabled by default for safety.
+
 Field's default value can be enabled as a target value when constructing
 target object. The support for them has to be explicitly enabled to avoid
 accidents.

--- a/docs/source/transformers/default-values.rst
+++ b/docs/source/transformers/default-values.rst
@@ -1,14 +1,15 @@
 Default values support
 ======================
 
-Chimney respects case classes' default values as a possible target
+Chimney allows case classes' default values as a possible target
 field value source.
 
-Automatic value provision
--------------------------
+Enabling default values in generated transformer
+------------------------------------------------
 
-Field's default value is automatically used as a target value when constructing
-target object.
+Field's default value can be enabled as a target value when constructing
+target object. The support for them has to be explicitly enabled to avoid
+accidents.
 
 .. code-block:: scala
 
@@ -17,31 +18,7 @@ target object.
 
   val stevie = Catterpillar(5, "Steve")
 
-  val steve = stevie.transformInto[Butterfly]
-  // Butterfly(5, "Steve", "purple")
-
-Providing the value manually has always a priority over the default.
-
-.. code-block:: scala
-
-  val steve = stevie.into[Butterfly]
-    .withFieldConst(_.wingsColor, "yellow")
-    .transform
-  // Butterfly(5, "Steve", "yellow")
-
-
-Enabling default values in generated transformer
--------------------------------------------------
-
-Using ``.enableDefaultValues`` operation it's possible to enable
-lookup for default values and fallback to default when there is no transformer
-or config setting the value for field.
-
-.. code-block:: scala
-
-  val steve = stevie
-    .into[Butterfly]
-    .transform
+  //val steve = stevie.transformInto[Butterfly] // fails with
   // error: Chimney can't derive transformation from Catterpillar to Butterfly
   //
   // Butterfly
@@ -51,12 +28,19 @@ or config setting the value for field.
   //
   //            .transform
   //            ^
+  val steve = stevie.into[Butterfly].enableDefaultValues.transform
+  // Butterfly(5, "Steve", "purple")
 
-  // this one will succeed
-  val steve = stevie
-    .into[Butterfly]
+Providing the value manually has always a priority over the default.
+
+.. code-block:: scala
+
+  val steve = stevie.into[Butterfly]
     .enableDefaultValues
+    .withFieldConst(_.wingsColor, "yellow")
     .transform
+  // Butterfly(5, "Steve", "yellow")
+
 
 Default values for ``Option`` fields
 ------------------------------------

--- a/docs/source/transformers/default-values.rst
+++ b/docs/source/transformers/default-values.rst
@@ -9,8 +9,8 @@ Enabling default values in generated transformer
 
 .. warning::
 
-  Before 0.7.0 default values was enabled by default. Due to feedback it was
-  changed to disabled by default for safety.
+  Prior to version 0.7.0 fallback to default values was automatically enabled
+  and required explicit disabling.
 
 Field's default value can be enabled as a target value when constructing
 target object. The support for them has to be explicitly enabled to avoid


### PR DESCRIPTION
Due to a lot of issues caused by default values enabled by default (vide https://github.com/scalalandio/chimney/issues/176#issuecomment-719835155, https://github.com/scalalandio/chimney/issues/192, https://github.com/scalalandio/chimney/issues/200), this PR changes the default setting to `.disableDefaultValues`. From now `.enableDefaultValues` should be set explicitly.

This is a breaking change, but one which aims for more safety.