### PR TITLE
Move to new macros endpoints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalafmtOnCompile := !isCI
 val versions = new {
   val scala212 = "2.12.17"
   val scala213 = "2.13.10"
-  val scala3 = "3.3.0-RC4"
+  val scala3 = "3.3.0-RC5"
 
   // Which versions should be cross-compiled for publishing
   val scalas = List(scala212, scala213, scala3)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -161,10 +161,10 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     *
     * @since 0.7.0
     */
-  def buildTransformer[ScopeFlags <: TransformerFlags](implicit
-      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
+  def buildTransformer[ImplicitScopeFlags <: TransformerFlags](implicit
+      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]
   ): PartialTransformer[From, To] =
-    macro TransformerBlackboxMacros.buildPartialTransformerImpl[From, To, Cfg, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.buildPartialTransformerImpl[From, To, Cfg, Flags, ImplicitScopeFlags]
 
   override protected def __updateRuntimeData(newRuntimeData: TransformerDefinitionCommons.RuntimeDataStore): this.type =
     new PartialTransformerDefinition(newRuntimeData).asInstanceOf[this.type]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -170,10 +170,10 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     *
     * @since 0.7.0
     */
-  def transform[ScopeFlags <: TransformerFlags](implicit
-      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
+  def transform[ImplicitScopeFlags <: TransformerFlags](implicit
+      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]
   ): partial.Result[To] =
-    macro TransformerBlackboxMacros.partialTransformNoFailFastImpl[From, To, Cfg, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.partialTransformNoFailFastImpl[From, To, Cfg, Flags, ImplicitScopeFlags]
 
   /** Apply configured partial transformation in-place in a short-circuit (fail fast) mode.
     *
@@ -185,10 +185,10 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     *
     * @since 0.7.0
     */
-  def transformFailFast[ScopeFlags <: TransformerFlags](implicit
-      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
+  def transformFailFast[ImplicitScopeFlags <: TransformerFlags](implicit
+      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]
   ): partial.Result[To] =
-    macro TransformerBlackboxMacros.partialTransformFailFastImpl[From, To, Cfg, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.partialTransformFailFastImpl[From, To, Cfg, Flags, ImplicitScopeFlags]
 
   /** Used internally by macro. Please don't use in your code.
     */

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -117,10 +117,10 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
     *
     * @since 0.4.0
     */
-  def buildTransformer[ScopeFlags <: TransformerFlags](implicit
-      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
+  def buildTransformer[ImplicitScopeFlags <: TransformerFlags](implicit
+      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]
   ): Transformer[From, To] =
-    macro TransformerBlackboxMacros.buildTransformerImpl[From, To, Cfg, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.buildTransformerImpl[From, To, Cfg, Flags, ImplicitScopeFlags]
 
   override protected def __updateRuntimeData(newRuntimeData: TransformerDefinitionCommons.RuntimeDataStore): this.type =
     new TransformerDefinition(newRuntimeData).asInstanceOf[this.type]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -114,10 +114,10 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
     *
     * @since 0.1.0
     */
-  def transform[ScopeFlags <: TransformerFlags](implicit
-      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ScopeFlags]
+  def transform[ImplicitScopeFlags <: TransformerFlags](implicit
+      tc: io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]
   ): To =
-    macro TransformerBlackboxMacros.transformImpl[From, To, Cfg, Flags, ScopeFlags]
+    macro TransformerBlackboxMacros.transformImpl[From, To, Cfg, Flags, ImplicitScopeFlags]
 
   /** Used internally by macro. Please don't use in your code.
     */

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -81,6 +81,9 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Def
 
     object RuntimeDataStore extends RuntimeDataStoreModule {
 
+      val empty: Expr[TransformerDefinitionCommons.RuntimeDataStore] =
+        c.Expr(q"_root_.io.scalaland.chimney.dsl.TransformerDefinitionCommons.emptyRuntimeDataStore")
+
       def extractAt(
           runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore],
           index: Int

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney.internal.compiletime
 
-import io.scalaland.chimney.dsl.ImplicitTransformerPreference
+import io.scalaland.chimney.dsl.{ImplicitTransformerPreference, TransformerDefinitionCommons}
 import io.scalaland.chimney.partial
 import io.scalaland.chimney.internal
 import io.scalaland.chimney.{PartialTransformer, Patcher, Transformer}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -35,6 +35,9 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Def
     val PreferPartialTransformer: Type[io.scalaland.chimney.dsl.PreferPartialTransformer.type] =
       fromWeak[io.scalaland.chimney.dsl.PreferPartialTransformer.type]
 
+    val RuntimeDataStore: Type[TransformerDefinitionCommons.RuntimeDataStore] =
+      fromWeak[TransformerDefinitionCommons.RuntimeDataStore]
+
     object TransformerCfg extends TransformerCfgModule {
       val Empty: Type[internal.TransformerCfg.Empty] = fromWeak[internal.TransformerCfg.Empty]
     }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -153,4 +153,14 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
       }
     }
   }
+
+  implicit private class StringSingletonTypeOps(private val tpe: c.Type) {
+
+    /** Assumes that this `tpe` is String singleton type and extracts its value */
+    def asStringSingletonType: String = tpe
+      .asInstanceOf[scala.reflect.internal.Types#UniqueConstantType]
+      .value
+      .value
+      .asInstanceOf[String]
+  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -12,10 +12,10 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
     final override def readTransformerConfig[
         Cfg <: internal.TransformerCfg: Type,
         InstanceFlags <: internal.TransformerFlags: Type,
-        ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
+        ImplicitScopeFlags <: internal.TransformerFlags: Type
     ]: TransformerConfig = {
-      val implicitImplicitScopeFlags = extractTransformerFlags[ImplicitImplicitScopeFlags](TransformerFlags())
-      val allFlags = extractTransformerFlags[InstanceFlags](implicitImplicitScopeFlags)
+      val implicitScopeFlags = extractTransformerFlags[ImplicitScopeFlags](TransformerFlags())
+      val allFlags = extractTransformerFlags[InstanceFlags](implicitScopeFlags)
       extractTransformerConfig[Cfg](runtimeDataIdx = 0).copy(flags = allFlags)
     }
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -12,10 +12,10 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
     final override def readTransformerConfig[
         Cfg <: internal.TransformerCfg: Type,
         InstanceFlags <: internal.TransformerFlags: Type,
-        SharedFlags <: internal.TransformerFlags: Type
+        ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
     ]: TransformerConfig = {
-      val sharedFlags = extractTransformerFlags[SharedFlags](TransformerFlags())
-      val allFlags = extractTransformerFlags[InstanceFlags](sharedFlags)
+      val implicitImplicitScopeFlags = extractTransformerFlags[ImplicitImplicitScopeFlags](TransformerFlags())
+      val allFlags = extractTransformerFlags[InstanceFlags](implicitImplicitScopeFlags)
       extractTransformerConfig[Cfg](runtimeDataIdx = 0).copy(flags = allFlags)
     }
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -7,6 +7,7 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
   final override type Expr[A] = c.Expr[A]
 
   object Expr extends ExprModule {
+    val Nothing: Expr[Nothing] = c.Expr(q"???")
     val Unit: Expr[Unit] = c.Expr(q"()")
     def Array[A: Type](args: Expr[A]*): Expr[Array[A]] = c.Expr(q"_root_.scala.Array[${Type[A]}](..${args})")
     object Option extends OptionModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -31,6 +31,8 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
 
   object Type extends TypeModule {
     import typeUtils.*
+
+    val Nothing: Type[Nothing] = fromWeak[Nothing]
     val Any: Type[Any] = fromWeak[Any]
     val Boolean: Type[Boolean] = fromWeak[Boolean]
     val Int: Type[Int] = fromWeak[Int]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -53,14 +53,4 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
 
     def prettyPrint[T: Type]: String = Type[T].toString
   }
-
-  implicit class UntypedTypeOps(private val tpe: c.Type) {
-
-    /** Assumes that this `tpe` is String singleton type and extracts its value */
-    def asStringSingletonType: String = tpe
-      .asInstanceOf[scala.reflect.internal.Types#UniqueConstantType]
-      .value
-      .value
-      .asInstanceOf[String]
-  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -5,8 +5,8 @@ import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
 private[derivation] trait DerivationPlatform
     extends Derivation
     with rules.TransformSubtypesRuleModule
-    with DerivationWithLegacyMacros {
+    with rules.LegacyMacrosFallbackRuleModule {
   this: DefinitionsPlatform =>
 
-  override protected val rulesAvailableForPlatform: Seq[Rule] = Seq(TransformSubtypesRule, LegacyMacrosRule)
+  override protected val rulesAvailableForPlatform: Seq[Rule] = Seq(TransformSubtypesRule, LegacyMacrosFallbackRule)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/GatewayPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/GatewayPlatform.scala
@@ -1,9 +1,7 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer
 
 import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
-import io.scalaland.chimney.{internal, partial, PartialTransformer, Transformer}
-
-import scala.annotation.unused
+import io.scalaland.chimney.{partial, PartialTransformer, Transformer}
 
 trait GatewayPlatform extends Gateway {
   this: DefinitionsPlatform & DerivationPlatform =>
@@ -12,59 +10,6 @@ trait GatewayPlatform extends Gateway {
   import typeUtils.fromWeakConversion.*
 
   // Intended to be called directly from macro splicing site; converts WeakTypeTags into our internal Types
-
-  final def deriveTotalTransformationResultImpl[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      Cfg <: internal.TransformerCfg: WeakTypeTag,
-      InstanceFlags <: internal.TransformerFlags: WeakTypeTag,
-      SharedFlags <: internal.TransformerFlags: WeakTypeTag
-  ](@unused tc: c.Tree): Expr[To] =
-    deriveTotalTransformationResult[From, To, Cfg, InstanceFlags, SharedFlags](
-      c.Expr[From](q"${c.prefix}.source")
-    )
-
-//  final def deriveTotalTransformerImpl[
-//    From: WeakTypeTag,
-//    To: WeakTypeTag,
-//    Cfg <: internal.TransformerCfg : WeakTypeTag,
-//    InstanceFlags <: internal.TransformerFlags : WeakTypeTag,
-//    SharedFlags <: internal.TransformerFlags : WeakTypeTag
-//  ](@unused tc: c.Tree): Expr[Transformer[From, To]] =
-//    deriveTotalTransformer[From, To, Cfg, InstanceFlags, SharedFlags]
-
-  final def derivePartialTransformationResultFullImpl[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      Cfg <: internal.TransformerCfg: WeakTypeTag,
-      InstanceFlags <: internal.TransformerFlags: WeakTypeTag,
-      SharedFlags <: internal.TransformerFlags: WeakTypeTag
-  ](@unused tc: c.Tree): Expr[partial.Result[To]] =
-    derivePartialTransformationResult[From, To, Cfg, InstanceFlags, SharedFlags](
-      c.Expr[From](q"${c.prefix}.source"),
-      c.Expr[Boolean](q"false")
-    )
-
-  final def derivePartialTransformationResultFailFastImpl[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      Cfg <: internal.TransformerCfg: WeakTypeTag,
-      InstanceFlags <: internal.TransformerFlags: WeakTypeTag,
-      SharedFlags <: internal.TransformerFlags: WeakTypeTag
-  ](@unused tc: c.Tree): Expr[partial.Result[To]] =
-    derivePartialTransformationResult[From, To, Cfg, InstanceFlags, SharedFlags](
-      c.Expr[From](q"${c.prefix}.source"),
-      c.Expr[Boolean](q"true")
-    )
-
-  final def derivePartialTransformerImpl[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      Cfg <: internal.TransformerCfg: WeakTypeTag,
-      InstanceFlags <: internal.TransformerFlags: WeakTypeTag,
-      SharedFlags <: internal.TransformerFlags: WeakTypeTag
-  ](@unused tc: c.Tree): Expr[PartialTransformer[From, To]] =
-    derivePartialTransformer[From, To, Cfg, InstanceFlags, SharedFlags]
 
   override protected def instantiateTotalTransformer[From: Type, To: Type](
       toExpr: Expr[From] => Expr[To]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -78,7 +78,4 @@ final class TransformerMacros(val c: blackbox.Context)
        """
     )
   }
-
-  implicit private val EmptyConfigType: Type[Empty] = ChimneyType.TransformerCfg.Empty
-  implicit private val DefaultFlagsType: Type[Default] = ChimneyType.TransformerFlags.Default
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -20,7 +20,9 @@ final class TransformerMacros(val c: blackbox.Context)
   ]: c.universe.Expr[Transformer[From, To]] =
     resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
       import typeUtils.fromWeakConversion.*
-      deriveTotalTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
+      deriveTotalTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](
+        runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty
+      )
     }
 
   final def derivePartialTransformerWithDefaults[
@@ -29,7 +31,9 @@ final class TransformerMacros(val c: blackbox.Context)
   ]: c.universe.Expr[PartialTransformer[From, To]] =
     resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
       import typeUtils.fromWeakConversion.*
-      derivePartialTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
+      derivePartialTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore =
+        ChimneyExpr.RuntimeDataStore.empty
+      )
     }
 
   private def findImplicitScopeFlags: c.universe.Tree = {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -12,27 +12,27 @@ final class TransformerMacros(val c: blackbox.Context)
     with DerivationPlatform
     with GatewayPlatform {
 
-  type LocalConfigType <: internal.TransformerFlags
+  type ImplicitScopeFlagsType <: internal.TransformerFlags
 
   final def deriveTotalTransformerWithDefaults[
       From: c.WeakTypeTag,
       To: c.WeakTypeTag
   ]: c.universe.Expr[Transformer[From, To]] =
-    resolveLocalTransformerConfigAndMuteUnusedConfigWarnings { implicit LocalConfigType =>
+    resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
       import typeUtils.fromWeakConversion.*
-      deriveTotalTransformer[From, To, Empty, Default, LocalConfigType](runtimeDataStore = None)
+      deriveTotalTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
     }
 
   final def derivePartialTransformerWithDefaults[
       From: c.WeakTypeTag,
       To: c.WeakTypeTag
   ]: c.universe.Expr[PartialTransformer[From, To]] =
-    resolveLocalTransformerConfigAndMuteUnusedConfigWarnings { implicit LocalConfigType =>
+    resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
       import typeUtils.fromWeakConversion.*
-      derivePartialTransformer[From, To, Empty, Default, LocalConfigType](runtimeDataStore = None)
+      derivePartialTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
     }
 
-  private def findLocalTransformerConfigurationFlags: c.universe.Tree = {
+  private def findImplicitScopeFlags: c.universe.Tree = {
     import c.universe.*
 
     val searchTypeTree =
@@ -59,12 +59,12 @@ final class TransformerMacros(val c: blackbox.Context)
       .filterNot(_ == c.universe.EmptyTree)
   }
 
-  private def resolveLocalTransformerConfigAndMuteUnusedConfigWarnings[A](
-      useLocalConfig: Type[LocalConfigType] => Expr[A]
+  private def resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings[A](
+      useLocalConfig: Type[ImplicitScopeFlagsType] => Expr[A]
   ): Expr[A] = {
-    val localConfig = findLocalTransformerConfigurationFlags
+    val localConfig = findImplicitScopeFlags
     val localConfigType =
-      typeUtils.fromUntyped(localConfig.tpe.typeArgs.head).asInstanceOf[Type[LocalConfigType]]
+      typeUtils.fromUntyped(localConfig.tpe.typeArgs.head).asInstanceOf[Type[ImplicitScopeFlagsType]]
 
     import c.universe.*
     c.Expr[A](

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/LegacyMacrosFallbackRuleModule.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/LegacyMacrosFallbackRuleModule.scala
@@ -1,24 +1,23 @@
-package io.scalaland.chimney.internal.compiletime.derivation.transformer
+package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
 
 import io.scalaland.chimney.internal.TransformerDerivationError
 import io.scalaland.chimney.internal.compiletime.{
-  ConfigurationsPlatform,
-  Contexts,
   DefinitionsPlatform,
   DerivationError,
   DerivationErrors,
   DerivationResult
 }
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.DerivationPlatform
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 import io.scalaland.chimney.partial
 
 import scala.annotation.nowarn
 
 @nowarn("msg=The outer reference in this type test cannot be checked at run time.")
-private[compiletime] trait DerivationWithLegacyMacros {
-  this: DefinitionsPlatform & ConfigurationsPlatform & Contexts & Derivation =>
+private[compiletime] trait LegacyMacrosFallbackRuleModule {
+  this: DefinitionsPlatform & DerivationPlatform =>
 
-  protected object LegacyMacrosRule extends Rule {
+  protected object LegacyMacrosFallbackRule extends Rule {
 
     // we want this fallback to ALWAYS work until we no longer need it
     override def isApplicableTo[From, To](implicit ctx: TransformerContext[From, To]): Boolean = true

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerConfigSupport.scala
@@ -12,9 +12,9 @@ trait TransformerConfigSupport extends MacroUtils {
 
   import c.universe.*
 
-  def readConfig[C: WeakTypeTag, InstanceFlags: WeakTypeTag, ScopeFlags: WeakTypeTag]: TransformerConfig = {
-    val scopeFlags = captureTransformerFlags(weakTypeOf[ScopeFlags])
-    val combinedFlags = captureTransformerFlags(weakTypeOf[InstanceFlags], scopeFlags)
+  def readConfig[C: WeakTypeTag, InstanceFlags: WeakTypeTag, ImplicitScopeFlags: WeakTypeTag]: TransformerConfig = {
+    val implicitScopeFlags = captureTransformerFlags(weakTypeOf[ImplicitScopeFlags])
+    val combinedFlags = captureTransformerFlags(weakTypeOf[InstanceFlags], implicitScopeFlags)
 
     captureTransformerConfig(weakTypeOf[C], runtimeDataIdx = 0).copy(flags = combinedFlags)
   }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -46,7 +46,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   def deriveWithTarget[From: WeakTypeTag, To: WeakTypeTag, ResultTpe](
       derivationTarget: DerivationTarget
   ): c.Expr[ResultTpe] = {
-    val tcTree = findImplicitScopeFlags
+    val tcTree = findImplicitScopeTransformerConfiguration
     val flags = captureFromTransformerConfigurationTree(tcTree)
     val config = TransformerConfig(flags = flags)
       .withDefinitionScope(weakTypeOf[From], weakTypeOf[To])
@@ -857,7 +857,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     }
   }
 
-  def findImplicitScopeFlags: Tree = {
+  def findImplicitScopeTransformerConfiguration: Tree = {
     val searchTypeTree =
       tq"${typeOf[io.scalaland.chimney.dsl.TransformerConfiguration[? <: io.scalaland.chimney.internal.TransformerFlags]]}"
     inferImplicitTpe(searchTypeTree, macrosDisabled = false)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -46,7 +46,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
   def deriveWithTarget[From: WeakTypeTag, To: WeakTypeTag, ResultTpe](
       derivationTarget: DerivationTarget
   ): c.Expr[ResultTpe] = {
-    val tcTree = findLocalTransformerConfigurationFlags
+    val tcTree = findImplicitScopeFlags
     val flags = captureFromTransformerConfigurationTree(tcTree)
     val config = TransformerConfig(flags = flags)
       .withDefinitionScope(weakTypeOf[From], weakTypeOf[To])
@@ -857,7 +857,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
     }
   }
 
-  def findLocalTransformerConfigurationFlags: Tree = {
+  def findImplicitScopeFlags: Tree = {
     val searchTypeTree =
       tq"${typeOf[io.scalaland.chimney.dsl.TransformerConfiguration[? <: io.scalaland.chimney.internal.TransformerFlags]]}"
     inferImplicitTpe(searchTypeTree, macrosDisabled = false)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -18,9 +18,9 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       To: WeakTypeTag,
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
-      ScopeFlags: WeakTypeTag
+      ImplicitScopeFlags: WeakTypeTag
   ](derivationTarget: DerivationTarget): Tree = {
-    val config = readConfig[C, InstanceFlags, ScopeFlags]
+    val config = readConfig[C, InstanceFlags, ImplicitScopeFlags]
       .withDefinitionScope(weakTypeOf[From], weakTypeOf[To])
       .withDerivationTarget(derivationTarget)
 
@@ -67,11 +67,11 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
       To: WeakTypeTag,
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
-      ScopeFlags: WeakTypeTag
+      ImplicitScopeFlags: WeakTypeTag
   ](derivationTarget: DerivationTarget, tcTree: c.Tree)(callTransform: (Tree, Tree) => Tree): Tree = {
     val tiName = freshTermName("ti")
 
-    val config = readConfig[C, InstanceFlags, ScopeFlags]
+    val config = readConfig[C, InstanceFlags, ImplicitScopeFlags]
       .withTransformerDefinitionPrefix(q"$tiName.td")
       .withDerivationTarget(derivationTarget)
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/macros/dsl/TransformerBlackboxMacros.scala
@@ -15,10 +15,10 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       To: WeakTypeTag,
       C: WeakTypeTag,
       Flags: WeakTypeTag,
-      ScopeFlags: WeakTypeTag
+      ImplicitScopeFlags: WeakTypeTag
   ](@unused tc: c.Tree): c.Expr[chimney.Transformer[From, To]] = {
     c.Expr[chimney.Transformer[From, To]](
-      buildDefinedTransformer[From, To, C, Flags, ScopeFlags](DerivationTarget.TotalTransformer)
+      buildDefinedTransformer[From, To, C, Flags, ImplicitScopeFlags](DerivationTarget.TotalTransformer)
     )
   }
 
@@ -27,10 +27,10 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       To: WeakTypeTag,
       C: WeakTypeTag,
       Flags: WeakTypeTag,
-      ScopeFlags: WeakTypeTag
+      ImplicitScopeFlags: WeakTypeTag
   ](@unused tc: c.Tree): c.Expr[chimney.PartialTransformer[From, To]] = {
     c.Expr[chimney.PartialTransformer[From, To]](
-      buildDefinedTransformer[From, To, C, Flags, ScopeFlags](DerivationTarget.PartialTransformer())
+      buildDefinedTransformer[From, To, C, Flags, ImplicitScopeFlags](DerivationTarget.PartialTransformer())
     )
   }
 
@@ -39,10 +39,10 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       To: WeakTypeTag,
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
-      ScopeFlags: WeakTypeTag
+      ImplicitScopeFlags: WeakTypeTag
   ](tc: c.Tree): c.Expr[To] = {
     c.Expr[To](
-      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.TotalTransformer, tc) {
+      expandTransform[From, To, C, InstanceFlags, ImplicitScopeFlags](DerivationTarget.TotalTransformer, tc) {
         (derivedTransformer, srcField) =>
           derivedTransformer.callTransform(srcField)
       }
@@ -54,10 +54,10 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       To: WeakTypeTag,
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
-      ScopeFlags: WeakTypeTag
+      ImplicitScopeFlags: WeakTypeTag
   ](tc: c.Tree): c.Expr[To] = {
     c.Expr[To](
-      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.PartialTransformer(), tc) {
+      expandTransform[From, To, C, InstanceFlags, ImplicitScopeFlags](DerivationTarget.PartialTransformer(), tc) {
         (derivedTransformer, srcField) =>
           derivedTransformer.callPartialTransform(srcField, q"false")
       }
@@ -69,10 +69,10 @@ class TransformerBlackboxMacros(val c: blackbox.Context) extends TransformerMacr
       To: WeakTypeTag,
       C: WeakTypeTag,
       InstanceFlags: WeakTypeTag,
-      ScopeFlags: WeakTypeTag
+      ImplicitScopeFlags: WeakTypeTag
   ](tc: c.Tree): c.Expr[To] = {
     c.Expr[To](
-      expandTransform[From, To, C, InstanceFlags, ScopeFlags](DerivationTarget.PartialTransformer(), tc) {
+      expandTransform[From, To, C, InstanceFlags, ImplicitScopeFlags](DerivationTarget.PartialTransformer(), tc) {
         (derivedTransformer, srcField) =>
           derivedTransformer.callPartialTransform(srcField, q"true")
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -67,10 +67,10 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     ${ PartialTransformerDefinitionImpl.withCoproductInstancePartial('this, 'f) }
   }
 
-  inline def buildTransformer[ScopeFlags <: TransformerFlags](using
-      tc: TransformerConfiguration[ScopeFlags]
+  inline def buildTransformer[ImplicitScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ImplicitScopeFlags]
   ): PartialTransformer[From, To] = {
-    ${ PartialTransformerDefinitionImpl.buildTransformer[From, To, Cfg, Flags, ScopeFlags]('this) }
+    ${ PartialTransformerDefinitionImpl.buildTransformer[From, To, Cfg, Flags, ImplicitScopeFlags]('this) }
   }
 
   override protected def __updateRuntimeData(newRuntimeData: TransformerDefinitionCommons.RuntimeDataStore): this.type =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -57,16 +57,16 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     ${ PartialTransformerIntoImpl.withCoproductInstancePartialImpl('this, 'f) }
   }
 
-  inline def transform[ScopeFlags <: TransformerFlags](using
-      tc: TransformerConfiguration[ScopeFlags]
+  inline def transform[ImplicitScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ImplicitScopeFlags]
   ): partial.Result[To] = {
-    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ScopeFlags]('source, 'td, failFast = false) }
+    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ImplicitScopeFlags]('source, 'td, failFast = false) }
 
   }
 
-  inline def transformFailFast[ScopeFlags <: TransformerFlags](using
-      tc: TransformerConfiguration[ScopeFlags]
+  inline def transformFailFast[ImplicitScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ImplicitScopeFlags]
   ): partial.Result[To] = {
-    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ScopeFlags]('source, 'td, failFast = true) }
+    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ImplicitScopeFlags]('source, 'td, failFast = true) }
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -1,7 +1,9 @@
 package io.scalaland.chimney.dsl
 
+import io.scalaland.chimney.internal.compiletime.dsl
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.partial
+import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoImpl
 
 final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: TransformerFlags](
     val source: From,
@@ -12,47 +14,47 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
       inline selector: To => T,
       inline value: U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldConst(selector, value))
+    ${ PartialTransformerIntoImpl.withFieldConstImpl('this, 'selector, 'value) }
   }
 
   transparent inline def withFieldConstPartial[T, U](
       inline selector: To => T,
       inline value: partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldConstPartial(selector, value))
+    ${ PartialTransformerIntoImpl.withFieldConstPartialImpl('this, 'selector, 'value) }
   }
 
   transparent inline def withFieldComputed[T, U](
       inline selector: To => T,
       inline f: From => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldComputed(selector, f))
+    ${ PartialTransformerIntoImpl.withFieldComputedImpl('this, 'selector, 'f) }
   }
 
   transparent inline def withFieldComputedPartial[T, U](
       inline selector: To => T,
       inline f: From => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldComputedPartial(selector, f))
+    ${ PartialTransformerIntoImpl.withFieldComputedPartialImpl('this, 'selector, 'f) }
   }
 
   transparent inline def withFieldRenamed[T, U](
       inline selectorFrom: From => T,
       inline selectorTo: To => U
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldRenamed(selectorFrom, selectorTo))
+    ${ PartialTransformerIntoImpl.withFieldRenamedImpl('this, 'selectorFrom, 'selectorTo) }
   }
 
   transparent inline def withCoproductInstance[Inst](
       inline f: Inst => To
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withCoproductInstance(f))
+    ${ PartialTransformerIntoImpl.withCoproductInstanceImpl('this, 'f) }
   }
 
   transparent inline def withCoproductInstancePartial[Inst](
       inline f: Inst => partial.Result[To]
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withCoproductInstancePartial(f))
+    ${ PartialTransformerIntoImpl.withCoproductInstancePartialImpl('this, 'f) }
   }
 
   inline def transform[ScopeFlags <: TransformerFlags](using

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -60,15 +60,13 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   inline def transform[ScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ScopeFlags]
   ): partial.Result[To] = {
-    // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
-    td.buildTransformer.transform(source, failFast = false)
+    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ScopeFlags]('source, 'td, failFast = false) }
+
   }
 
   inline def transformFailFast[ScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ScopeFlags]
   ): partial.Result[To] = {
-    // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
-    td.buildTransformer.transform(source, failFast = true)
+    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ScopeFlags]('source, 'td, failFast = true) }
   }
-
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -61,7 +61,14 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
       tc: TransformerConfiguration[ScopeFlags]
   ): partial.Result[To] = {
     // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
-    td.buildTransformer.transform(source)
+    td.buildTransformer.transform(source, failFast = false)
+  }
+
+  inline def transformFailFast[ScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ScopeFlags]
+  ): partial.Result[To] = {
+    // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
+    td.buildTransformer.transform(source, failFast = true)
   }
 
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -57,10 +57,10 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
     ${ TransformerDefinitionImpl.withCoproductInstance('this, 'f) }
   }
 
-  inline def buildTransformer[ScopeFlags <: TransformerFlags](using
-      tc: TransformerConfiguration[ScopeFlags]
+  inline def buildTransformer[ImplicitScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ImplicitScopeFlags]
   ): Transformer[From, To] = {
-    ${ TransformerDefinitionImpl.buildTransformer[From, To, Cfg, Flags, ScopeFlags]('this) }
+    ${ TransformerDefinitionImpl.buildTransformer[From, To, Cfg, Flags, ImplicitScopeFlags]('this) }
   }
 
   override protected def __updateRuntimeData(newRuntimeData: TransformerDefinitionCommons.RuntimeDataStore): this.type =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -39,7 +39,9 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
     ${ TransformerIntoImpl.withCoproductInstanceImpl('this, 'f) }
   }
 
-  inline def transform[ScopeFlags <: TransformerFlags](using tc: TransformerConfiguration[ScopeFlags]): To = {
-    ${ TransformerIntoImpl.transform[From, To, Cfg, Flags, ScopeFlags]('source, 'td) }
+  inline def transform[ImplicitScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ImplicitScopeFlags]
+  ): To = {
+    ${ TransformerIntoImpl.transform[From, To, Cfg, Flags, ImplicitScopeFlags]('source, 'td) }
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -80,6 +80,9 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Def
 
     object RuntimeDataStore extends RuntimeDataStoreModule {
 
+      val empty: Expr[TransformerDefinitionCommons.RuntimeDataStore] =
+        '{ TransformerDefinitionCommons.emptyRuntimeDataStore }
+
       def extractAt(
           runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore],
           index: Int

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.internal.compiletime
 import io.scalaland.chimney.dsl as dsls
 import io.scalaland.chimney.internal
 import io.scalaland.chimney.{partial, PartialTransformer, Patcher, Transformer}
-import io.scalaland.chimney.dsl.ImplicitTransformerPreference
+import io.scalaland.chimney.dsl.{ImplicitTransformerPreference, TransformerDefinitionCommons}
 
 import scala.quoted
 
@@ -33,6 +33,9 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Def
       quoted.Type.of[io.scalaland.chimney.dsl.PreferTotalTransformer.type]
     val PreferPartialTransformer: Type[io.scalaland.chimney.dsl.PreferPartialTransformer.type] =
       quoted.Type.of[io.scalaland.chimney.dsl.PreferPartialTransformer.type]
+
+    val RuntimeDataStore: Type[TransformerDefinitionCommons.RuntimeDataStore] =
+      quoted.Type.of[TransformerDefinitionCommons.RuntimeDataStore]
 
     object TransformerCfg extends TransformerCfgModule {
       val Empty: Type[internal.TransformerCfg.Empty] = quoted.Type.of[internal.TransformerCfg.Empty]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -94,7 +94,9 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
               RuntimeCoproductOverride.CoproductInstancePartial(runtimeDataIdx)
             )
         case _ =>
-          reportError(s"Bad internal transformer config type shape!  ${Type.prettyPrint[Cfg]}")
+          reportError(
+            s"Bad internal transformer config type shape!  ${Type.prettyPrint[Cfg]} dealiased to ${cfgTpe.show(using Printer.TypeReprAnsiCode)}"
+          )
       }
     }
   }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -45,7 +45,7 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
             case _ =>
               flagsRest.setBoolFlag[flag](value = false)
         case _ =>
-          reportError(s"Bad internal transformer flags type shape!  ${Type.prettyPrint[Flag]}")
+          reportError("Bad internal transformer flags type shape!")
       }
     }
 
@@ -93,9 +93,7 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
               RuntimeCoproductOverride.CoproductInstancePartial(runtimeDataIdx)
             )
         case _ =>
-          reportError(
-            s"Bad internal transformer config type shape!  ${Type.prettyPrint[Cfg]} dealiased to ${cfgTpe.show(using Printer.TypeReprAnsiCode)}"
-          )
+          reportError("Bad internal transformer config type shape!")
       }
     }
   }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -13,10 +13,10 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
     final override def readTransformerConfig[
         Cfg <: internal.TransformerCfg: Type,
         InstanceFlags <: internal.TransformerFlags: Type,
-        SharedFlags <: internal.TransformerFlags: Type
+        ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
     ]: TransformerConfig = {
-      val sharedFlags = extractTransformerFlags[SharedFlags](TransformerFlags())
-      val allFlags = extractTransformerFlags[InstanceFlags](sharedFlags)
+      val implicitImplicitScopeFlags = extractTransformerFlags[ImplicitImplicitScopeFlags](TransformerFlags())
+      val allFlags = extractTransformerFlags[InstanceFlags](implicitImplicitScopeFlags)
       extractTransformerConfig[Cfg](runtimeDataIdx = 0).copy(flags = allFlags)
     }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -13,10 +13,10 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
     final override def readTransformerConfig[
         Cfg <: internal.TransformerCfg: Type,
         InstanceFlags <: internal.TransformerFlags: Type,
-        ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
+        ImplicitScopeFlags <: internal.TransformerFlags: Type
     ]: TransformerConfig = {
-      val implicitImplicitScopeFlags = extractTransformerFlags[ImplicitImplicitScopeFlags](TransformerFlags())
-      val allFlags = extractTransformerFlags[InstanceFlags](implicitImplicitScopeFlags)
+      val implicitScopeFlags = extractTransformerFlags[ImplicitScopeFlags](TransformerFlags())
+      val allFlags = extractTransformerFlags[InstanceFlags](implicitScopeFlags)
       extractTransformerConfig[Cfg](runtimeDataIdx = 0).copy(flags = allFlags)
     }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -97,4 +97,16 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
       }
     }
   }
+
+  extension [T <: String](tpe: Type[T]) {
+
+    private def asStringSingletonType: String = {
+      import quotes.reflect.*
+
+      quoted.Type.valueOfConstant[T](using tpe)(using quotes) match {
+        case Some(str) => str
+        case None      => reportError(s"Invalid string literal type: ${tpe}")
+      }
+    }
+  }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -45,7 +45,6 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
             case _ =>
               flagsRest.setBoolFlag[flag](value = false)
         case _ =>
-          println(s"Bad tpe: ${Type.prettyPrint[Flag]}")
           reportError(s"Bad internal transformer flags type shape!  ${Type.prettyPrint[Flag]}")
       }
     }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ConfigurationsPlatform.scala
@@ -45,7 +45,8 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
             case _ =>
               flagsRest.setBoolFlag[flag](value = false)
         case _ =>
-          reportError("Bad internal transformer flags type shape!")
+          println(s"Bad tpe: ${Type.prettyPrint[Flag]}")
+          reportError(s"Bad internal transformer flags type shape!  ${Type.prettyPrint[Flag]}")
       }
     }
 
@@ -93,7 +94,7 @@ private[compiletime] trait ConfigurationsPlatform extends Configurations { this:
               RuntimeCoproductOverride.CoproductInstancePartial(runtimeDataIdx)
             )
         case _ =>
-          reportError("Bad internal transformer config type shape!")
+          reportError(s"Bad internal transformer config type shape!  ${Type.prettyPrint[Cfg]}")
       }
     }
   }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -11,6 +11,7 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
   final override type Expr[A] = quoted.Expr[A]
 
   object Expr extends ExprModule {
+    val Nothing: Expr[Nothing] = '{ ??? }
     val Unit: Expr[Unit] = '{ () }
     def Array[A: Type](args: Expr[A]*): Expr[Array[A]] =
       '{ scala.Array.apply[A](${ quoted.Varargs(args.toSeq) }*)(${ quoted.Expr.summon[ClassTag[A]].get }) }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -54,13 +54,12 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
     }
   }
 
-  implicit class UntypedTypeOps[T](private val tpe: Type[T]) {
+  extension [T <: String](tpe: Type[T]) {
 
-    /** Assumes that this `tpe` is String singleton type and extracts its value */
     def asStringSingletonType: String = {
       import quotes.reflect.*
 
-      quoted.Type.valueOfConstant[T](using tpe)(using quotes).map(_.toString) match {
+      quoted.Type.valueOfConstant[T](using tpe)(using quotes) match {
         case Some(str) => str
         case None      => reportError(s"Invalid string literal type: ${tpe}")
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -57,6 +57,7 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
   implicit class UntypedTypeOps[T](private val tpe: Type[T]) {
 
     /** Assumes that this `tpe` is String singleton type and extracts its value */
-    def asStringSingletonType: String = ???
+    def asStringSingletonType: String = s"TODO impl (${tpe.toString})"
+    // TODO: provide real implementation
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -30,6 +30,7 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
   object Type extends TypeModule {
     import typeUtils.*
 
+    val Nothing: Type[Nothing] = quoted.Type.of[Nothing]
     val Any: Type[Any] = quoted.Type.of[Any]
     val Boolean: Type[Boolean] = quoted.Type.of[Boolean]
     val Int: Type[Int] = quoted.Type.of[Int]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -53,16 +53,4 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
       scala.util.Try(repr.dealias.show(using Printer.TypeReprAnsiCode)).getOrElse(repr.toString)
     }
   }
-
-  extension [T <: String](tpe: Type[T]) {
-
-    def asStringSingletonType: String = {
-      import quotes.reflect.*
-
-      quoted.Type.valueOfConstant[T](using tpe)(using quotes) match {
-        case Some(str) => str
-        case None      => reportError(s"Invalid string literal type: ${tpe}")
-      }
-    }
-  }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -57,7 +57,13 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
   implicit class UntypedTypeOps[T](private val tpe: Type[T]) {
 
     /** Assumes that this `tpe` is String singleton type and extracts its value */
-    def asStringSingletonType: String = s"TODO impl (${tpe.toString})"
-    // TODO: provide real implementation
+    def asStringSingletonType: String = {
+      import quotes.reflect.*
+
+      quoted.Type.valueOfConstant[T](using tpe)(using quotes).map(_.toString) match {
+        case Some(str) => str
+        case None      => reportError(s"Invalid string literal type: ${tpe}")
+      }
+    }
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -103,6 +103,18 @@ object TransformerMacros {
   )(using quotes: Quotes): Expr[Transformer[From, To]] =
     new TransformerMacros(quotes).deriveTotalTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
 
+  final def deriveTotalTransformerResultWithConfig[
+      From: Type,
+      To: Type,
+      Cfg <: internal.TransformerCfg: Type,
+      Flags <: internal.TransformerFlags: Type,
+      ScopeFlags <: internal.TransformerFlags: Type
+  ](source: Expr[From], td: Expr[TransformerDefinition[From, To, Cfg, Flags]])(using quotes: Quotes): Expr[To] =
+    new TransformerMacros(quotes).deriveTotalTransformationResult[From, To, Cfg, Flags, ScopeFlags](
+      source,
+      Some('{ ${ td }.runtimeData })
+    )
+
   final def derivePartialTransformerWithDefaults[
       From: Type,
       To: Type

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -20,7 +20,9 @@ final class TransformerMacros(q: Quotes)
       To: Type
   ](using quotes: Quotes): Expr[Transformer[From, To]] =
     resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
-      deriveTotalTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
+      deriveTotalTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](
+        runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty
+      )
     }
 
   final def deriveTotalTransformerWithConfig[
@@ -32,14 +34,16 @@ final class TransformerMacros(q: Quotes)
   ](
       td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[Transformer[From, To]] =
-    deriveTotalTransformer[From, To, Cfg, Flags, ImplicitScopeFlags](runtimeDataStore = Some('{ ${ td }.runtimeData }))
+    deriveTotalTransformer[From, To, Cfg, Flags, ImplicitScopeFlags](runtimeDataStore = '{ ${ td }.runtimeData })
 
   final def derivePartialTransformerWithDefaults[
       From: Type,
       To: Type
   ](using quotes: Quotes): Expr[PartialTransformer[From, To]] =
     resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
-      derivePartialTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
+      derivePartialTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](
+        runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty
+      )
     }
 
   final def derivePartialTransformerWithConfig[
@@ -51,9 +55,7 @@ final class TransformerMacros(q: Quotes)
   ](
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[PartialTransformer[From, To]] =
-    derivePartialTransformer[From, To, Cfg, Flags, ImplicitScopeFlags](runtimeDataStore = Some('{
-      ${ td }.runtimeData
-    }))
+    derivePartialTransformer[From, To, Cfg, Flags, ImplicitScopeFlags](runtimeDataStore = '{ ${ td }.runtimeData })
 
   private def findImplicitScopeFlags(using
       quotes: Quotes
@@ -114,7 +116,7 @@ object TransformerMacros {
   ](source: Expr[From], td: Expr[TransformerDefinition[From, To, Cfg, Flags]])(using quotes: Quotes): Expr[To] =
     new TransformerMacros(quotes).deriveTotalTransformationResult[From, To, Cfg, Flags, ImplicitScopeFlags](
       source,
-      Some('{ ${ td }.runtimeData })
+      '{ ${ td }.runtimeData }
     )
 
   final def derivePartialTransformerWithDefaults[
@@ -146,7 +148,7 @@ object TransformerMacros {
     new TransformerMacros(quotes).derivePartialTransformationResult[From, To, Cfg, Flags, ImplicitScopeFlags](
       source,
       Expr(failFast),
-      Some('{ ${ td }.runtimeData })
+      '{ ${ td }.runtimeData }
     )
 
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -131,4 +131,20 @@ object TransformerMacros {
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[PartialTransformer[From, To]] =
     new TransformerMacros(quotes).derivePartialTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
+
+  final def derivePartialTransformerResultWithConfig[
+      From: Type,
+      To: Type,
+      Cfg <: internal.TransformerCfg: Type,
+      Flags <: internal.TransformerFlags: Type,
+      ScopeFlags <: internal.TransformerFlags: Type
+  ](source: Expr[From], td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]], failFast: Boolean)(using
+      quotes: Quotes
+  ): Expr[partial.Result[To]] =
+    new TransformerMacros(quotes).derivePartialTransformationResult[From, To, Cfg, Flags, ScopeFlags](
+      source,
+      Expr(failFast),
+      Some('{ ${ td }.runtimeData })
+    )
+
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -28,11 +28,11 @@ final class TransformerMacros(q: Quotes)
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       Flags <: internal.TransformerFlags: Type,
-      ScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](
       td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[Transformer[From, To]] =
-    deriveTotalTransformer[From, To, Cfg, Flags, ScopeFlags](runtimeDataStore = Some('{ ${ td }.runtimeData }))
+    deriveTotalTransformer[From, To, Cfg, Flags, ImplicitScopeFlags](runtimeDataStore = Some('{ ${ td }.runtimeData }))
 
   final def derivePartialTransformerWithDefaults[
       From: Type,
@@ -47,11 +47,13 @@ final class TransformerMacros(q: Quotes)
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       Flags <: internal.TransformerFlags: Type,
-      ScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[PartialTransformer[From, To]] =
-    derivePartialTransformer[From, To, Cfg, Flags, ScopeFlags](runtimeDataStore = Some('{ ${ td }.runtimeData }))
+    derivePartialTransformer[From, To, Cfg, Flags, ImplicitScopeFlags](runtimeDataStore = Some('{
+      ${ td }.runtimeData
+    }))
 
   private def findLocalTransformerConfigurationFlags(using
       quotes: Quotes
@@ -97,20 +99,20 @@ object TransformerMacros {
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       Flags <: internal.TransformerFlags: Type,
-      ScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](
       td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[Transformer[From, To]] =
-    new TransformerMacros(quotes).deriveTotalTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
+    new TransformerMacros(quotes).deriveTotalTransformerWithConfig[From, To, Cfg, Flags, ImplicitScopeFlags](td)
 
   final def deriveTotalTransformerResultWithConfig[
       From: Type,
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       Flags <: internal.TransformerFlags: Type,
-      ScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](source: Expr[From], td: Expr[TransformerDefinition[From, To, Cfg, Flags]])(using quotes: Quotes): Expr[To] =
-    new TransformerMacros(quotes).deriveTotalTransformationResult[From, To, Cfg, Flags, ScopeFlags](
+    new TransformerMacros(quotes).deriveTotalTransformationResult[From, To, Cfg, Flags, ImplicitScopeFlags](
       source,
       Some('{ ${ td }.runtimeData })
     )
@@ -126,22 +128,22 @@ object TransformerMacros {
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       Flags <: internal.TransformerFlags: Type,
-      ScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[PartialTransformer[From, To]] =
-    new TransformerMacros(quotes).derivePartialTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
+    new TransformerMacros(quotes).derivePartialTransformerWithConfig[From, To, Cfg, Flags, ImplicitScopeFlags](td)
 
   final def derivePartialTransformerResultWithConfig[
       From: Type,
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       Flags <: internal.TransformerFlags: Type,
-      ScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](source: Expr[From], td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]], failFast: Boolean)(using
       quotes: Quotes
   ): Expr[partial.Result[To]] =
-    new TransformerMacros(quotes).derivePartialTransformationResult[From, To, Cfg, Flags, ScopeFlags](
+    new TransformerMacros(quotes).derivePartialTransformationResult[From, To, Cfg, Flags, ImplicitScopeFlags](
       source,
       Expr(failFast),
       Some('{ ${ td }.runtimeData })

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -75,7 +75,7 @@ final class TransformerMacros(q: Quotes)
     import quotes.reflect.*
 
     val localConfig = findImplicitScopeFlags
-    val localConfigType = findImplicitScopeFlags.asTerm.tpe.widen.typeArgs.head.asType
+    val localConfigType = localConfig.asTerm.tpe.widen.typeArgs.head.asType
       .asInstanceOf[Type[ImplicitScopeFlagsType]]
 
     '{
@@ -83,9 +83,6 @@ final class TransformerMacros(q: Quotes)
       ${ useLocalConfig(localConfigType) }
     }
   }
-
-  implicit private val EmptyConfigType: Type[Empty] = ChimneyType.TransformerCfg.Empty
-  implicit private val DefaultFlagsType: Type[Default] = ChimneyType.TransformerFlags.Default
 }
 
 object TransformerMacros {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -13,14 +13,14 @@ final class TransformerMacros(q: Quotes)
     with DerivationPlatform
     with GatewayPlatform {
 
-  type LocalConfigType <: internal.TransformerFlags
+  type ImplicitScopeFlagsType <: internal.TransformerFlags
 
   final def deriveTotalTransformerWithDefaults[
       From: Type,
       To: Type
   ](using quotes: Quotes): Expr[Transformer[From, To]] =
-    resolveLocalTransformerConfigAndMuteUnusedConfigWarnings { implicit LocalConfigType =>
-      deriveTotalTransformer[From, To, Empty, Default, LocalConfigType](runtimeDataStore = None)
+    resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
+      deriveTotalTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
     }
 
   final def deriveTotalTransformerWithConfig[
@@ -38,8 +38,8 @@ final class TransformerMacros(q: Quotes)
       From: Type,
       To: Type
   ](using quotes: Quotes): Expr[PartialTransformer[From, To]] =
-    resolveLocalTransformerConfigAndMuteUnusedConfigWarnings { implicit LocalConfigType =>
-      derivePartialTransformer[From, To, Empty, Default, LocalConfigType](runtimeDataStore = None)
+    resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings { implicit ImplicitScopeFlagsType =>
+      derivePartialTransformer[From, To, Empty, Default, ImplicitScopeFlagsType](runtimeDataStore = None)
     }
 
   final def derivePartialTransformerWithConfig[
@@ -55,7 +55,7 @@ final class TransformerMacros(q: Quotes)
       ${ td }.runtimeData
     }))
 
-  private def findLocalTransformerConfigurationFlags(using
+  private def findImplicitScopeFlags(using
       quotes: Quotes
   ): Expr[io.scalaland.chimney.dsl.TransformerConfiguration[? <: io.scalaland.chimney.internal.TransformerFlags]] =
     scala.quoted.Expr
@@ -66,15 +66,15 @@ final class TransformerMacros(q: Quotes)
         // $COVERAGE-ON$
       }
 
-  private def resolveLocalTransformerConfigAndMuteUnusedConfigWarnings[A: Type](
-      useLocalConfig: Type[LocalConfigType] => Expr[A]
+  private def resolveImplicitScopeFlagsAndMuteUnusedConfigWarnings[A: Type](
+      useLocalConfig: Type[ImplicitScopeFlagsType] => Expr[A]
   ): Expr[A] = {
     import quotes.*
     import quotes.reflect.*
 
-    val localConfig = findLocalTransformerConfigurationFlags
-    val localConfigType = findLocalTransformerConfigurationFlags.asTerm.tpe.widen.typeArgs.head.asType
-      .asInstanceOf[Type[LocalConfigType]]
+    val localConfig = findImplicitScopeFlags
+    val localConfigType = findImplicitScopeFlags.asTerm.tpe.widen.typeArgs.head.asType
+      .asInstanceOf[Type[ImplicitScopeFlagsType]]
 
     '{
       val _ = $localConfig

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/FieldNameUtils.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/FieldNameUtils.scala
@@ -1,5 +1,6 @@
 package io.scalaland.chimney.internal.compiletime.dsl
 
+import scala.annotation.nowarn
 import scala.quoted.*
 
 object FieldNameUtils {
@@ -42,6 +43,9 @@ object FieldNameUtils {
     }
   }
 
+  @nowarn(
+    "msg=the type test for quotes.reflect.ValDef cannot be checked at runtime because it refers to an abstract type member or type parameter"
+  )
   def extractSelectorFieldNameOpt(using quotes: Quotes)(selectorTerm: quotes.reflect.Term): Option[String] = {
     import quotes.reflect.*
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionImpl.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.FieldNameUtils
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.partial
@@ -139,12 +140,6 @@ object PartialTransformerDefinitionImpl {
       ScopeFlags <: TransformerFlags: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]]
-  )(using Quotes): Expr[PartialTransformer[From, To]] = {
-    '{
-      new PartialTransformer[From, To] {
-        def transform(src: From, failFast: Boolean): partial.Result[To] =
-          partial.Result.fromErrorString("not implemented yet")
-      }
-    }
-  }
+  )(using Quotes): Expr[PartialTransformer[From, To]] =
+    TransformerMacros.derivePartialTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionImpl.scala
@@ -137,9 +137,9 @@ object PartialTransformerDefinitionImpl {
       To: Type,
       Cfg <: TransformerCfg: Type,
       Flags <: TransformerFlags: Type,
-      ScopeFlags <: TransformerFlags: Type
+      ImplicitScopeFlags <: TransformerFlags: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]]
   )(using Quotes): Expr[PartialTransformer[From, To]] =
-    TransformerMacros.derivePartialTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
+    TransformerMacros.derivePartialTransformerWithConfig[From, To, Cfg, Flags, ImplicitScopeFlags](td)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
@@ -136,13 +136,13 @@ object PartialTransformerIntoImpl {
       To: Type,
       Cfg <: TransformerCfg: Type,
       Flags <: TransformerFlags: Type,
-      ScopeFlags <: TransformerFlags: Type
+      ImplicitScopeFlags <: TransformerFlags: Type
   ](
       source: Expr[From],
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]],
       failFast: Boolean
   )(using Quotes): Expr[partial.Result[To]] = {
-    TransformerMacros.derivePartialTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](
+    TransformerMacros.derivePartialTransformerResultWithConfig[From, To, Cfg, Flags, ImplicitScopeFlags](
       source,
       td,
       failFast

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
@@ -139,9 +139,13 @@ object PartialTransformerIntoImpl {
       ScopeFlags <: TransformerFlags: Type
   ](
       source: Expr[From],
-      td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
-  )(using Quotes): Expr[To] = {
-    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](source, td)
+      td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]],
+      failFast: Boolean
+  )(using Quotes): Expr[partial.Result[To]] = {
+    TransformerMacros.derivePartialTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](
+      source,
+      td,
+      failFast
+    )
   }
-
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
@@ -1,0 +1,147 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.*
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.*
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
+
+import scala.quoted.*
+
+object PartialTransformerIntoImpl {
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      valueExpr: Expr[U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldConstImpl('{ ${ tiExpr }.td }, selectorExpr, valueExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldConstPartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      valueExpr: Expr[partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldConstPartialImpl('{ ${ tiExpr }.td }, selectorExpr, valueExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      fExpr: Expr[From => U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldComputedImpl('{ ${ tiExpr }.td }, selectorExpr, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldComputedPartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      fExpr: Expr[From => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldComputedPartialImpl('{ ${ tiExpr }.td }, selectorExpr, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorFromExpr: Expr[From => T],
+      selectorToExpr: Expr[To => U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldRenamed('{ ${ tiExpr }.td }, selectorFromExpr, selectorToExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withCoproductInstanceImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Inst: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      fExpr: Expr[Inst => To]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withCoproductInstance('{ ${ tiExpr }.td }, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withCoproductInstancePartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Inst: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      fExpr: Expr[Inst => partial.Result[To]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withCoproductInstancePartial('{ ${ tiExpr }.td }, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def transform[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      ScopeFlags <: TransformerFlags: Type
+  ](
+      source: Expr[From],
+      td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
+  )(using Quotes): Expr[To] = {
+    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](source, td)
+  }
+
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionImpl.scala
@@ -85,9 +85,9 @@ object TransformerDefinitionImpl {
       To: Type,
       Cfg <: TransformerCfg: Type,
       Flags <: TransformerFlags: Type,
-      ScopeFlags <: TransformerFlags: Type
+      ImplicitScopeFlags <: TransformerFlags: Type
   ](
       td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
   )(using Quotes): Expr[Transformer[From, To]] =
-    TransformerMacros.deriveTotalTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
+    TransformerMacros.deriveTotalTransformerWithConfig[From, To, Cfg, Flags, ImplicitScopeFlags](td)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionImpl.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.FieldNameUtils
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
 
@@ -87,11 +88,6 @@ object TransformerDefinitionImpl {
       ScopeFlags <: TransformerFlags: Type
   ](
       td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
-  )(using Quotes): Expr[Transformer[From, To]] = {
-    '{
-      new Transformer[From, To] {
-        def transform(src: From): To = null.asInstanceOf[To]
-      }
-    }
-  }
+  )(using Quotes): Expr[Transformer[From, To]] =
+    TransformerMacros.deriveTotalTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoImpl.scala
@@ -85,12 +85,12 @@ object TransformerIntoImpl {
       To: Type,
       Cfg <: TransformerCfg: Type,
       Flags <: TransformerFlags: Type,
-      ScopeFlags <: TransformerFlags: Type
+      ImplicitScopeFlags <: TransformerFlags: Type
   ](
       source: Expr[From],
       td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
   )(using Quotes): Expr[To] = {
-    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](source, td)
+    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ImplicitScopeFlags](source, td)
   }
 
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoImpl.scala
@@ -1,0 +1,96 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import scala.quoted.*
+import io.scalaland.chimney.*
+import io.scalaland.chimney.internal.*
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
+
+import scala.quoted.*
+
+object TransformerIntoImpl {
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      valueExpr: Expr[U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withFieldConstImpl('{ ${ tiExpr }.td }, selectorExpr, valueExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      fExpr: Expr[From => U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withFieldComputedImpl('{ ${ tiExpr }.td }, selectorExpr, fExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      selectorFromExpr: Expr[From => T],
+      selectorToExpr: Expr[To => U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withFieldRenamed('{ ${ tiExpr }.td }, selectorFromExpr, selectorToExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withCoproductInstanceImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Inst: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      fExpr: Expr[Inst => To]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withCoproductInstance('{ ${ tiExpr }.td }, fExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def transform[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      ScopeFlags <: TransformerFlags: Type
+  ](
+      source: Expr[From],
+      td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
+  )(using Quotes): Expr[To] = {
+    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](source, td)
+  }
+
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
@@ -71,6 +71,8 @@ private[compiletime] trait ChimneyExprs { this: Definitions =>
     val RuntimeDataStore: RuntimeDataStoreModule
     trait RuntimeDataStoreModule { this: RuntimeDataStore.type =>
 
+      def empty: Expr[TransformerDefinitionCommons.RuntimeDataStore]
+
       def extractAt(
           runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore],
           index: Int

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.internal.compiletime
 
 import io.scalaland.chimney.*
-import io.scalaland.chimney.dsl.ImplicitTransformerPreference
+import io.scalaland.chimney.dsl.{ImplicitTransformerPreference, TransformerDefinitionCommons}
 
 private[compiletime] trait ChimneyTypes { this: Types =>
 
@@ -21,6 +21,8 @@ private[compiletime] trait ChimneyTypes { this: Types =>
 
     val PreferTotalTransformer: Type[io.scalaland.chimney.dsl.PreferTotalTransformer.type]
     val PreferPartialTransformer: Type[io.scalaland.chimney.dsl.PreferPartialTransformer.type]
+
+    val RuntimeDataStore: Type[TransformerDefinitionCommons.RuntimeDataStore]
 
     val TransformerCfg: TransformerCfgModule
     trait TransformerCfgModule {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Configurations.scala
@@ -114,7 +114,7 @@ private[compiletime] trait Configurations { this: Definitions =>
     def readTransformerConfig[
         Cfg <: internal.TransformerCfg: Type,
         InstanceFlags <: internal.TransformerFlags: Type,
-        SharedFlags <: internal.TransformerFlags: Type
+        ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
     ]: TransformerConfig
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Configurations.scala
@@ -114,7 +114,7 @@ private[compiletime] trait Configurations { this: Definitions =>
     def readTransformerConfig[
         Cfg <: internal.TransformerCfg: Type,
         InstanceFlags <: internal.TransformerFlags: Type,
-        ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
+        ImplicitScopeFlags <: internal.TransformerFlags: Type
     ]: TransformerConfig
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
@@ -1,5 +1,6 @@
 package io.scalaland.chimney.internal.compiletime
 
+import io.scalaland.chimney.dsl.TransformerDefinitionCommons
 import io.scalaland.chimney.{PartialTransformer, Patcher, Transformer}
 import io.scalaland.chimney.partial
 
@@ -26,6 +27,7 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
         From: Type[From],
         To: Type[To],
         src: Expr[From],
+        runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore],
         config: TransformerConfig
     ) extends TransformerContext[From, To] {
 
@@ -42,11 +44,17 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
     }
     object ForTotal {
 
-      def create[From: Type, To: Type](src: Expr[From], config: TransformerConfig): ForTotal[From, To] =
+      def create[From: Type, To: Type](
+          src: Expr[From],
+          config: TransformerConfig,
+          runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]
+      ): ForTotal[From, To] =
         ForTotal(
           From = Type[From],
           To = Type[To],
           src = src,
+          runtimeDataStore =
+            runtimeDataStore.getOrElse(Expr.asInstanceOf(Expr.Nothing)(Type.Nothing, ChimneyType.RuntimeDataStore)),
           config = config.withDefinitionScope((ComputedType(Type[From]), ComputedType(Type[To])))
         )
     }
@@ -56,6 +64,7 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
         To: Type[To],
         src: Expr[From],
         failFast: Expr[Boolean],
+        runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore],
         config: TransformerConfig
     ) extends TransformerContext[From, To] {
 
@@ -75,12 +84,15 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
       def create[From: Type, To: Type](
           src: Expr[From],
           failFast: Expr[Boolean],
-          config: TransformerConfig
+          config: TransformerConfig,
+          runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]
       ): ForPartial[From, To] = ForPartial(
         From = Type[From],
         To = Type[To],
         src = src,
         failFast = failFast,
+        runtimeDataStore =
+          runtimeDataStore.getOrElse(Expr.asInstanceOf(Expr.Nothing)(Type.Nothing, ChimneyType.RuntimeDataStore)),
         config = config.withDefinitionScope((ComputedType(Type[From]), ComputedType(Type[To])))
       )
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
@@ -53,8 +53,13 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
           From = Type[From],
           To = Type[To],
           src = src,
-          runtimeDataStore =
-            runtimeDataStore.getOrElse(Expr.asInstanceOf(Expr.Nothing)(Type.Nothing, ChimneyType.RuntimeDataStore)),
+          runtimeDataStore = runtimeDataStore
+            .getOrElse(
+              Expr.asInstanceOf[Nothing, TransformerDefinitionCommons.RuntimeDataStore](Expr.Nothing)(
+                Type.Nothing,
+                ChimneyType.RuntimeDataStore
+              )
+            ),
           config = config.withDefinitionScope((ComputedType(Type[From]), ComputedType(Type[To])))
         )
     }
@@ -91,8 +96,12 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
         To = Type[To],
         src = src,
         failFast = failFast,
-        runtimeDataStore =
-          runtimeDataStore.getOrElse(Expr.asInstanceOf(Expr.Nothing)(Type.Nothing, ChimneyType.RuntimeDataStore)),
+        runtimeDataStore = runtimeDataStore.getOrElse(
+          Expr.asInstanceOf[Nothing, TransformerDefinitionCommons.RuntimeDataStore](Expr.Nothing)(
+            Type.Nothing,
+            ChimneyType.RuntimeDataStore
+          )
+        ),
         config = config.withDefinitionScope((ComputedType(Type[From]), ComputedType(Type[To])))
       )
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
@@ -47,19 +47,13 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
       def create[From: Type, To: Type](
           src: Expr[From],
           config: TransformerConfig,
-          runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]
+          runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]
       ): ForTotal[From, To] =
         ForTotal(
           From = Type[From],
           To = Type[To],
           src = src,
-          runtimeDataStore = runtimeDataStore
-            .getOrElse(
-              Expr.asInstanceOf[Nothing, TransformerDefinitionCommons.RuntimeDataStore](Expr.Nothing)(
-                Type.Nothing,
-                ChimneyType.RuntimeDataStore
-              )
-            ),
+          runtimeDataStore = runtimeDataStore,
           config = config.withDefinitionScope((ComputedType(Type[From]), ComputedType(Type[To])))
         )
     }
@@ -90,18 +84,13 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
           src: Expr[From],
           failFast: Expr[Boolean],
           config: TransformerConfig,
-          runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]
+          runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]
       ): ForPartial[From, To] = ForPartial(
         From = Type[From],
         To = Type[To],
         src = src,
         failFast = failFast,
-        runtimeDataStore = runtimeDataStore.getOrElse(
-          Expr.asInstanceOf[Nothing, TransformerDefinitionCommons.RuntimeDataStore](Expr.Nothing)(
-            Type.Nothing,
-            ChimneyType.RuntimeDataStore
-          )
-        ),
+        runtimeDataStore = runtimeDataStore,
         config = config.withDefinitionScope((ComputedType(Type[From]), ComputedType(Type[To])))
       )
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -10,6 +10,7 @@ private[compiletime] trait Exprs { this: Definitions =>
 
   val Expr: ExprModule
   trait ExprModule { this: Expr.type =>
+    val Nothing: Expr[Nothing]
     val Unit: Expr[Unit]
     def Array[A: Type](args: Expr[A]*): Expr[Array[A]]
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
@@ -9,6 +9,7 @@ private[compiletime] trait Types {
   trait TypeModule { this: Type.type =>
     def apply[T](implicit T: Type[T]): Type[T] = T
 
+    val Nothing: Type[Nothing]
     val Any: Type[Any]
     val Boolean: Type[Boolean]
     val Int: Type[Int]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
@@ -16,12 +16,12 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      SharedFlags <: internal.TransformerFlags: Type
+      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
   ](src: Expr[From], runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]): Expr[To] =
     deriveTransformationResult(
       TransformerContext.ForTotal.create[From, To](
         src,
-        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, SharedFlags],
+        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, ImplicitImplicitScopeFlags],
         runtimeDataStore
       )
     ).toEither.fold(
@@ -46,10 +46,10 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      SharedFlags <: internal.TransformerFlags: Type
+      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
   ](runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]): Expr[Transformer[From, To]] =
     instantiateTotalTransformer[From, To] { (src: Expr[From]) =>
-      deriveTotalTransformationResult[From, To, Cfg, InstanceFlags, SharedFlags](src, runtimeDataStore)
+      deriveTotalTransformationResult[From, To, Cfg, InstanceFlags, ImplicitImplicitScopeFlags](src, runtimeDataStore)
     }
 
   final def derivePartialTransformationResult[
@@ -57,7 +57,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      SharedFlags <: internal.TransformerFlags: Type
+      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
   ](
       src: Expr[From],
       failFast: Expr[Boolean],
@@ -67,7 +67,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       TransformerContext.ForPartial.create[From, To](
         src,
         failFast,
-        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, SharedFlags],
+        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, ImplicitImplicitScopeFlags],
         runtimeDataStore
       )
     ).toEither.fold(
@@ -92,10 +92,14 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      SharedFlags <: internal.TransformerFlags: Type
+      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
   ](runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]): Expr[PartialTransformer[From, To]] =
     instantiatePartialTransformer[From, To] { (src: Expr[From], failFast: Expr[Boolean]) =>
-      derivePartialTransformationResult[From, To, Cfg, InstanceFlags, SharedFlags](src, failFast, runtimeDataStore)
+      derivePartialTransformationResult[From, To, Cfg, InstanceFlags, ImplicitImplicitScopeFlags](
+        src,
+        failFast,
+        runtimeDataStore
+      )
     }
 
   /** Adapts DerivedExpr[To] to expected type of transformation */

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
@@ -16,12 +16,12 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](src: Expr[From], runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]): Expr[To] =
     deriveTransformationResult(
       TransformerContext.ForTotal.create[From, To](
         src,
-        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, ImplicitImplicitScopeFlags],
+        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags],
         runtimeDataStore
       )
     ).toEither.fold(
@@ -46,10 +46,10 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]): Expr[Transformer[From, To]] =
     instantiateTotalTransformer[From, To] { (src: Expr[From]) =>
-      deriveTotalTransformationResult[From, To, Cfg, InstanceFlags, ImplicitImplicitScopeFlags](src, runtimeDataStore)
+      deriveTotalTransformationResult[From, To, Cfg, InstanceFlags, ImplicitScopeFlags](src, runtimeDataStore)
     }
 
   final def derivePartialTransformationResult[
@@ -57,7 +57,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](
       src: Expr[From],
       failFast: Expr[Boolean],
@@ -67,7 +67,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       TransformerContext.ForPartial.create[From, To](
         src,
         failFast,
-        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, ImplicitImplicitScopeFlags],
+        configurationsImpl.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags],
         runtimeDataStore
       )
     ).toEither.fold(
@@ -92,10 +92,10 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       To: Type,
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
-      ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
+      ImplicitScopeFlags <: internal.TransformerFlags: Type
   ](runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]): Expr[PartialTransformer[From, To]] =
     instantiatePartialTransformer[From, To] { (src: Expr[From], failFast: Expr[Boolean]) =>
-      derivePartialTransformationResult[From, To, Cfg, InstanceFlags, ImplicitImplicitScopeFlags](
+      derivePartialTransformationResult[From, To, Cfg, InstanceFlags, ImplicitScopeFlags](
         src,
         failFast,
         runtimeDataStore

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
@@ -107,18 +107,18 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       .flatMap {
         case DerivedExpr.TotalExpr(expr) =>
           ctx match {
-            case TransformerContext.ForTotal(_, _, _, _, _) =>
+            case _: TransformerContext.ForTotal[?, ?] =>
               DerivationResult.pure(expr)
-            case TransformerContext.ForPartial(_, _, _, _, _, _) =>
+            case _: TransformerContext.ForPartial[?, ?] =>
               DerivationResult.pure(ChimneyExpr.PartialResult.Value(expr))
           }
         case DerivedExpr.PartialExpr(expr) =>
           ctx match {
-            case TransformerContext.ForTotal(_, _, _, _, _) =>
+            case _: TransformerContext.ForTotal[?, ?] =>
               DerivationResult.fromException(
                 new AssertionError("Derived partial.Result expression where total Transformer excepts direct value")
               )
-            case TransformerContext.ForPartial(_, _, _, _, _, _) =>
+            case _: TransformerContext.ForPartial[?, ?] =>
               DerivationResult.pure(expr)
           }
       }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
@@ -17,7 +17,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
       ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
-  ](src: Expr[From], runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]): Expr[To] =
+  ](src: Expr[From], runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]): Expr[To] =
     deriveTransformationResult(
       TransformerContext.ForTotal.create[From, To](
         src,
@@ -47,7 +47,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
       ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
-  ](runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]): Expr[Transformer[From, To]] =
+  ](runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]): Expr[Transformer[From, To]] =
     instantiateTotalTransformer[From, To] { (src: Expr[From]) =>
       deriveTotalTransformationResult[From, To, Cfg, InstanceFlags, ImplicitImplicitScopeFlags](src, runtimeDataStore)
     }
@@ -61,7 +61,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
   ](
       src: Expr[From],
       failFast: Expr[Boolean],
-      runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]
+      runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]
   ): Expr[partial.Result[To]] =
     deriveTransformationResult(
       TransformerContext.ForPartial.create[From, To](
@@ -93,7 +93,7 @@ private[compiletime] trait Gateway { this: Definitions & Derivation =>
       Cfg <: internal.TransformerCfg: Type,
       InstanceFlags <: internal.TransformerFlags: Type,
       ImplicitImplicitScopeFlags <: internal.TransformerFlags: Type
-  ](runtimeDataStore: Option[Expr[TransformerDefinitionCommons.RuntimeDataStore]]): Expr[PartialTransformer[From, To]] =
+  ](runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]): Expr[PartialTransformer[From, To]] =
     instantiatePartialTransformer[From, To] { (src: Expr[From], failFast: Expr[Boolean]) =>
       derivePartialTransformationResult[From, To, Cfg, InstanceFlags, ImplicitImplicitScopeFlags](
         src,

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
@@ -53,5 +53,16 @@ object PartialTransformerSpec extends TestSuite {
         // no second error due to fail fast mode
       )
     }
+
+    test("fail fast transform with dsl") {
+      import io.scalaland.chimney.dsl.*
+
+      implicit val strToInt: PartialTransformer[String, Int] = pt1
+
+      FooStr("abc", "xyz").intoPartial[Foo].transformFailFast.asErrorPathMessageStrings ==> Iterable(
+        ("s1", """For input string: "abc"""")
+        // no second error due to fail fast mode
+      )
+    }
   }
 }


### PR DESCRIPTION
PR to help keeping trace of endpoints rewired:

 * Scala 2 macros should move new endpoints (they call old macros as a fallback)
 * Scala 3 macros should start using a new macros in the first place
 * found bugs (mostly in Scala 3) should be fixed so that CI errors would be only due to not yet ported rules

- [x] `Transformer.derive`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `PartialTransformer.derive`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `Transformer.define.buildTransformer`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `PartialTransformer.define.buildTransformer` 
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `.transformInto`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `.transformIntoPartial`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `.into.transform`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `.intoPartial.transform`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
- [x] `.intoPartial.transformFailFast`
  - [x] Scala 2 DSL
  - [x] Scala 3 DSL
 
- [x] fix errors with Scala 3 TransformerCfg parsing
- [x] implement String singleton type to String parsing in config reading 