### PR TITLE
Vector based runtime dsl

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.dsl.PartialTransformerDefinition
+import io.scalaland.chimney.dsl.{PartialTransformerDefinition, TransformerDefinitionCommons}
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
 
@@ -123,5 +123,5 @@ object PartialTransformer {
     * @since 0.7.0
     */
   def define[From, To]: PartialTransformerDefinition[From, To, TransformerCfg.Empty, TransformerFlags.Default] =
-    new PartialTransformerDefinition(Map.empty, Map.empty)
+    new PartialTransformerDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore)
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney
 
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
-import io.scalaland.chimney.dsl.{PartialTransformerDefinition, TransformerDefinition, TransformerFDefinition}
+import io.scalaland.chimney.dsl.{PartialTransformerDefinition, TransformerDefinition, TransformerDefinitionCommons, TransformerFDefinition}
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 
 import scala.language.experimental.macros
@@ -53,7 +53,7 @@ object Transformer {
     * @since 0.4.0
     */
   def define[From, To]: TransformerDefinition[From, To, TransformerCfg.Empty, TransformerFlags.Default] =
-    new TransformerDefinition(Map.empty, Map.empty)
+    new TransformerDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore)
 
   /** Creates an empty [[io.scalaland.chimney.dsl.PartialTransformerDefinition]] that
     * you can customize to derive [[io.scalaland.chimney.PartialTransformer]].
@@ -67,7 +67,7 @@ object Transformer {
     * @since 0.7.0
     */
   def definePartial[From, To]: PartialTransformerDefinition[From, To, TransformerCfg.Empty, TransformerFlags.Default] =
-    new PartialTransformerDefinition(Map.empty, Map.empty)
+    new PartialTransformerDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore)
 
   /** Creates an empty [[io.scalaland.chimney.dsl.TransformerFDefinition]] that
     * you can customize to derive [[io.scalaland.chimney.TransformerF]].

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -1,7 +1,12 @@
 package io.scalaland.chimney
 
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
-import io.scalaland.chimney.dsl.{PartialTransformerDefinition, TransformerDefinition, TransformerDefinitionCommons, TransformerFDefinition}
+import io.scalaland.chimney.dsl.{
+  PartialTransformerDefinition,
+  TransformerDefinition,
+  TransformerDefinitionCommons,
+  TransformerFDefinition
+}
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 
 import scala.language.experimental.macros

--- a/chimney/src/main/scala/io/scalaland/chimney/TransformerF.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/TransformerF.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.dsl.TransformerFDefinition
+import io.scalaland.chimney.dsl.{TransformerDefinitionCommons, TransformerFDefinition}
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 
@@ -69,6 +69,6 @@ object TransformerF {
     */
   def define[F[+_], From, To]
       : TransformerFDefinition[F, From, To, TransformerCfg.WrapperType[F, TransformerCfg.Empty], TransformerFlags.Default] =
