### PR TITLE
Improve support for value classes

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
@@ -20,6 +20,16 @@ trait TypeTestUtils extends MacroUtils {
     to.isValueClass && to.valueClassMember.exists(_.returnType =:= from)
   }
 
+  def fromValueClassToValueClass(from: Type, to: Type): Boolean = {
+    from.isValueClass &&
+    to.isValueClass && {
+      for {
+        fromValueMember <- from.valueClassMember
+        toValueMember <- to.valueClassMember
+      } yield fromValueMember.returnType =:= toValueMember.returnType
+    }.contains(true)
+  }
+
   def isOption(t: Type): Boolean = {
     t <:< optionTpe
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DslSpec.scala
@@ -428,6 +428,13 @@ object DslSpec extends TestSuite {
         UserDTO("100", "abc").transformInto[User] ==>
           User("100", UserName("abc"))
       }
+
+      "transforming value class to a value class" - {
+
+        UserName("Batman").transformInto[UserNameAlias] ==> UserNameAlias("Batman")
+        User("100", UserName("abc")).transformInto[UserAlias] ==>
+          UserAlias("100", UserNameAlias("abc"))
+      }
     }
 
     "support common data types" - {
@@ -1089,10 +1096,13 @@ object VCDomain1 {
 
   case class UserName(value: String) extends AnyVal
 
+  case class UserNameAlias(value: String) extends AnyVal
+
   case class UserDTO(id: String, name: String)
 
   case class User(id: String, name: UserName)
 
+  case class UserAlias(id: String, name: UserNameAlias)
 }
 
 object Poly {


### PR DESCRIPTION
Implementation of #249

- [x] Add rewrapping value of one value class to another value class if value is the same type.
      ```case class Foo(t: T) extends AnyVal => case class Bar(t: T) extends AnyVal```

- [ ] Add unwrapping of a value class's value of one type(`T`) to another type(`S`) if `T => S` transformer exists.
       ```case class Foo(t: T) extends AnyVal => S```
       
- [ ] Add wrapping a value of one type(`T`) to value class of another type(`S`) if `T => S` transformer exists.
       ```T => case class Foo(s: S)```
       
- [ ]  Add rewrapping value(type `T`) of one value class to another value class(with value of type `S`  if `T => S` transformer exists.
        ```case class Foo(t: T) => case class Bar(s: S)```