### PR TITLE
Refactor: move srcPrefixTree into TransformerConfig

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/MappingMacros.scala
@@ -64,7 +64,6 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils with Gen
   }
 
   def resolveOverrides(
-      srcPrefixTree: Tree,
       From: Type,
       targets: Iterable[Target],
       config: TransformerConfig
@@ -99,7 +98,7 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils with Gen
           Some {
             target -> TransformerBodyTree(
               q"""
-                ${liftedFunction.callUnaryApply(srcPrefixTree)}
+                ${liftedFunction.callUnaryApply(config.srcPrefixTree)}
                   .prependErrorPath(${Trees.PathElement.accessor(target.name)})
               """,
               config.derivationTarget
@@ -111,7 +110,7 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils with Gen
             target -> TransformerBodyTree(
               config.transformerDefinitionPrefix
                 .accessOverriddenComputedFunction(runtimeDataIdx, From, target.tpe)
-                .callUnaryApply(srcPrefixTree),
+                .callUnaryApply(config.srcPrefixTree),
               DerivationTarget.TotalTransformer
             )
           }
@@ -123,7 +122,7 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils with Gen
               q"""
                 ${config.transformerDefinitionPrefix
                   .accessOverriddenComputedFunction(runtimeDataIdx, From, fTargetTpe)
-                  .callUnaryApply(srcPrefixTree)}
+                  .callUnaryApply(config.srcPrefixTree)}
                   .prependErrorPath(${Trees.PathElement.accessor(target.name)})
               """,
               config.derivationTarget
@@ -147,7 +146,7 @@ trait MappingMacros extends Model with TypeTestUtils with DslMacroUtils with Gen
             target -> TransformerBodyTree(
               config.transformerDefinitionPrefix
                 .accessOverriddenComputedFunction(runtimeDataIdx, From, fTargetTpe)
-                .callUnaryApply(srcPrefixTree),
+                .callUnaryApply(config.srcPrefixTree),
               config.derivationTarget
             )
           }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/PatcherMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/PatcherMacros.scala
@@ -91,7 +91,7 @@ trait PatcherMacros extends PatcherConfiguration with TransformerMacros with Gen
           if (patchParamTpe <:< tParamTpe) {
             Right(pParam.name -> q"$patchField.orElse($entityField)")
           } else {
-            expandTransformerTree(patchField, TransformerConfig())(
+            expandTransformerTree(TransformerConfig().withSrcPrefixTree(patchField))(
               patchParamTpe,
               tParamTpe
             ).map { transformerTree =>
@@ -104,7 +104,7 @@ trait PatcherMacros extends PatcherConfiguration with TransformerMacros with Gen
         Some(Right(pParam.name -> patchField))
       case Some(tParam) =>
         Some(
-          expandTransformerTree(patchField, TransformerConfig())(
+          expandTransformerTree(TransformerConfig().withSrcPrefixTree(patchField))(
             patchParamTpe,
             tParam.resultTypeIn(T)
           ).map { transformerTree =>
@@ -112,7 +112,7 @@ trait PatcherMacros extends PatcherConfiguration with TransformerMacros with Gen
           }.left
             .flatMap { errors =>
               if (isOption(patchParamTpe)) {
-                expandTransformerTree(q"$patchField.get", TransformerConfig())(
+                expandTransformerTree(TransformerConfig().withSrcPrefixTree(q"$patchField.get"))(
                   patchParamTpe.typeArgs.head,
                   tParam.resultTypeIn(T)
                 ).map { innerTransformerTree =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -70,7 +70,8 @@ trait TransformerConfigSupport extends MacroUtils {
     }
   }
 
-  case class TransformerConfig(
+  case class TransformerConfig( // TODO: rename to TransformerContext
+      srcPrefixTree: Tree = EmptyTree,
       derivationTarget: DerivationTarget = DerivationTarget.TotalTransformer,
       flags: TransformerFlags = TransformerFlags(),
       fieldOverrides: Map[String, FieldOverride] = Map.empty,
@@ -81,10 +82,10 @@ trait TransformerConfigSupport extends MacroUtils {
       definitionScope: Option[(Type, Type)] = None
   ) {
 
-    def withDerivationTarget(derivationTarget: DerivationTarget): TransformerConfig = {
+    def withSrcPrefixTree(srcPrefixTree: Tree): TransformerConfig =
+      copy(srcPrefixTree = srcPrefixTree)
+    def withDerivationTarget(derivationTarget: DerivationTarget): TransformerConfig =
       copy(derivationTarget = derivationTarget)
-    }
-
     def withTransformerDefinitionPrefix(tdPrefix: Tree): TransformerConfig =
       copy(transformerDefinitionPrefix = tdPrefix)
     def withDefinitionScope(fromTpe: Type, toTpe: Type): TransformerConfig =


### PR DESCRIPTION
It doesn't affect behavior, but makes `srcPrefixTree` part of `TransformerConfig`, simplifying transformation rules functions signatures.
