### PR TITLE
Add rewrapping a value from one value class to another

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -242,7 +242,9 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   ): Either[Seq[TransformerDerivationError], Tree] = {
 
     val fromValueClassMember = From.valueClassMember.toRight(
+      // $COVERAGE-OFF$
       Seq(CantFindValueClassMember(From.typeSymbol.name.toString, To.typeSymbol.name.toString))
+      // $COVERAGE-ON$
     )
 
     for {
@@ -264,7 +266,9 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       To: Type
   ): Either[Seq[TransformerDerivationError], Tree] = {
     val toValueClassMember = To.valueClassMember.toRight(
+      // $COVERAGE-OFF$
       Seq(CantFindValueClassMember(To.typeSymbol.name.toString, From.typeSymbol.name.toString))
+      // $COVERAGE-ON$
     )
 
     for {
@@ -303,11 +307,15 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   ): Either[Seq[TransformerDerivationError], Tree] = {
 
     val fromValueClassMember = From.valueClassMember.toRight(
+      // $COVERAGE-OFF$
       Seq(CantFindValueClassMember(From.typeSymbol.name.toString, To.typeSymbol.name.toString))
+      // $COVERAGE-ON$
     )
 
     val toValueClassMember = To.valueClassMember.toRight(
+      // $COVERAGE-OFF$
       Seq(CantFindValueClassMember(To.typeSymbol.name.toString, From.typeSymbol.name.toString))
+      // $COVERAGE-ON$
     )
 
     for {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
@@ -13,8 +13,8 @@ trait TypeTestUtils extends MacroUtils {
     from <:< to
   }
 
-  def fromValueClassToType(from: Type, to: Type): Boolean = {
-    from.isValueClass && from.valueClassMember.exists(_.returnType =:= to)
+  def fromValueClass(from: Type, to: Type): Boolean = {
+    from.isValueClass && !to.isValueClass
   }
 
   def fromTypeToValueClass(from: Type, to: Type): Boolean = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
@@ -21,14 +21,8 @@ trait TypeTestUtils extends MacroUtils {
     to.isValueClass && to.valueClassMember.exists(_.returnType =:= from)
   }
 
-  def fromValueClassToValueClass(from: Type, to: Type): Boolean = {
-    from.isValueClass &&
-    to.isValueClass && {
-      for {
-        fromValueMember <- from.valueClassMember
-        toValueMember <- to.valueClassMember
-      } yield fromValueMember.returnType =:= toValueMember.returnType
-    }.contains(true)
+  def bothValueClasses(from: Type, to: Type): Boolean = {
+    from.isValueClass && to.isValueClass
   }
 
   def isOption(t: Type): Boolean = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
@@ -17,8 +17,8 @@ trait TypeTestUtils extends MacroUtils {
     from.isValueClass && !to.isValueClass
   }
 
-  def fromTypeToValueClass(from: Type, to: Type): Boolean = {
-    to.isValueClass && to.valueClassMember.exists(_.returnType =:= from)
+  def toValueClass(from: Type, to: Type): Boolean = {
+    to.isValueClass && !from.isValueClass
   }
 
   def bothValueClasses(from: Type, to: Type): Boolean = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/TypeTestUtils.scala
@@ -21,6 +21,16 @@ trait TypeTestUtils extends MacroUtils {
     to.isValueClass && to.valueClassMember.exists(_.returnType =:= from)
   }
 
+  def fromValueClassToValueClass(from: Type, to: Type): Boolean = {
+    from.isValueClass &&
+    to.isValueClass && {
+      for {
+        fromValueMember <- from.valueClassMember
+        toValueMember <- to.valueClassMember
+      } yield fromValueMember.returnType =:= toValueMember.returnType
+    }.contains(true)
+  }
+
   def isOption(t: Type): Boolean = {
     t <:< optionTpe
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerValueTypeSpec.scala
@@ -8,7 +8,7 @@ object LiftedTransformerValueTypeSpec extends TestSuite {
 
   val tests = Tests {
 
-    test("transform from a value class into a value") {
+    test("transform from a value class(member type 'T') into a value(type 'T')") {
 
       test("when F = Option") {
         UserName("Batman").transformIntoF[Option, String] ==> Some("Batman")
@@ -21,7 +21,7 @@ object LiftedTransformerValueTypeSpec extends TestSuite {
       }
     }
 
-    test("transforming from a value to a value class") {
+    test("transforming from a value(type 'T') to a value class(member type 'T')") {
 
       test("when F = Option") {
         "Batman".transformIntoF[Option, UserName] ==> Some(UserName("Batman"))
@@ -31,6 +31,98 @@ object LiftedTransformerValueTypeSpec extends TestSuite {
       test("when F = Either[List[String], +*]") {
         "Batman".transformIntoF[Either[List[String], +*], UserName] ==> Right(UserName("Batman"))
         UserDTO("100", "abc").transformIntoF[Either[List[String], +*], User] ==> Right(User("100", UserName("abc")))
+      }
+    }
+
+    test("transforming value class(member type: 'T') to a value class(member type: 'T')") {
+
+      test("when F = Option") {
+        UserName("Batman").transformIntoF[Option, UserNameAlias] ==> Some(UserNameAlias("Batman"))
+        User("100", UserName("abc")).transformIntoF[Option, UserAlias] ==>
+          Some(UserAlias("100", UserNameAlias("abc")))
+      }
+
+      test("when F = Either[List[String], +*]") {
+        UserName("Batman").transformIntoF[Either[List[String], +*], UserNameAlias] ==> Right(UserNameAlias("Batman"))
+        User("100", UserName("abc")).transformIntoF[Either[List[String], +*], UserAlias] ==>
+          Right(UserAlias("100", UserNameAlias("abc")))
+      }
+    }
+
+    test("transform from a value class(member type: 'T') into a value(type 'S') if 'T'=>'S' exists") {
+      implicit val transformerOption = new TransformerF[Option, String, Int] {
+        override def transform(src: String): Option[Int] = Some(src.length)
+      }
+
+      implicit val transformerEither = new TransformerF[Either[List[String], +*], String, Int] {
+        override def transform(src: String): Either[List[String], Int] = Right(src.length)
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+
+      test("when F = Option") {
+        UserName(batman).transformIntoF[Option, Int] ==> Some(batman.length)
+        UserWithUserName(UserName(abc)).transformIntoF[Option, UserWithId] ==> Some(UserWithId(abc.length))
+      }
+
+      test("when F = Either[List[String], +*]") {
+        UserName(batman).transformIntoF[Either[List[String], +*], Int] ==> Right(batman.length)
+        UserWithUserName(UserName(abc)).transformIntoF[Either[List[String], +*], UserWithId] ==> Right(
+          UserWithId(abc.length)
+        )
+      }
+    }
+
+    test("transform from a value(type: 'T') into a value class(member type: 'S') if 'T'=>'S' exists") {
+      implicit val transformerOption = new TransformerF[Option, String, Int] {
+        override def transform(src: String): Option[Int] = Some(src.length)
+      }
+
+      implicit val transformerEither = new TransformerF[Either[List[String], +*], String, Int] {
+        override def transform(src: String): Either[List[String], Int] = Right(src.length)
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+
+      test("when F = Option") {
+        batman.transformIntoF[Option, UserId] ==> Some(UserId(batman.length))
+        UserWithName(abc).transformIntoF[Option, UserWithUserId] ==> Some(UserWithUserId(UserId(abc.length)))
+      }
+
+      test("when F = Either[List[String], +*]") {
+        batman.transformIntoF[Either[List[String], +*], UserId] ==> Right(UserId(batman.length))
+        UserWithName(abc).transformIntoF[Either[List[String], +*], UserWithUserId] ==> Right(
+          UserWithUserId(UserId(abc.length))
+        )
+      }
+    }
+
+    test("transforming value class(member type: `S`) to value class(member type: 'T') if 'T'=>'S' exists") {
+      implicit val transformerOption = new TransformerF[Option, String, Int] {
+        override def transform(src: String): Option[Int] = Some(src.length)
+      }
+
+      implicit val transformerEither = new TransformerF[Either[List[String], +*], String, Int] {
+        override def transform(src: String): Either[List[String], Int] = Right(src.length)
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+
+      test("when F = Option") {
+        UserName(batman).transformIntoF[Option, UserId] ==> Some(UserId(batman.length))
+        UserWithUserName(UserName(abc)).transformIntoF[Option, UserWithUserId] ==> Some(
+          UserWithUserId(UserId(abc.length))
+        )
+      }
+
+      test("when F = Either[List[String], +*]") {
+        UserName(batman).transformIntoF[Either[List[String], +*], UserId] ==> Right(UserId(batman.length))
+        UserWithUserName(UserName(abc)).transformIntoF[Either[List[String], +*], UserWithUserId] ==> Right(
+          UserWithUserId(UserId(abc.length))
+        )
       }
     }
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerValueTypeSpec.scala
@@ -8,14 +8,54 @@ object PartialTransformerValueTypeSpec extends TestSuite {
 
   val tests = Tests {
 
-    test("transform from a value class into a value") {
+    test("transform from a value class(member type 'T') into a value(type 'T')") {
       UserName("Batman").transformIntoPartial[String].asOption ==> Some("Batman")
       User("100", UserName("abc")).transformIntoPartial[UserDTO].asOption ==> Some(UserDTO("100", "abc"))
     }
 
-    test("transforming from a value to a value class") {
+    test("transforming from a value(type 'T') to a value class(member type 'T')") {
       "Batman".transformIntoPartial[UserName].asOption ==> Some(UserName("Batman"))
       UserDTO("100", "abc").transformIntoPartial[User].asOption ==> Some(User("100", UserName("abc")))
+    }
+
+    test("transforming value class(member type: 'T') to a value class(member type: 'T')") {
+      UserName("Batman").transformIntoPartial[UserNameAlias].asOption ==> Some(UserNameAlias("Batman"))
+      User("100", UserName("abc")).transformIntoPartial[UserAlias].asOption ==>
+        Some(UserAlias("100", UserNameAlias("abc")))
+    }
+
+    test("transform from a value class(member type: 'T') into a value(type 'S') if 'T'=>'S' exists") {
+      implicit val transformer = new PartialTransformer[String, Int] {
+        override def transform(src: String, failFast: Boolean): partial.Result[Int] = partial.Result.Value(src.length)
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+      UserName(batman).transformIntoPartial[Int].asOption ==> Some(batman.length)
+      UserWithUserName(UserName(abc)).transformIntoPartial[UserWithId].asOption ==> Option(UserWithId(abc.length))
+    }
+
+    test("transform from a value(type: 'T') into a value class(member type: 'S') if 'T'=>'S' exists") {
+      implicit val transformer = new Transformer[String, Int] {
+        override def transform(src: String): Int = src.length
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+      batman.transformInto[UserId] ==> UserId(batman.length)
+      UserWithName(abc).transformInto[UserWithUserId] ==> UserWithUserId(UserId(abc.length))
+    }
+
+    test("transforming value class(member type: `S`) to value class(member type: 'T') if 'T'=>'S' exists") {
+      implicit val transformer = new Transformer[String, Int] {
+        override def transform(src: String): Int = src.length
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+      UserName(batman).transformInto[UserId] ==> UserId(batman.length)
+      UserWithUserName(UserName(abc)).transformInto[UserWithUserId] ==> UserWithUserId(UserId(abc.length))
+
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
@@ -18,11 +18,23 @@ object TotalTransformerValueTypeSpec extends TestSuite {
       UserDTO("100", "abc").transformInto[User] ==> User("100", UserName("abc"))
     }
 
-    test("transforming value class to a value class") {
+    test("transforming value class(member type: 'T') to a value class(member type: 'T')") {
 
       UserName("Batman").transformInto[UserNameAlias] ==> UserNameAlias("Batman")
       User("100", UserName("abc")).transformInto[UserAlias] ==>
         UserAlias("100", UserNameAlias("abc"))
+    }
+
+    test("transforming value class(member type: `S`) to value class(member type: 'T') if 'T'=>'S' transformer exists") {
+      implicit val transformer = new Transformer[String, Int] {
+        override def transform(src: String): Int = src.length
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+      UserName(batman).transformInto[UserId] ==> UserId(batman.length)
+      UserWithName(UserName(abc)).transformInto[UserWithId] ==> UserWithId(UserId(abc.length))
+
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
@@ -8,12 +8,12 @@ object TotalTransformerValueTypeSpec extends TestSuite {
 
   val tests = Tests {
 
-    test("transform from a value class into a value") {
+    test("transform from a value class(member type: 'T') into a value(type 'T')") {
       UserName("Batman").transformInto[String] ==> "Batman"
       User("100", UserName("abc")).transformInto[UserDTO] ==> UserDTO("100", "abc")
     }
 
-    test("transforming from a value to a value class") {
+    test("transforming from a value(type 'T') to a value class(member type: 'T')") {
       "Batman".transformInto[UserName] ==> UserName("Batman")
       UserDTO("100", "abc").transformInto[User] ==> User("100", UserName("abc"))
     }
@@ -25,7 +25,18 @@ object TotalTransformerValueTypeSpec extends TestSuite {
         UserAlias("100", UserNameAlias("abc"))
     }
 
-    test("transforming value class(member type: `S`) to value class(member type: 'T') if 'T'=>'S' transformer exists") {
+    test("transform from a value class(member type: 'T') into a value(type 'S') if 'T'=>'S' exists") {
+      implicit val transformer = new Transformer[String, Int] {
+        override def transform(src: String): Int = src.length
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+      UserName(batman).transformInto[Int] ==> batman.length
+      UserWithUserName(UserName(abc)).transformInto[UserWithId] ==> UserWithId(abc.length)
+    }
+
+    test("transforming value class(member type: `S`) to value class(member type: 'T') if 'T'=>'S' exists") {
       implicit val transformer = new Transformer[String, Int] {
         override def transform(src: String): Int = src.length
       }
@@ -33,7 +44,7 @@ object TotalTransformerValueTypeSpec extends TestSuite {
       val batman = "Batman"
       val abc = "abc"
       UserName(batman).transformInto[UserId] ==> UserId(batman.length)
-      UserWithName(UserName(abc)).transformInto[UserWithId] ==> UserWithId(UserId(abc.length))
+      UserWithUserName(UserName(abc)).transformInto[UserWithUserId] ==> UserWithUserId(UserId(abc.length))
 
     }
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
@@ -17,5 +17,12 @@ object TotalTransformerValueTypeSpec extends TestSuite {
       "Batman".transformInto[UserName] ==> UserName("Batman")
       UserDTO("100", "abc").transformInto[User] ==> User("100", UserName("abc"))
     }
+
+    test("transforming value class to a value class") {
+
+      UserName("Batman").transformInto[UserNameAlias] ==> UserNameAlias("Batman")
+      User("100", UserName("abc")).transformInto[UserAlias] ==>
+        UserAlias("100", UserNameAlias("abc"))
+    }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
@@ -36,6 +36,17 @@ object TotalTransformerValueTypeSpec extends TestSuite {
       UserWithUserName(UserName(abc)).transformInto[UserWithId] ==> UserWithId(abc.length)
     }
 
+    test("transform from a value(type: 'T') into a value class(member type: 'S') if 'T'=>'S' exists") {
+      implicit val transformer = new Transformer[String, Int] {
+        override def transform(src: String): Int = src.length
+      }
+
+      val batman = "Batman"
+      val abc = "abc"
+      batman.transformInto[UserId] ==> UserId(batman.length)
+      UserWithName(abc).transformInto[UserWithUserId] ==> UserWithUserId(UserId(abc.length))
+    }
+
     test("transforming value class(member type: `S`) to value class(member type: 'T') if 'T'=>'S' exists") {
       implicit val transformer = new Transformer[String, Int] {
         override def transform(src: String): Int = src.length

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
@@ -2,6 +2,11 @@ package io.scalaland.chimney.examples.valuetypes
 
 case class UserName(value: String) extends AnyVal
 case class UserNameAlias(value: String) extends AnyVal
+case class UserId(value: Int) extends AnyVal
+
 case class UserDTO(id: String, name: String)
 case class User(id: String, name: UserName)
 case class UserAlias(id: String, name: UserNameAlias)
+
+case class UserWithName(id: UserName)
+case class UserWithId(id: UserId)

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
@@ -1,5 +1,7 @@
 package io.scalaland.chimney.examples.valuetypes
 
 case class UserName(value: String) extends AnyVal
+case class UserNameAlias(value: String) extends AnyVal
 case class UserDTO(id: String, name: String)
 case class User(id: String, name: UserName)
+case class UserAlias(id: String, name: UserNameAlias)

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
@@ -9,5 +9,6 @@ case class User(id: String, name: UserName)
 case class UserAlias(id: String, name: UserNameAlias)
 
 case class UserWithUserName(id: UserName)
+case class UserWithName(id: String)
 case class UserWithUserId(id: UserId)
 case class UserWithId(id: Int)

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/valuetypes/valuetypes.scala
@@ -8,5 +8,6 @@ case class UserDTO(id: String, name: String)
 case class User(id: String, name: UserName)
 case class UserAlias(id: String, name: UserNameAlias)
 
-case class UserWithName(id: UserName)
-case class UserWithId(id: UserId)
+case class UserWithUserName(id: UserName)
+case class UserWithUserId(id: UserId)
+case class UserWithId(id: Int)


### PR DESCRIPTION
Implementation of #249

- [x] Add rewrapping value of one value class to another value class if value is the same type.
      ```case class Foo(t: T) extends AnyVal => case class Bar(t: T) extends AnyVal```

- [x] Add unwrapping of a value class's value of one type(`T`) to another type(`S`) if `T => S` transformer exists.
       ```case class Foo(t: T) extends AnyVal => S```
       
- [x] Add wrapping a value of one type(`T`) to value class of another type(`S`) if `T => S` transformer exists.
       ```T => case class Foo(s: S)```
       
- [x]  Add rewrapping value(type `T`) of one value class to another value class(with value of type `S`  if `T => S` transformer exists.
        ```case class Foo(t: T) => case class Bar(s: S)```