### PR TITLE
Fix majority of compilation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ val settings = Seq(
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) =>
-        Seq("-release", "8", "-Wunused:patvars", "-Ytasty-reader", "-Wconf:origin=scala.collection.compat.*:s")
+        Seq("-release", "8", "-Wunused:patvars", "-Ytasty-reader", "-Wconf:origin=scala.collection.compat.*:s", "-Xfatal-warnings")
       case Some((2, 12)) =>
         Seq(
           "-target:jvm-1.8",

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,8 @@ val settings = Seq(
     "-Ywarn-macros:after",
 //    "-Xfatal-warnings",
     "-language:higherKinds",
-    "-Xsource:3"
+    "-Xsource:3",
+    "-Wconf:cat=deprecation&origin=io.scalaland.chimney.*:s"
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build.sbt
+++ b/build.sbt
@@ -58,10 +58,10 @@ val settings = Seq(
     "-Ywarn-unused:locals",
     "-Ywarn-unused:imports",
     "-Ywarn-macros:after",
-//    "-Xfatal-warnings",
     "-language:higherKinds",
     "-Xsource:3",
-    "-Wconf:cat=deprecation&origin=io.scalaland.chimney.*:s"
+    "-Wconf:cat=deprecation&origin=io.scalaland.chimney.*:s",
+    "-Wconf:src=io/scalaland/chimney/cats/package.scala:s" // silence package object inheritance deprecation
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/Model.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/Model.scala
@@ -31,8 +31,11 @@ trait Model extends TransformerConfigSupport {
   case class InstanceClause(matchName: Option[TermName], matchTpe: Type, body: DerivedTree) {
     def toPatMatClauseTree: Tree = {
       matchName match {
-        case Some(name) => cq"$name: $matchTpe => ${body.tree}"
-        case None       => cq"_: $matchTpe => ${body.tree}"
+        case Some(name) =>
+          // in general pat var name is not tracked whether it was used in body tree
+          // introducing synthetic val _ helps avoid reporting unused warnings in macro-generated code
+          cq"$name: $matchTpe => { val _ = $name; ${body.tree} }"
+        case None => cq"_: $matchTpe => ${body.tree}"
       }
     }
     def mapBody(f: DerivedTree => DerivedTree): InstanceClause = copy(body = f(body))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -62,7 +62,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](derivationTarget: DerivationTarget)(callTransform: (Tree, Tree) => Tree): Tree = {
+  ](derivationTarget: DerivationTarget, tcTree: c.Tree)(callTransform: (Tree, Tree) => Tree): Tree = {
     val tiName = freshTermName("ti")
 
     val config = readConfig[C, InstanceFlags, ScopeFlags]
@@ -72,8 +72,11 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     val derivedTransformerTree = genTransformer[From, To](config)
 
     q"""
-       final val $tiName = ${c.prefix.tree}
-       ${callTransform(derivedTransformerTree, q"$tiName.source")}
+       {
+         val _ = $tcTree // hack to avoid unused warnings
+         val $tiName = ${c.prefix.tree}
+         ${callTransform(derivedTransformerTree, q"$tiName.source")}
+       }
     """
   }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
@@ -60,9 +60,9 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](@unused tc: c.Tree): c.Expr[To] = {
+  ](tc: c.Tree): c.Expr[To] = {
     c.Expr[To](
-      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.TotalTransformer) {
+      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.TotalTransformer, tc) {
         (derivedTransformer, srcField) =>
           derivedTransformer.callTransform(srcField)
       }
@@ -75,9 +75,9 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](@unused tc: c.Tree): c.Expr[To] = {
+  ](tc: c.Tree): c.Expr[To] = {
     c.Expr[To](
-      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.PartialTransformer()) {
+      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.PartialTransformer(), tc) {
         (derivedTransformer, srcField) =>
           derivedTransformer.callPartialTransform(srcField, q"false")
       }
@@ -90,9 +90,9 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
-  ](@unused tc: c.Tree): c.Expr[To] = {
+  ](tc: c.Tree): c.Expr[To] = {
     c.Expr[To](
-      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.PartialTransformer()) {
+      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.PartialTransformer(), tc) {
         (derivedTransformer, srcField) =>
           derivedTransformer.callPartialTransform(srcField, q"true")
       }
@@ -107,14 +107,14 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       InstanceFlags: WeakTypeTag,
       ScopeFlags: WeakTypeTag
   ](
-      @unused tc: c.Tree,
+      tc: c.Tree,
       tfs: c.Expr[TransformerFSupport[F]]
   ): c.Expr[F[To]] = {
     val wrapperType = extractWrapperType(weakTypeOf[C])
     val derivationTarget =
       DerivationTarget.LiftedTransformer(wrapperType, tfs.tree, findTransformerErrorPathSupport(wrapperType))
     c.Expr[F[To]](
-      expandTransform[From, To, C, InstanceFlags, ScopeFlags](derivationTarget) { (derivedTransformer, srcField) =>
+      expandTransform[From, To, C, InstanceFlags, ScopeFlags](derivationTarget, tc) { (derivedTransformer, srcField) =>
         derivedTransformer.callTransform(srcField)
       }
     )

--- a/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerJavaBeanSpec.scala
@@ -4,6 +4,8 @@ import utest.*
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.examples.javabeans.*
 
+import scala.annotation.nowarn
+
 object LiftedTransformerJavaBeanSpec extends TestSuite {
 
   val tests = Tests {
@@ -25,7 +27,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
       }
 
       test("when F = Either[List[String], +*]") {
-        type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+        @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
         compileError(
           """new JavaBeanSourceWithFlag(id = "test-id", name = "test-name", flag = true).intoF[EitherList, CaseClassWithFlag].transform"""
         ).check(
@@ -53,7 +55,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
       }
 
       test("when F = Either[List[String], +*]") {
-        type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+        @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
         compileError("""CaseClassWithFlag("100", "name", flag = true).intoF[EitherList, JavaBeanTarget].transform""")
           .check(
             "",
@@ -172,7 +174,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           compileError("""
              case class MistypedTarget(flag: Int)
              class MistypedSource(private var flag: Int) {
@@ -221,7 +223,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError(
@@ -261,7 +263,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError(
@@ -349,7 +351,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           compileError("""
             CaseClassNoFlag("100", "name")
               .intoF[EitherList, JavaBeanTarget]
@@ -415,7 +417,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           compileError("""
             CaseClassWithFlagMethod("100", "name")
               .intoF[EitherList, JavaBeanTarget]
@@ -514,7 +516,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           implicit val config = TransformerConfiguration.default.enableBeanSetters
 
           compileError("""
@@ -606,7 +608,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           implicit val config = TransformerConfiguration.default.enableMethodAccessors
 
           compileError("""
@@ -660,7 +662,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           // need to enable both setters and getters; only one of them is not enough for this use case!
           compileError("source.intoF[EitherList, JavaBeanTarget].transform")

--- a/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerJavaBeanSpec.scala
@@ -4,7 +4,7 @@ import utest.*
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.examples.javabeans.*
 
-import scala.annotation.nowarn
+import scala.annotation.{nowarn, unused}
 
 object LiftedTransformerJavaBeanSpec extends TestSuite {
 
@@ -160,7 +160,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
             .check("", "Chimney can't derive transformation from MistypedSource to MistypedTarget")
 
           locally {
-            implicit val config = TransformerConfiguration.default.enableBeanGetters
+            @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
             compileError("""
                case class MistypedTarget(flag: Int)
@@ -185,7 +185,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
             .check("", "Chimney can't derive transformation from MistypedSource to MistypedTarget")
 
           locally {
-            implicit val config = TransformerConfiguration.default.enableBeanGetters
+            @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
             compileError("""
                case class MistypedTarget(flag: Int)
@@ -205,7 +205,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
       test("should disable globally enabled .enableBeanGetters") {
 
         test("when F = Option") {
-          implicit val config = TransformerConfiguration.default.enableBeanGetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError(
             """
@@ -224,7 +224,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
 
         test("when F = Either[List[String], +*]") {
           @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
-          implicit val config = TransformerConfiguration.default.enableBeanGetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError(
             """
@@ -245,7 +245,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
       test("should disable globally enabled .enableBeanGetters") {
 
         test("when F = Option") {
-          implicit val config = TransformerConfiguration.default.enableBeanGetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError(
             """
@@ -264,7 +264,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
 
         test("when F = Either[List[String], +*]") {
           @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
-          implicit val config = TransformerConfiguration.default.enableBeanGetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError(
             """
@@ -336,7 +336,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
             )
 
           locally {
-            implicit val config = TransformerConfiguration.default.enableBeanSetters
+            @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
             compileError("""
               CaseClassNoFlag("100", "name")
@@ -364,7 +364,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
             )
 
           locally {
-            implicit val config = TransformerConfiguration.default.enableBeanSetters
+            @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
             compileError("""
               CaseClassNoFlag("100", "name")
@@ -398,7 +398,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
             )
 
           locally {
-            implicit val config = TransformerConfiguration.default.enableBeanSetters
+            @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
             compileError("""
               CaseClassWithFlagMethod("100", "name")
@@ -434,7 +434,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
             )
 
           locally {
-            implicit val config = TransformerConfiguration.default.enableBeanSetters
+            @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
             compileError("""
               CaseClassWithFlagMethod("100", "name")
@@ -498,7 +498,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
       test("should disable globally enabled .enableBeanSetters") {
 
         test("when F = Option") {
-          implicit val config = TransformerConfiguration.default.enableBeanSetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
           compileError("""
             CaseClassWithFlag("100", "name", flag = true)
@@ -517,7 +517,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
 
         test("when F = Either[List[String], +*]") {
           @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
-          implicit val config = TransformerConfiguration.default.enableBeanSetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
           compileError("""
             CaseClassWithFlag("100", "name", flag = true)
@@ -588,7 +588,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
       test("should disable globally enabled .MethodAccessors") {
 
         test("when F = Option") {
-          implicit val config = TransformerConfiguration.default.enableMethodAccessors
+          @unused implicit val config = TransformerConfiguration.default.enableMethodAccessors
 
           compileError("""
             CaseClassWithFlagMethod("100", "name")
@@ -609,7 +609,7 @@ object LiftedTransformerJavaBeanSpec extends TestSuite {
 
         test("when F = Either[List[String], +*]") {
           @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
-          implicit val config = TransformerConfiguration.default.enableMethodAccessors
+          @unused implicit val config = TransformerConfiguration.default.enableMethodAccessors
 
           compileError("""
             CaseClassWithFlagMethod("100", "name")

--- a/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerProductSpec.scala
@@ -6,6 +6,8 @@ import io.scalaland.chimney.utils.EitherUtils.*
 import io.scalaland.chimney.utils.OptionUtils.*
 import utest.*
 
+import scala.annotation.nowarn
+
 object LiftedTransformerProductSpec extends TestSuite {
 
   val tests = Tests {
@@ -63,7 +65,7 @@ object LiftedTransformerProductSpec extends TestSuite {
       }
 
       test("when F = Either[List[String], +*]") {
-        type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+        @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
         compileError("Bar(3, (3.14, 3.14)).transformIntoF[EitherList, Foo]").check(
           "",
@@ -135,7 +137,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError(
             """
@@ -227,7 +229,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError(
             """
@@ -338,7 +340,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError(
             """
@@ -448,7 +450,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError(
             """
@@ -548,7 +550,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError("""User(1, "Kuba", Some(28)).transformIntoF[EitherList, UserPL]""").check(
             "",
@@ -599,7 +601,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError(
             """
@@ -692,7 +694,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError(
             """
@@ -813,7 +815,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError("""Source(1, "yy", 1.0).transformIntoF[EitherList, Target]""").check(
             "",
@@ -1049,7 +1051,7 @@ object LiftedTransformerProductSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
           compileError("""Source(1, "yy", 1.0).intoF[EitherList, Target].disableDefaultValues.transform""").check(
             "",

--- a/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerProductSpec.scala
@@ -6,7 +6,7 @@ import io.scalaland.chimney.utils.EitherUtils.*
 import io.scalaland.chimney.utils.OptionUtils.*
 import utest.*
 
-import scala.annotation.nowarn
+import scala.annotation.{nowarn, unused}
 
 object LiftedTransformerProductSpec extends TestSuite {
 
@@ -1037,7 +1037,7 @@ object LiftedTransformerProductSpec extends TestSuite {
       test("should disable globally enabled .enableDefaultValues") {
         import products.Defaults.*
 
-        implicit val config = TransformerConfiguration.default.enableDefaultValues
+        @unused implicit val config = TransformerConfiguration.default.enableDefaultValues
 
         test("when F = Option") {
           compileError("""Source(1, "yy", 1.0).intoF[Option, Target].disableDefaultValues.transform""").check(

--- a/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerSdtLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerSdtLibTypesSpec.scala
@@ -5,6 +5,7 @@ import io.scalaland.chimney.utils.EitherUtils.*
 import io.scalaland.chimney.utils.OptionUtils.*
 import utest.*
 
+import scala.annotation.nowarn
 import scala.collection.immutable.Queue
 import scala.collection.mutable.ArrayBuffer
 
@@ -30,7 +31,7 @@ object LiftedTransformerSdtLibTypesSpec extends TestSuite {
       }
 
       test("when F = Either[List[String], +*]") {
-        type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+        @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
 
         compileError("""Buzz("a").transformIntoF[EitherList, ConflictingFooBuzz]""").check(
           "",
@@ -559,7 +560,7 @@ object LiftedTransformerSdtLibTypesSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           compileError(
             """Source("foo").intoF[EitherList, TargetWithOption].transform ==> Right(TargetWithOption("foo", None))"""
           ).check(
@@ -674,7 +675,7 @@ object LiftedTransformerSdtLibTypesSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           compileError("""Source(Some(1)).intoF[EitherList, Target].transform ==> Right(Target("1"))""").check(
             "",
             "Chimney can't derive transformation from Source to Target",

--- a/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerSumTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/LiftedTransformerSumTypeSpec.scala
@@ -6,6 +6,8 @@ import io.scalaland.chimney.utils.EitherUtils.*
 import io.scalaland.chimney.utils.OptionUtils.*
 import utest.*
 
+import scala.annotation.nowarn
+
 object LiftedTransformerSumTypeSpec extends TestSuite {
 
   val tests = Tests {
@@ -220,7 +222,7 @@ object LiftedTransformerSumTypeSpec extends TestSuite {
         }
 
         test("when F = Either[List[String], +*]") {
-          type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
+          @nowarn type EitherList[+A] = Either[List[String], A] // String parsing macro cannot accept +* as type
           compileError("""(colors2.Black: colors2.Color).transformIntoF[EitherList, colors1.Color]""").check(
             "",
             "Chimney can't derive transformation from io.scalaland.chimney.examples.colors2.Color to io.scalaland.chimney.examples.colors1.Color",

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
@@ -4,6 +4,8 @@ import utest.*
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.examples.javabeans.*
 
+import scala.annotation.unused
+
 object PartialTransformerJavaBeanSpec extends TestSuite {
 
   val tests = Tests {
@@ -84,7 +86,7 @@ object PartialTransformerJavaBeanSpec extends TestSuite {
           .check("", "Chimney can't derive transformation from MistypedSource to MistypedTarget")
 
         locally {
-          implicit val config = TransformerConfiguration.default.enableBeanGetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError("""
                case class MistypedTarget(flag: Int)
@@ -101,7 +103,7 @@ object PartialTransformerJavaBeanSpec extends TestSuite {
     test("""flag .disableBeanGetters""") {
 
       test("should disable globally enabled .enableBeanGetters") {
-        implicit val config = TransformerConfiguration.default.enableBeanGetters
+        @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
         compileError(
           """
@@ -156,7 +158,7 @@ object PartialTransformerJavaBeanSpec extends TestSuite {
           )
 
         locally {
-          implicit val config = TransformerConfiguration.default.enableBeanSetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
           compileError("""
               CaseClassNoFlag("100", "name")
@@ -187,7 +189,7 @@ object PartialTransformerJavaBeanSpec extends TestSuite {
           )
 
         locally {
-          implicit val config = TransformerConfiguration.default.enableBeanSetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
           compileError("""
               CaseClassWithFlagMethod("100", "name")
@@ -229,7 +231,7 @@ object PartialTransformerJavaBeanSpec extends TestSuite {
     test("""flag .disableBeanSetters""") {
 
       test("should disable globally enabled .enableBeanSetters") {
-        implicit val config = TransformerConfiguration.default.enableBeanSetters
+        @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
         compileError("""
             CaseClassWithFlag("100", "name", flag = true)
@@ -279,7 +281,7 @@ object PartialTransformerJavaBeanSpec extends TestSuite {
     test("""flag .enableMethodAccessors""") {
 
       test("should disable globally enabled .MethodAccessors") {
-        implicit val config = TransformerConfiguration.default.enableMethodAccessors
+        @unused implicit val config = TransformerConfiguration.default.enableMethodAccessors
 
         compileError("""
             CaseClassWithFlagMethod("100", "name")

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -5,6 +5,8 @@ import io.scalaland.chimney.examples.*
 import io.scalaland.chimney.utils.OptionUtils.*
 import utest.*
 
+import scala.annotation.unused
+
 object PartialTransformerProductSpec extends TestSuite {
 
   val tests = Tests {
@@ -661,7 +663,7 @@ object PartialTransformerProductSpec extends TestSuite {
       test("should disable globally enabled .enableDefaultValues") {
         import products.Defaults.*
 
-        implicit val config = TransformerConfiguration.default.enableDefaultValues
+        @unused implicit val config = TransformerConfiguration.default.enableDefaultValues
 
         compileError("""Source(1, "yy", 1.0).intoPartial[Target].disableDefaultValues.transform""").check(
           "",

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
@@ -4,6 +4,8 @@ import utest.*
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.examples.javabeans.*
 
+import scala.annotation.unused
+
 object TotalTransformerJavaBeansSpec extends TestSuite {
 
   val tests = Tests {
@@ -78,7 +80,7 @@ object TotalTransformerJavaBeansSpec extends TestSuite {
           .check("", "Chimney can't derive transformation from MistypedSource to MistypedTarget")
 
         locally {
-          implicit val config = TransformerConfiguration.default.enableBeanGetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
           compileError("""
                case class MistypedTarget(flag: Int)
@@ -95,7 +97,7 @@ object TotalTransformerJavaBeansSpec extends TestSuite {
     test("""flag .disableBeanGetters""") {
 
       test("should disable globally enabled .enableBeanGetters") {
-        implicit val config = TransformerConfiguration.default.enableBeanGetters
+        @unused implicit val config = TransformerConfiguration.default.enableBeanGetters
 
         compileError(
           """
@@ -148,7 +150,7 @@ object TotalTransformerJavaBeansSpec extends TestSuite {
           )
 
         locally {
-          implicit val config = TransformerConfiguration.default.enableBeanSetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
           compileError("""
               CaseClassNoFlag("100", "name")
@@ -179,7 +181,7 @@ object TotalTransformerJavaBeansSpec extends TestSuite {
           )
 
         locally {
-          implicit val config = TransformerConfiguration.default.enableBeanSetters
+          @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
           compileError("""
               CaseClassWithFlagMethod("100", "name")
@@ -219,7 +221,7 @@ object TotalTransformerJavaBeansSpec extends TestSuite {
     test("""flag .disableBeanSetters""") {
 
       test("should disable globally enabled .enableBeanSetters") {
-        implicit val config = TransformerConfiguration.default.enableBeanSetters
+        @unused implicit val config = TransformerConfiguration.default.enableBeanSetters
 
         compileError("""
             CaseClassWithFlag("100", "name", flag = true)
@@ -267,7 +269,7 @@ object TotalTransformerJavaBeansSpec extends TestSuite {
     test("""flag .enableMethodAccessors""") {
 
       test("should disable globally enabled .MethodAccessors") {
-        implicit val config = TransformerConfiguration.default.enableMethodAccessors
+        @unused implicit val config = TransformerConfiguration.default.enableMethodAccessors
 
         compileError("""
             CaseClassWithFlagMethod("100", "name")

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -4,6 +4,8 @@ import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.examples.*
 import utest.*
 
+import scala.annotation.unused
+
 object TotalTransformerProductSpec extends TestSuite {
 
   val tests = Tests {
@@ -327,7 +329,7 @@ object TotalTransformerProductSpec extends TestSuite {
       test("should disable globally enabled .enableDefaultValues") {
         import products.Defaults.*
 
-        implicit val config = TransformerConfiguration.default.enableDefaultValues
+        @unused implicit val config = TransformerConfiguration.default.enableDefaultValues
 
         compileError("""Source(1, "yy", 1.0).into[Target].disableDefaultValues.transform""").check(
           "",

--- a/chimneyCats/src/main/scala/io/scalaland/chimney/cats/CatsPartialTransformerImplicits.scala
+++ b/chimneyCats/src/main/scala/io/scalaland/chimney/cats/CatsPartialTransformerImplicits.scala
@@ -5,7 +5,6 @@ import _root_.cats.kernel.Semigroup
 import _root_.cats.Applicative
 import io.scalaland.chimney.partial
 
-import scala.collection.compat.*
 import language.implicitConversions
 
 /** @since 0.7.0 */

--- a/chimneyCats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerResultErrorSemigroupSpec.scala
+++ b/chimneyCats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerResultErrorSemigroupSpec.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.cats
 
 import _root_.cats.syntax.semigroup.*
-import io.scalaland.chimney.{partial, PartialTransformer}
+import io.scalaland.chimney.partial
 import utest.*
 
 object PartialTransformerResultErrorSemigroupSpec extends TestSuite {

--- a/chimneyCats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerResultSemigroupalSpec.scala
+++ b/chimneyCats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerResultSemigroupalSpec.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.cats
 
 import _root_.cats.syntax.semigroupal.*
-import io.scalaland.chimney.{partial, PartialTransformer}
+import io.scalaland.chimney.partial
 import utest.*
 
 object PartialTransformerResultSemigroupalSpec extends TestSuite {

--- a/chimneyCats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerToCatsDataConversionSpec.scala
+++ b/chimneyCats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerToCatsDataConversionSpec.scala
@@ -6,7 +6,6 @@ import _root_.cats.syntax.semigroup.*
 import _root_.cats.syntax.semigroupal.*
 import cats.Semigroupal
 import io.scalaland.chimney.partial
-import io.scalaland.chimney.PartialTransformer
 import io.scalaland.chimney.partial.{Error, PathElement}
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.examples.trip.*


### PR DESCRIPTION
This PR fixes (or silences globally) majority of the compilation warnings and brings back `-Xfatal-warnings` for Scala 2.13.

For 2.12 it seems that semantics of `@unused` annotation is a bit different for tests asserting compilation errors.

It also fixes two classes of unused warnings in macro-generated code:
- one related to implicit `TransformerConfiguration`, when it's defined
- one related to sealed classes (coproducts) pattern match variables