### PR TITLE
Deferred wrapping of generated code

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/PatcherMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/PatcherMacros.scala
@@ -95,7 +95,7 @@ trait PatcherMacros extends PatcherConfiguration with TransformerMacros with Gen
               patchParamTpe,
               tParamTpe
             ).map { transformerTree =>
-              pParam.name -> q"$transformerTree.orElse($entityField)"
+              pParam.name -> q"${transformerTree.tree}.orElse($entityField)"
             }.left
               .map(TransformerDerivationError.printErrors)
           }
@@ -108,7 +108,7 @@ trait PatcherMacros extends PatcherConfiguration with TransformerMacros with Gen
             patchParamTpe,
             tParam.resultTypeIn(T)
           ).map { transformerTree =>
-            pParam.name -> transformerTree
+            pParam.name -> transformerTree.tree
           }.left
             .flatMap { errors =>
               if (isOption(patchParamTpe)) {
@@ -116,7 +116,7 @@ trait PatcherMacros extends PatcherConfiguration with TransformerMacros with Gen
                   patchParamTpe.typeArgs.head,
                   tParam.resultTypeIn(T)
                 ).map { innerTransformerTree =>
-                  pParam.name -> q"if($patchField.isDefined) { $innerTransformerTree } else { $entityField }"
+                  pParam.name -> q"if($patchField.isDefined) { ${innerTransformerTree.tree} } else { $entityField }"
                 }.left
                   .map(errors2 => TransformerDerivationError.printErrors(errors ++ errors2))
               } else {


### PR DESCRIPTION
So far generated transformers were eagerly wrapped in requested derivation targets types (`partial.Result.fromValue` or `TransformerFSupport.pure`), even for trivial cases.

This PR brings more flexibility and adjust the contract so that they can always return simpler total transformer, even if requested deriving partial/lifted target. That allows to generate much simpler resulting code for complex transformers. Wrapping in target types is deferred and performed only at the end of derivation. 

To give an example, the simple example from tests was previously expanded into something like this:

```
final def rd_name$11: _root_.io.scalaland.chimney.partial.Result[String] = _root_.io.scalaland.chimney.partial.Result.Value(person$11.name).prependErrorPath(_root_.io.scalaland.chimney.partial.PathElement.Accessor("name"));
final def rd_age$11: _root_.io.scalaland.chimney.partial.Result[Int] = _root_.io.scalaland.chimney.partial.Result.Value(person$11.age).prependErrorPath(_root_.io.scalaland.chimney.partial.PathElement.Accessor("age"));
final def rd_height$10: _root_.io.scalaland.chimney.partial.Result[Double] = ti$41.td.runtimeData(0).asInstanceOf[io.scalaland.chimney.partial.Result[Double]].prependErrorPath(_root_.io.scalaland.chimney.partial.PathElement.Accessor("height"));
if (failfast$49) {
  rd_name$11.flatMap(((rvff_name$11) => rd_age$11.flatMap(((rvff_age$11) => rd_height$10.map(((rvff_height$10) => new io.scalaland.chimney.examples.trip.User(rvff_name$11, rvff_age$11, rvff_height$10)))))))
} else {
  final val rv_name$11 = rd_name$11;
  final val rv_age$11 = rd_age$11;
  final val rv_height$10 = rd_height$10;
  var allerrors$23: _root_.io.scalaland.chimney.partial.Result.Errors = null;
  allerrors$23 = _root_.io.scalaland.chimney.partial.Result.Errors.mergeResult(allerrors$23, rv_name$11);
  allerrors$23 = _root_.io.scalaland.chimney.partial.Result.Errors.mergeResult(allerrors$23, rv_age$11);
  allerrors$23 = _root_.io.scalaland.chimney.partial.Result.Errors.mergeResult(allerrors$23, rv_height$10);
  if (allerrors$23.$eq$eq(null)) {
    _root_.io.scalaland.chimney.partial.Result.Value(new io.scalaland.chimney.examples.trip.User(rv_name$11.asInstanceOf[_root_.io.scalaland.chimney.partial.Result.Value[String]].value, rv_age$11.asInstanceOf[_root_.io.scalaland.chimney.partial.Result.Value[Int]].value, rv_height$10.asInstanceOf[_root_.io.scalaland.chimney.partial.Result.Value[Double]].value))
  } else {
    allerrors$23
  }
}  
```

After this improvement, it will be simplified to semantically equivalent code
```
ti$41.td.runtimeData(0)
  .asInstanceOf[io.scalaland.chimney.partial.Result[Double]]
  .prependErrorPath(_root_.io.scalaland.chimney.partial.PathElement.Accessor("height"))
  .map(((height$3: Double) =>
    new io.scalaland.chimney.examples.trip.User(person$11.name, person$11.age, height$3))
  )
```
eliminating ceremony of wrapping `name` and `age` in partial value, prepending with error path, allowing the composition code to call trivial total accessors directly and making the final code much simpler.