### PR TITLE
Run implicit search with macros always enabled

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -1048,7 +1048,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   def findLocalTransformerConfigurationFlags: Tree = {
     val searchTypeTree =
       tq"${typeOf[io.scalaland.chimney.dsl.TransformerConfiguration[? <: io.scalaland.chimney.internal.TransformerFlags]]}"
-    inferImplicitTpe(searchTypeTree, macrosDisabled = true)
+    inferImplicitTpe(searchTypeTree, macrosDisabled = false)
       .getOrElse {
         // $COVERAGE-OFF$
         c.abort(c.enclosingPosition, "Can't locate implicit TransformerConfiguration!")
@@ -1070,7 +1070,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   }
 
   def findTransformerErrorPathSupport(wrapperType: Type): Option[Tree] = {
-    inferImplicitTpe(tq"_root_.io.scalaland.chimney.TransformerFErrorPathSupport[$wrapperType]", macrosDisabled = true)
+    inferImplicitTpe(tq"_root_.io.scalaland.chimney.TransformerFErrorPathSupport[$wrapperType]", macrosDisabled = false)
   }
 
   private def inferImplicitTpe(tpeTree: Tree, macrosDisabled: Boolean): Option[Tree] = {


### PR DESCRIPTION
It fixes #268 by making sure that we don't run implicit search with macros disabled, which doesn't seem to be supported by Scala 3's `summon`/`summonExpr`.