-    new TransformerFDefinition(Map.empty, Map.empty)
+    new TransformerFDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore)
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -16,8 +16,7 @@ import scala.language.experimental.macros
   * @since 0.7.0
   */
 final class PartialTransformerDefinition[From, To, C <: TransformerCfg, Flags <: TransformerFlags](
-    val overrides: Map[String, Any],
-    val instances: Map[(String, String), Any]
+    val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends FlagsDsl[Lambda[`F1 <: TransformerFlags` => PartialTransformerDefinition[From, To, C, F1]], Flags]
     with TransformerDefinitionCommons[
       Lambda[`C1 <: TransformerCfg` => PartialTransformerDefinition[From, To, C1, Flags]]
@@ -167,6 +166,6 @@ final class PartialTransformerDefinition[From, To, C <: TransformerCfg, Flags <:
   ): PartialTransformer[From, To] =
     macro TransformerBlackboxMacros.buildPartialTransformerImpl[From, To, C, Flags, ScopeFlags]
 
-  override protected def updated(newOverrides: Map[String, Any], newInstances: Map[(String, String), Any]): this.type =
-    new PartialTransformerDefinition(newOverrides, newInstances).asInstanceOf[this.type]
+  override protected def __updateRuntimeData(newRuntimeData: TransformerDefinitionCommons.RuntimeDataStore): this.type =
+    new PartialTransformerDefinition(newRuntimeData).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -17,8 +17,7 @@ import scala.language.experimental.macros
   * @since 0.4.0
   */
 final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: TransformerFlags](
-    val overrides: Map[String, Any],
-    val instances: Map[(String, String), Any]
+    val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends FlagsDsl[Lambda[`F1 <: TransformerFlags` => TransformerDefinition[From, To, C, F1]], Flags]
     with TransformerDefinitionCommons[Lambda[`C1 <: TransformerCfg` => TransformerDefinition[From, To, C1, Flags]]] {
 
@@ -34,7 +33,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: Transf
     */
   @deprecated("Lifted transformers are deprecated. Consider using PartialTransformer.", since = "Chimney 0.7.0")
   def lift[F[+_]]: TransformerFDefinition[F, From, To, WrapperType[F, C], Flags] =
-    new TransformerFDefinition[F, From, To, WrapperType[F, C], Flags](overrides, instances)
+    new TransformerFDefinition[F, From, To, WrapperType[F, C], Flags](runtimeData)
 
   /** Lifts current transformer definition as `PartialTransformer` definition
     *
@@ -199,6 +198,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: Transf
   ): Transformer[From, To] =
     macro TransformerBlackboxMacros.buildTransformerImpl[From, To, C, Flags, ScopeFlags]
 
-  override protected def updated(newOverrides: Map[String, Any], newInstances: Map[(String, String), Any]): this.type =
-    new TransformerDefinition(newOverrides, newInstances).asInstanceOf[this.type]
+  override protected def __updateRuntimeData(newRuntimeData: TransformerDefinitionCommons.RuntimeDataStore): this.type =
+    new TransformerDefinition(newRuntimeData).asInstanceOf[this.type]
+
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -43,7 +43,7 @@ final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: Transf
     * @return [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     */
   def partial: PartialTransformerDefinition[From, To, C, Flags] =
-    new PartialTransformerDefinition[From, To, C, Flags](overrides, instances)
+    new PartialTransformerDefinition[From, To, C, Flags](runtimeData)
 
   /** Use provided value `value` for field picked using `selector`.
     *

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.TransformerCfg
 
-private[dsl] object TransformerDefinitionCommons {
+object TransformerDefinitionCommons {
   type RuntimeDataStore = Vector[Any]
   def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -2,27 +2,32 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.TransformerCfg
 
+private[dsl] object TransformerDefinitionCommons {
+  type RuntimeDataStore = Vector[Any]
+  def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
+}
+
 private[dsl] trait TransformerDefinitionCommons[UpdateCfg[_ <: TransformerCfg]] {
 
-  val overrides: Map[String, Any]
-  val instances: Map[(String, String), Any]
+  import TransformerDefinitionCommons._
 
-  protected def updated(newOverrides: Map[String, Any], newInstances: Map[(String, String), Any]): this.type
+  /** runtime storage for values and functions that transformer definition is customized with */
+  val runtimeData: RuntimeDataStore
+
+  /** updates runtime data in the upper transformer definition  */
+  protected def __updateRuntimeData(newRuntimeData: RuntimeDataStore): this.type
 
   // used by generated code to help debugging
 
-  /** Used internally by macro. Please don't use in your code.
-    */
-  final def __refineConfig[C1 <: TransformerCfg]: UpdateCfg[C1] =
+  /** Used internally by macro. Please don't use in your code. */
+  def __refineConfig[C1 <: TransformerCfg]: UpdateCfg[C1] =
     this.asInstanceOf[UpdateCfg[C1]]
 
-  /** Used internally by macro. Please don't use in your code.
-    */
-  final def __addOverride(key: String, value: Any): this.type =
-    updated(overrides.updated(key, value), instances)
+  /** Used internally by macro. Please don't use in your code. */
+  def __addOverride(overrideData: Any): this.type =
+    __updateRuntimeData(overrideData +: runtimeData)
 
-  /** Used internally by macro. Please don't use in your code.
-    */
-  final def __addInstance(from: String, to: String, value: Any): this.type =
-    updated(overrides, instances.updated((from, to), value))
+  /** Used internally by macro. Please don't use in your code. */
+  def __addInstance(instanceData: Any): this.type =
+    __updateRuntimeData(instanceData +: runtimeData)
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFDefinition.scala
@@ -20,8 +20,7 @@ import scala.language.experimental.macros
   */
 @deprecated("Lifted transformers are deprecated. Consider using PartialTransformer.", since = "Chimney 0.7.0")
 final class TransformerFDefinition[F[+_], From, To, C <: TransformerCfg, Flags <: TransformerFlags](
-    val overrides: Map[String, Any],
-    val instances: Map[(String, String), Any]
+    val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends FlagsDsl[Lambda[`F1 <: TransformerFlags` => TransformerFDefinition[F, From, To, C, F1]], Flags]
     with TransformerDefinitionCommons[Lambda[`C1 <: TransformerCfg` => TransformerFDefinition[F, From, To, C1, Flags]]] {
 
@@ -181,6 +180,7 @@ final class TransformerFDefinition[F[+_], From, To, C <: TransformerCfg, Flags <
   ): TransformerF[F, From, To] =
     macro TransformerBlackboxMacros.buildTransformerFImpl[F, From, To, C, Flags, ScopeFlags]
 
-  override protected def updated(newOverrides: Map[String, Any], newInstances: Map[(String, String), Any]): this.type =
-    new TransformerFDefinition(newOverrides, newInstances).asInstanceOf[this.type]
+  override protected def __updateRuntimeData(newRuntimeData: TransformerDefinitionCommons.RuntimeDataStore): this.type =
+    new TransformerFDefinition(newRuntimeData).asInstanceOf[this.type]
+
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
@@ -27,7 +27,7 @@ package object dsl {
       * @since 0.1.0
       */
     final def into[To]: TransformerInto[From, To, TransformerCfg.Empty, TransformerFlags.Default] =
-      new TransformerInto(source, new TransformerDefinition(Map.empty, Map.empty))
+      new TransformerInto(source, new TransformerDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore))
 
     /** Performs in-place transformation of captured source value to target type.
       *
@@ -123,7 +123,7 @@ package object dsl {
     @deprecated("Lifted transformers are deprecated. Consider using PartialTransformer.", since = "Chimney 0.7.0")
     final def intoF[F[+_], To]
         : TransformerFInto[F, From, To, TransformerCfg.WrapperType[F, TransformerCfg.Empty], TransformerFlags.Default] =
-      new TransformerFInto(source, new TransformerFDefinition(Map.empty, Map.empty))
+      new TransformerFInto(source, new TransformerFDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore))
 
     /** Performs in-place lifted transformation of captured source value to target type.
       *

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/package.scala
@@ -63,7 +63,10 @@ package object dsl {
       * @since 0.7.0
       */
     final def intoPartial[To]: PartialTransformerInto[From, To, TransformerCfg.Empty, TransformerFlags.Default] =
-      new PartialTransformerInto(source, new PartialTransformerDefinition(Map.empty, Map.empty))
+      new PartialTransformerInto(
+        source,
+        new PartialTransformerDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore)
+      )
 
     /** Performs in-place partial transformation of captured source value to target type.
       *

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
@@ -2,11 +2,11 @@ package io.scalaland.chimney.internal.macros
 
 import io.scalaland.chimney.internal.utils.AssertUtils
 
+import io.scalaland.chimney.internal.utils.DslMacroUtils
+
 import scala.reflect.macros.blackbox
 
-import scala.collection.compat._
-
-trait TargetConstructorMacros extends Model with AssertUtils with GenTrees {
+trait TargetConstructorMacros extends Model with DslMacroUtils with AssertUtils with GenTrees {
 
   val c: blackbox.Context
 
@@ -33,16 +33,13 @@ trait TargetConstructorMacros extends Model with AssertUtils with GenTrees {
   def mkCoproductInstance(
       transformerDefinitionPrefix: Tree,
       srcPrefixTree: Tree,
-      instSymbol: Symbol,
       To: Type,
+      runtimeDataIndex: Int,
       derivationTarget: DerivationTarget
   ): Tree = {
-    val instFullName = instSymbol.fullName
-    val fullTargetName = To.typeSymbol.fullName
     val finalTpe = derivationTarget.targetType(To)
     q"""
-      $transformerDefinitionPrefix
-        .instances(($instFullName, $fullTargetName))
+      ${transformerDefinitionPrefix.accessRuntimeData(runtimeDataIndex)}
         .asInstanceOf[Any => $finalTpe]
         .apply($srcPrefixTree)
         .asInstanceOf[$finalTpe]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
@@ -5,6 +5,7 @@ import io.scalaland.chimney.internal.utils.AssertUtils
 import io.scalaland.chimney.internal.utils.DslMacroUtils
 
 import scala.reflect.macros.blackbox
+import scala.collection.compat._
 
 trait TargetConstructorMacros extends Model with DslMacroUtils with AssertUtils with GenTrees {
 
@@ -118,7 +119,7 @@ trait TargetConstructorMacros extends Model with DslMacroUtils with AssertUtils 
 
         if (partialArgs.isEmpty) {
           mkTransformerBodyTree0(pt)(mkTargetValueTree(bodyTreeArgs.map(_.tree)))
-        } else if (partialArgs.sizeCompare(1) == 0) {
+        } else if (partialArgs.sizeIs == 1) {
           val (target, bodyTree) = partialArgs.head
           val fn = freshTermName(target.name)
           val totalArgsMap = totalArgs.map { case (target, bt) => target -> bt.tree }.toMap
@@ -126,7 +127,7 @@ trait TargetConstructorMacros extends Model with DslMacroUtils with AssertUtils 
           val updatedArgs = targets.map(argsMap)
 
           q"${bodyTree.tree}.map { ($fn: ${target.tpe}) => ${mkTargetValueTree(updatedArgs)} }"
-        } else if (partialArgs.sizeCompare(2) == 0) {
+        } else if (partialArgs.sizeIs == 2) {
           val (target0, bodyTree0) = partialArgs.head
           val (target1, bodyTree1) = partialArgs.last
           val fn0 = freshTermName(target0.name)
@@ -151,7 +152,7 @@ trait TargetConstructorMacros extends Model with DslMacroUtils with AssertUtils 
           val partialTrees = partialBodyTrees.map(_.tree)
           val totalArgsMap = totalArgs.map { case (target, bt) => target -> bt.tree }.toMap
 
-          if (partialArgs.sizeCompare(22) <= 0) { // tuple-based encoding, type info preserved
+          if (partialArgs.sizeIs <= 22) { // tuple-based encoding, type info preserved
 
             val localDefNames = partialTrees.map(_ => freshTermName("t"))
             val localTreeDefs = (localDefNames zip partialTrees).map { case (n, t) => q"final def $n = { $t }" }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -328,7 +328,11 @@ trait TransformerConfigSupport extends MacroUtils {
   def captureFromTransformerConfigurationTree(transformerConfigurationTree: Tree): TransformerFlags = {
     transformerConfigurationTree.tpe.typeArgs.headOption
       .map(flagsTpe => captureTransformerFlags(flagsTpe))
-      .getOrElse(TransformerFlags())
+      .getOrElse {
+        // $COVERAGE-OFF$
+        c.abort(c.enclosingPosition, "Impossible case: TransformerConfiguration without type parameter!")
+        // $COVERAGE-ON$
+      }
   }
 
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -78,7 +78,7 @@ trait TransformerConfigSupport extends MacroUtils {
       coproductInstanceFOverrides: Map[(Symbol, Type), Int] = Map.empty,
       coproductInstancesPartialOverrides: Map[(Symbol, Type), Int] = Map.empty,
       transformerDefinitionPrefix: Tree = EmptyTree,
-      definitionScope: Option[(Type, Type)] = None,
+      definitionScope: Option[(Type, Type)] = None
   ) {
 
     def withDerivationTarget(derivationTarget: DerivationTarget): TransformerConfig = {
@@ -118,7 +118,11 @@ trait TransformerConfigSupport extends MacroUtils {
     }
 
     def coproductInstancePartial(instanceType: Type, targetType: Type, runtimeDataIdx: Int): TransformerConfig = {
-      copy(coproductInstancesPartialOverrides = coproductInstancesPartialOverrides + ((instanceType.typeSymbol, targetType) -> runtimeDataIdx))
+      copy(coproductInstancesPartialOverrides = coproductInstancesPartialOverrides + ((
+        instanceType.typeSymbol,
+        targetType
+      ) -> runtimeDataIdx)
+      )
     }
   }
 
@@ -205,21 +209,21 @@ trait TransformerConfigSupport extends MacroUtils {
     } else if (cfgTpe.typeConstructor =:= coproductInstanceFT) {
       val List(instanceType, targetType, rest) = cfgTpe.typeArgs
       captureTransformerConfig(rest, 1 + runtimeDataIdx)
-        .coproductInstanceF(instanceType, targetType)
+        .coproductInstanceF(instanceType, targetType, runtimeDataIdx)
     } else if (cfgTpe.typeConstructor =:= fieldConstPartialT) {
       val List(fieldNameT, rest) = cfgTpe.typeArgs
       val fieldName = fieldNameT.singletonString
       captureTransformerConfig(rest, 1 + runtimeDataIdx)
-        .fieldOverride(fieldName, FieldOverride.ConstPartial)
+        .fieldOverride(fieldName, FieldOverride.ConstPartial(runtimeDataIdx))
     } else if (cfgTpe.typeConstructor =:= fieldComputedPartialT) {
       val List(fieldNameT, rest) = cfgTpe.typeArgs
       val fieldName = fieldNameT.singletonString
       captureTransformerConfig(rest, 1 + runtimeDataIdx)
-        .fieldOverride(fieldName, FieldOverride.ComputedPartial)
+        .fieldOverride(fieldName, FieldOverride.ComputedPartial(runtimeDataIdx))
     } else if (cfgTpe.typeConstructor =:= coproductInstancePartialT) {
       val List(instanceType, targetType, rest) = cfgTpe.typeArgs
       captureTransformerConfig(rest, 1 + runtimeDataIdx)
-        .coproductInstancePartial(instanceType, targetType)
+        .coproductInstancePartial(instanceType, targetType, runtimeDataIdx)
     } else {
       // $COVERAGE-OFF$
       c.abort(c.enclosingPosition, "Bad internal transformer config type shape!")

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -710,7 +710,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   ): Option[Tree] = {
     val pureRuntimeDataIdxOpt = config.coproductInstanceOverrides.get((From.typeSymbol, To))
     val liftedRuntimeDataIdxOpt = config.coproductInstanceFOverrides.get((From.typeSymbol, To))
-    val partialRuntimeDataIdxOpt = config.coproductInstacePartialOverrides.get((From.typeSymbol, To))
+    val partialRuntimeDataIdxOpt = config.coproductInstancesPartialOverrides.get((From.typeSymbol, To))
 
     (config.derivationTarget, pureRuntimeDataIdxOpt, partialRuntimeDataIdxOpt, liftedRuntimeDataIdxOpt) match {
       case (liftedTarget: DerivationTarget.LiftedTransformer, _, _, Some(runtimeDataIdxLifted)) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -708,37 +708,41 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       To: Type,
       config: TransformerConfig
   ): Option[Tree] = {
-    config.derivationTarget match {
-      case DerivationTarget.LiftedTransformer(_, _, _) if config.coproductInstancesF.contains((From.typeSymbol, To)) =>
+    val pureRuntimeDataIdxOpt = config.coproductInstanceOverrides.get((From.typeSymbol, To))
+    val liftedRuntimeDataIdxOpt = config.coproductInstanceFOverrides.get((From.typeSymbol, To))
+    val partialRuntimeDataIdxOpt = config.coproductInstacePartialOverrides.get((From.typeSymbol, To))
+
+    (config.derivationTarget, pureRuntimeDataIdxOpt, partialRuntimeDataIdxOpt, liftedRuntimeDataIdxOpt) match {
+      case (liftedTarget: DerivationTarget.LiftedTransformer, _, _, Some(runtimeDataIdxLifted)) =>
         Some(
           mkCoproductInstance(
             config.transformerDefinitionPrefix,
             srcPrefixTree,
-            From.typeSymbol,
             To,
-            config.derivationTarget
+            runtimeDataIdxLifted,
+            liftedTarget
           )
         )
 
-      case DerivationTarget.PartialTransformer(_) if config.coproductInstancesPartial.contains((From.typeSymbol, To)) =>
+      case (partialTarget: DerivationTarget.PartialTransformer, _, Some(runtimeDataIdxPartial), _) =>
         Some(
           mkCoproductInstance(
             config.transformerDefinitionPrefix,
             srcPrefixTree,
-            From.typeSymbol,
             To,
-            config.derivationTarget
+            runtimeDataIdxPartial,
+            partialTarget
           )
         )
 
-      case _ if config.coproductInstances.contains((From.typeSymbol, To)) =>
+      case (_, Some(runtimeDataIdxPure), _, _) =>
         Some(
           mkTransformerBodyTree0(config.derivationTarget) {
             mkCoproductInstance(
               config.transformerDefinitionPrefix,
               srcPrefixTree,
-              From.typeSymbol,
               To,
+              runtimeDataIdxPure,
               DerivationTarget.TotalTransformer
             )
           }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
@@ -30,7 +30,6 @@ trait MacroUtils extends CompanionUtils {
 
   implicit class NameOps(n: Name) {
     def toNameConstant: Constant = Constant(n.decodedName.toString)
-    def toNameLiteral: Literal = Literal(toNameConstant)
     def toSingletonTpe: ConstantType = c.internal.constantType(toNameConstant)
   }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney.internal.utils
 
 import scala.reflect.macros.blackbox
+import scala.collection.compat._
 
 trait TypeTestUtils extends MacroUtils {
 
@@ -37,7 +38,7 @@ trait TypeTestUtils extends MacroUtils {
   }
 
   def fromOptionToNonOption(from: Type, to: Type): Boolean = {
-    isOption(from) && !isOption(to) && from.typeArgs.size == 1
+    isOption(from) && !isOption(to) && from.typeArgs.sizeIs == 1
   }
 
   def isTuple(to: Type): Boolean =


### PR DESCRIPTION
So far Chimney were using two `Map`s for each dsl class `TransformerInto`/`TransformerDefinition` (including their lifted/partial counterparts) - one for field values and computing functions, the other one for coproduct symbols.

This PR brings simplified runtime representation using a single `Vector[Any]`, with the compile-time index management.
