### PR TITLE
Simplified partial transformers composition encoding

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/GenTrees.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/GenTrees.scala
@@ -76,12 +76,20 @@ trait GenTrees extends Model with TypeTestUtils with DslMacroUtils {
 
     object PartialResult {
 
+      def tpe(innerTpe: Type): Tree = {
+        tq"_root_.io.scalaland.chimney.partial.Result[$innerTpe]"
+      }
+
       def empty: Tree = {
         q"_root_.io.scalaland.chimney.partial.Result.fromEmpty"
       }
 
       def value(valTree: Tree): Tree = {
         q"_root_.io.scalaland.chimney.partial.Result.Value($valTree)"
+      }
+
+      def valueTpe(innerTpe: Type): Tree = {
+        tq"_root_.io.scalaland.chimney.partial.Result.Value[$innerTpe]"
       }
 
       def patValue(termName: TermName): Tree = {
@@ -112,8 +120,16 @@ trait GenTrees extends Model with TypeTestUtils with DslMacroUtils {
     object PartialErrors {
       val tpe: Tree = tq"_root_.io.scalaland.chimney.partial.Result.Errors"
 
-      def merge(tn1: TermName, tn2: TermName): Tree = {
-        q"_root_.io.scalaland.chimney.partial.Result.Errors.merge($tn1, $tn2)"
+      def merge(t1: Tree, t2: Tree): Tree = {
+        q"_root_.io.scalaland.chimney.partial.Result.Errors.merge($t1, $t2)"
+      }
+
+      def mergeNullable(t1: Tree, t2: Tree): Tree = {
+        q"_root_.io.scalaland.chimney.partial.Result.Errors.mergeNullable($t1, $t2)"
+      }
+
+      def mergeResultNullable(t1: Tree, t2: Tree): Tree = {
+        q"_root_.io.scalaland.chimney.partial.Result.Errors.mergeResultNullable($t1, $t2)"
       }
     }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/GenTrees.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/GenTrees.scala
@@ -124,12 +124,8 @@ trait GenTrees extends Model with TypeTestUtils with DslMacroUtils {
         q"_root_.io.scalaland.chimney.partial.Result.Errors.merge($t1, $t2)"
       }
 
-      def mergeNullable(t1: Tree, t2: Tree): Tree = {
-        q"_root_.io.scalaland.chimney.partial.Result.Errors.mergeNullable($t1, $t2)"
-      }
-
       def mergeResultNullable(t1: Tree, t2: Tree): Tree = {
-        q"_root_.io.scalaland.chimney.partial.Result.Errors.mergeResultNullable($t1, $t2)"
+        q"_root_.io.scalaland.chimney.partial.Result.Errors.__mergeResultNullable($t1, $t2)"
       }
     }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TargetConstructorMacros.scala
@@ -147,90 +147,54 @@ trait TargetConstructorMacros extends Model with DslMacroUtils with AssertUtils 
               pt.failFastTree
             )
         } else {
-          val (partialTargets, partialBodyTrees) = partialArgs.unzip
-          val partialTrees = partialBodyTrees.map(_.tree)
           val totalArgsMap = totalArgs.map { case (target, bt) => target -> bt.tree }.toMap
 
-          if (partialArgs.sizeIs <= 22) { // tuple-based encoding, type info preserved
+          val partialTargets = partialArgs.map(_._1)
 
-            val localDefNames = partialTrees.map(_ => freshTermName("t"))
-            val localTreeDefs = (localDefNames zip partialTrees).map { case (n, t) => q"final def $n = { $t }" }
+          val localDefNames = partialTargets.map(t => freshTermName(s"rd_${t.name}"))
+          val localTreeDefs = (localDefNames zip partialArgs).map { case (dn, (target, tbt)) =>
+            q"final def $dn: ${Trees.PartialResult.tpe(target.tpe)} = { ${tbt.tree} }"
+          }
+          val localValNames = partialTargets.map(t => freshTermName(s"rv_${t.name}"))
+          val localTreeVals = (localValNames zip localDefNames).map { case (rv, rd) =>
+            q"final val $rv = $rd"
+          }
 
-            val succFFValIdents = partialArgs.map(_ => freshTermName("vff"))
-            val succFFFqs = (succFFValIdents zip localDefNames).map { case (vId, lt) => fq"$vId <- $lt" }
-            val succValFFTrees = succFFValIdents.map(vId => q"$vId")
-            val patRefArgsMapFF = (partialTargets zip succValFFTrees).toMap
-            val argsMapFF = totalArgsMap ++ patRefArgsMapFF
-            val updatedArgsFF = targets.map(argsMapFF)
+          // short circuit branch (fail fast)
+          val succFFValIdents = partialTargets.map(t => freshTermName(s"rvff_${t.name}"))
+          val succFFFqs = (succFFValIdents zip localDefNames).map { case (rvff, rd) => fq"$rvff <- $rd" }
+          val succValFFTrees = succFFValIdents.map(rvff => q"$rvff")
+          val patRefArgsMapFF = (partialTargets zip succValFFTrees).toMap
+          val argsMapFF = totalArgsMap ++ patRefArgsMapFF
+          val updatedArgsFF = targets.map(argsMapFF)
 
-            val succValIdents = partialTrees.map(_ => freshTermName("v"))
-            val localTreeRefs = localDefNames.map { lt =>
-              q"$lt"
-            }
-            val succValPats = succValIdents.map(vId => Trees.PartialResult.patValue(vId))
-            val allSuccPat = pq"(..${succValPats})"
-            val succValTrees = succValIdents.map(vId => q"$vId")
-            val patRefArgsMap = (partialTargets zip succValTrees).toMap
-            val argsMap = totalArgsMap ++ patRefArgsMap
-            val updatedArgs = targets.map(argsMap)
+          // long circuit branch (errors accumulation)
+          val succValTrees = (localValNames zip partialTargets).map { case (rv, target) =>
+            q"$rv.asInstanceOf[${Trees.PartialResult.valueTpe(target.tpe)}].value"
+          }
+          val patRefArgsMap = (partialTargets zip succValTrees).toMap
+          val argsMap = totalArgsMap ++ patRefArgsMap
+          val updatedArgs = targets.map(argsMap)
+          val allErrorsIdent = freshTermName("allErrors")
+          val errorsCaptureTrees = localValNames.map { resultVal =>
+            q"""$allErrorsIdent = ${Trees.PartialErrors.mergeResultNullable(q"$allErrorsIdent", q"$resultVal")}"""
+          }
 
-            val errIdents = partialTrees.map(_ => freshTermName("err"))
-            val errPats = errIdents.map(errId => pq"$errId")
-            val errPat = pq"(..${errPats})"
-
-            val allErrorsIdent = freshTermName("allErrors")
-            val allErrIfTrees = errIdents.map { errId =>
-              val localErrsIdent = freshTermName("localErrs")
-              q"""
-                if ($errId.isInstanceOf[${Trees.PartialErrors.tpe}]) {
-                  val $localErrsIdent = $errId.asInstanceOf[${Trees.PartialErrors.tpe}]
-                  if ($allErrorsIdent == null) {
-                    $allErrorsIdent = $localErrsIdent
-                  } else {
-                    $allErrorsIdent = ${Trees.PartialErrors.merge(allErrorsIdent, localErrsIdent)}
-                  }
-                }
-               """
-            }
-
-            q"""
-              {
+          q"""{
                 ..$localTreeDefs
                 if(${pt.failFastTree}) {
                   for (..$succFFFqs) yield ${mkTargetValueTree(updatedArgsFF)}
                 } else {
-                  (..${localTreeRefs}) match {
-                    case $allSuccPat =>
-                      ${Trees.PartialResult.value(mkTargetValueTree(updatedArgs))}
-                    case $errPat => // (r1, r2, .., rk)
-                      var $allErrorsIdent: ${Trees.PartialErrors.tpe} = null
-                      ..$allErrIfTrees
-                      $allErrorsIdent
+                  ..$localTreeVals
+                  var $allErrorsIdent: ${Trees.PartialErrors.tpe} = null
+                  ..$errorsCaptureTrees
+                  if ($allErrorsIdent == null) {
+                    ${Trees.PartialResult.value(mkTargetValueTree(updatedArgs))}
+                  } else {
+                    $allErrorsIdent
                   }
                 }
-              }
-            """
-          } else { // Array[Any] + sequence, type info lost
-            // should be possible to optimize with nested tuples
-            val partialTreesArray = Trees.array(partialTrees)
-            val arrayFn = freshTermName("array")
-            val argIndices = partialTargets.indices
-            val patRefArgsMap = (partialTargets zip argIndices).map { case (target, argIndex) =>
-              target -> q"$arrayFn.apply($argIndex).asInstanceOf[${target.tpe}]"
-            }.toMap
-            val argsMap = totalArgsMap ++ patRefArgsMap
-            val updatedArgs = targets.map(argsMap)
-
-            q"""
-               ${Trees.PartialResult.sequence(
-                Trees.arrayAny,
-                Trees.any,
-                q"${partialTreesArray}.iterator",
-                pt.failFastTree
-              )}
-               .map { ($arrayFn: ${Trees.arrayAny}) => ${mkTargetValueTree(updatedArgs)} }
-             """
-          }
+              }"""
         }
 
       case lt @ DerivationTarget.LiftedTransformer(_, wrapperSupportInstance, _) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
@@ -178,6 +178,31 @@ object Result {
       */
     final def merge(errors1: Errors, errors2: Errors): Errors =
       apply(errors1.errors ++ errors2.errors)
+
+    /** Merges errors with potentially nullable first argument
+      *
+      * @param errorsNullable failed result which errors should appear in the beginning, potentially nullable
+      * @param errors failed result which errors should appear in the end
+      * @return result aggregating errors from both results, potentially nullable
+      * @since 0.7.0
+      */
+    final def mergeNullable(errorsNullable: Errors, errors: Errors): Errors = {
+      if (errorsNullable == null) errors else merge(errorsNullable, errors)
+    }
+
+    /** Merges potentially nullable errors with eventual errors coming from passed result
+      *
+      * @param errorsNullable failed result which errors should appear in the beginning, potentially nullable
+      * @param result result which eventuall erors should appear in the end
+      * @return result aggregating errors from both results, potentially nullable
+      * @since 0.7.0
+      */
+    final def mergeResultNullable[T](errorsNullable: Errors, result: Result[T]): Errors = {
+      result match {
+        case Value(_)       => errorsNullable
+        case errors: Errors => mergeNullable(errorsNullable, errors)
+      }
+    }
   }
 
   /** Converts a function that throws Exceptions into function that returns Result.

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
@@ -179,28 +179,12 @@ object Result {
     final def merge(errors1: Errors, errors2: Errors): Errors =
       apply(errors1.errors ++ errors2.errors)
 
-    /** Merges errors with potentially nullable first argument
-      *
-      * @param errorsNullable failed result which errors should appear in the beginning, potentially nullable
-      * @param errors failed result which errors should appear in the end
-      * @return result aggregating errors from both results, potentially nullable
-      * @since 0.7.0
+    /** Used internally by macro. Please don't use in your code.
       */
-    final def mergeNullable(errorsNullable: Errors, errors: Errors): Errors = {
-      if (errorsNullable == null) errors else merge(errorsNullable, errors)
-    }
-
-    /** Merges potentially nullable errors with eventual errors coming from passed result
-      *
-      * @param errorsNullable failed result which errors should appear in the beginning, potentially nullable
-      * @param result result which eventuall erors should appear in the end
-      * @return result aggregating errors from both results, potentially nullable
-      * @since 0.7.0
-      */
-    final def mergeResultNullable[T](errorsNullable: Errors, result: Result[T]): Errors = {
+    final def __mergeResultNullable[T](errorsNullable: Errors, result: Result[T]): Errors = {
       result match {
         case Value(_)       => errorsNullable
-        case errors: Errors => mergeNullable(errorsNullable, errors)
+        case errors: Errors => if (errorsNullable == null) errors else merge(errorsNullable, errors)
       }
     }
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
@@ -183,7 +183,7 @@ object Result {
       */
     final def __mergeResultNullable[T](errorsNullable: Errors, result: Result[T]): Errors = {
       result match {
-        case Value(_)       => errorsNullable
+        case _: Value[?]    => errorsNullable
         case errors: Errors => if (errorsNullable == null) errors else merge(errorsNullable, errors)
       }
     }


### PR DESCRIPTION
So far partial transformers composition encoding produced quite lengthy code:
- for arities from 3 up to 22, encoding was tuple-based, which preserved argument type information
- for arities above 22, encoding was `Array[Any]` + `sequence` based

This PR brings few simplifications and optimizations to the generated composition code:
- it's unified for arities above 2
- no extra allocations for intermediate data (tuples or arrays)
- emitted code is much shorter
- macro implementation was greatly simplified
- it also eliminates a few warnings `fruitless type test` that appeared in generated code
