### PR TITLE
Empty option rule for partial transformers

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/GenTrees.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/GenTrees.scala
@@ -76,6 +76,10 @@ trait GenTrees extends Model with TypeTestUtils with DslMacroUtils {
 
     object PartialResult {
 
+      def empty: Tree = {
+        q"_root_.io.scalaland.chimney.partial.Result.fromEmpty"
+      }
+
       def value(valTree: Tree): Tree = {
         q"_root_.io.scalaland.chimney.partial.Result.Value($valTree)"
       }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -214,7 +214,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
                 $srcPrefixTree
                   .map(($fn: ${From.typeArgs.head}) => $liftedTree)
                   .getOrElse(${Trees.PartialResult.empty})
-             """.debug
+             """
           }
       }
     } else {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -162,47 +162,64 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       srcPrefixTree: Tree,
       config: TransformerConfig
   )(From: Type, To: Type): Either[Seq[TransformerDerivationError], Tree] = {
-    if (isSubtype(From, To)) {
-      expandSubtypes(srcPrefixTree, config)
-    } else if (fromValueClassToType(From, To)) {
-      expandValueClassToType(srcPrefixTree, config)(From, To)
-    } else if (fromTypeToValueClass(From, To)) {
-      expandTypeToValueClass(srcPrefixTree, config)(From, To)
-    } else if (bothOptions(From, To)) {
-      expandOptions(srcPrefixTree, config)(From, To)
-    } else if (config.derivationTarget.isPartial
-               && !config.flags.unsafeOption
-               && isOption(From)
-               && !isOption(To)
-               && From.typeArgs.sizeIs == 1
-               && resolveRecursiveTransformerBody(srcPrefixTree, config.rec)(From.typeArgs.head, To).isRight) { // TODO: extract magic to TypeTestUtils
-      val fn = Ident(freshTermName("value"))
-      resolveRecursiveTransformerBody(q"$fn", config.rec)(From.typeArgs.head, To).map { tbt =>
-        val liftedTree = if (tbt.isTotalTarget) mkTransformerBodyTree0(config.derivationTarget)(tbt.tree) else tbt.tree
-        q"$srcPrefixTree.map(($fn: ${From.typeArgs.head}) => $liftedTree).getOrElse(${Trees.PartialResult.empty})".debug
-      }
-    } else if (isOption(To) && !To.typeArgs.headOption.exists(_.isSealedClass)) { // TODO: check for None?
-      expandTargetWrappedInOption(srcPrefixTree, config)(From, To)
-    } else if (config.flags.unsafeOption && isOption(From)) {
-      expandSourceWrappedInOption(srcPrefixTree, config)(From, To)
-    } else if (bothEithers(From, To)) {
-      expandEithers(srcPrefixTree, config)(From, To)
-    } else if (isMap(From)) {
-      expandFromMap(srcPrefixTree, config)(From, To)
-    } else if (bothOfIterableOrArray(From, To)) {
-      expandIterableOrArray(srcPrefixTree, config)(From, To)
-    } else if (isTuple(To)) {
-      expandDestinationTuple(srcPrefixTree, config)(From, To)
-    } else if (destinationCaseClass(To)) {
-      expandDestinationCaseClass(srcPrefixTree, config)(From, To)
-    } else if (config.flags.beanSetters && destinationJavaBean(To)) {
-      expandDestinationJavaBean(srcPrefixTree, config)(From, To)
-    } else if (bothSealedClasses(From, To)) {
-      expandSealedClasses(srcPrefixTree, config)(From, To)
-    } else {
-      notSupportedDerivation(srcPrefixTree, From, To)
-    }
 
+    expandPartialFromOptionToNonOption(srcPrefixTree, config)(From, To)
+      .getOrElse {
+        if (isSubtype(From, To)) {
+          expandSubtypes(srcPrefixTree, config)
+        } else if (fromValueClassToType(From, To)) {
+          expandValueClassToType(srcPrefixTree, config)(From, To)
+        } else if (fromTypeToValueClass(From, To)) {
+          expandTypeToValueClass(srcPrefixTree, config)(From, To)
+        } else if (bothOptions(From, To)) {
+          expandOptions(srcPrefixTree, config)(From, To)
+        } else if (isOption(To) && !To.typeArgs.headOption.exists(_.isSealedClass)) { // TODO: check for None?
+          expandTargetWrappedInOption(srcPrefixTree, config)(From, To)
+        } else if (config.flags.unsafeOption && isOption(From)) {
+          expandSourceWrappedInOption(srcPrefixTree, config)(From, To)
+        } else if (bothEithers(From, To)) {
+          expandEithers(srcPrefixTree, config)(From, To)
+        } else if (isMap(From)) {
+          expandFromMap(srcPrefixTree, config)(From, To)
+        } else if (bothOfIterableOrArray(From, To)) {
+          expandIterableOrArray(srcPrefixTree, config)(From, To)
+        } else if (isTuple(To)) {
+          expandDestinationTuple(srcPrefixTree, config)(From, To)
+        } else if (destinationCaseClass(To)) {
+          expandDestinationCaseClass(srcPrefixTree, config)(From, To)
+        } else if (config.flags.beanSetters && destinationJavaBean(To)) {
+          expandDestinationJavaBean(srcPrefixTree, config)(From, To)
+        } else if (bothSealedClasses(From, To)) {
+          expandSealedClasses(srcPrefixTree, config)(From, To)
+        } else {
+          notSupportedDerivation(srcPrefixTree, From, To)
+        }
+      }
+  }
+
+  def expandPartialFromOptionToNonOption(
+      srcPrefixTree: Tree,
+      config: TransformerConfig
+  )(From: Type, To: Type): Option[Either[Seq[TransformerDerivationError], Tree]] = {
+    if (config.derivationTarget.isPartial && !config.flags.unsafeOption && fromOptionToNonOption(From, To)) {
+      Some {
+        val fn = Ident(freshTermName("value"))
+        resolveRecursiveTransformerBody(q"$fn", config.rec)(From.typeArgs.head, To)
+          .map { tbt =>
+            val liftedTree =
+              if (tbt.isPartialTarget) tbt.tree
+              else mkTransformerBodyTree0(config.derivationTarget)(tbt.tree)
+
+            q"""
+                $srcPrefixTree
+                  .map(($fn: ${From.typeArgs.head}) => $liftedTree)
+                  .getOrElse(${Trees.PartialResult.empty})
+             """.debug
+          }
+      }
+    } else {
+      None
+    }
   }
 
   def expandSubtypes(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
@@ -36,6 +36,10 @@ trait TypeTestUtils extends MacroUtils {
     iterableOrArray(from) && iterableOrArray(to)
   }
 
+  def fromOptionToNonOption(from: Type, to: Type): Boolean = {
+    isOption(from) && !isOption(to) && from.typeArgs.sizeIs == 1
+  }
+
   def isTuple(to: Type): Boolean =
     Seq(
       typeOf[Tuple1[_]],

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSdtLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSdtLibTypesSpec.scala
@@ -151,6 +151,57 @@ object PartialTransformerSdtLibTypesSpec extends TestSuite {
       }
     }
 
+    test("transform from Option-type into non-Option-type, using Total Transformer for inner type transformation") {
+
+      implicit val intPrinter: Transformer[Int, String] = _.toString
+
+      test("when option is non-empty") {
+        val result = Option(10).transformIntoPartial[String]
+
+        result.asOption ==> Some("10")
+        result.asEither ==> Right("10")
+        result.asErrorPathMessageStrings ==> Iterable.empty
+      }
+
+      test("when option is empty") {
+        val result = Option.empty[Int].transformIntoPartial[String]
+
+        result.asOption ==> None
+        result.asEither ==> Left(partial.Result.fromEmpty)
+        result.asErrorPathMessageStrings ==> Iterable(("", "empty value"))
+      }
+    }
+
+    test("transform from Option-type into non-Option-type, using Partial Transformer for inner type transformation") {
+
+      implicit val intPartialParser: PartialTransformer[String, Int] =
+        PartialTransformer(_.parseInt.toPartialResultOrString("bad int"))
+
+      test("when option is non-empty and inner is success") {
+        val result = Option("10").transformIntoPartial[Int]
+
+        result.asOption ==> Some(10)
+        result.asEither ==> Right(10)
+        result.asErrorPathMessageStrings ==> Iterable.empty
+      }
+
+      test("when option is non-empty and inner is failure") {
+        val result = Option("abc").transformIntoPartial[Int]
+
+        result.asOption ==> None
+        result.asEither ==> Left(partial.Result.fromErrorString("bad int"))
+        result.asErrorPathMessageStrings ==> Iterable("" -> "bad int")
+      }
+
+      test("when option is empty") {
+        val result = Option.empty[String].transformIntoPartial[Int]
+
+        result.asOption ==> None
+        result.asEither ==> Left(partial.Result.fromEmpty)
+        result.asErrorPathMessageStrings ==> Iterable(("", "empty value"))
+      }
+    }
+
     test("transform from Either-type into Either-type, using Total Transformer for inner types transformation") {
       implicit val intPrinter: Transformer[Int, String] = _.toString
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSdtLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSdtLibTypesSpec.scala
@@ -186,7 +186,7 @@ object PartialTransformerSdtLibTypesSpec extends TestSuite {
       }
 
       test("when option is non-empty and inner is failure") {
-        val result = Option("abc").transformIntoPartial[Int]
+        val result = Some("abc").transformIntoPartial[Int]
 
         result.asOption ==> None
         result.asEither ==> Left(partial.Result.fromErrorString("bad int"))
@@ -194,7 +194,7 @@ object PartialTransformerSdtLibTypesSpec extends TestSuite {
       }
 
       test("when option is empty") {
-        val result = Option.empty[String].transformIntoPartial[Int]
+        val result = (None: Option[String]).transformIntoPartial[Int]
 
         result.asOption ==> None
         result.asEither ==> Left(partial.Result.fromEmpty)


### PR DESCRIPTION
The rule essentially provides partial transformation from `Option[A]` to `B`, where:
- `B` is non-optional type
- there exists transformation between `A` and `B` types (partial or total)

It handles empty option case as `partial.Result.fromEmpty`.
