### PR TITLE
Fix few issues with Scala 3 DSL implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalafmtOnCompile := !isCI
 val versions = new {
   val scala212 = "2.12.17"
   val scala213 = "2.13.10"
-  val scala3 = "3.3.0-RC4"
+  val scala3 = "3.3.0-RC5"
 
   // Which versions should be cross-compiled for publishing
   val scalas = List(scala212, scala213, scala3)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -1,7 +1,9 @@
 package io.scalaland.chimney.dsl
 
+import io.scalaland.chimney.internal.compiletime.dsl
 import io.scalaland.chimney.internal.{TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.partial
+import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoImpl
 
 final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: TransformerFlags](
     val source: From,
@@ -12,47 +14,47 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
       inline selector: To => T,
       inline value: U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldConst(selector, value))
+    ${ PartialTransformerIntoImpl.withFieldConstImpl('this, 'selector, 'value) }
   }
 
   transparent inline def withFieldConstPartial[T, U](
       inline selector: To => T,
       inline value: partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldConstPartial(selector, value))
+    ${ PartialTransformerIntoImpl.withFieldConstPartialImpl('this, 'selector, 'value) }
   }
 
   transparent inline def withFieldComputed[T, U](
       inline selector: To => T,
       inline f: From => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldComputed(selector, f))
+    ${ PartialTransformerIntoImpl.withFieldComputedImpl('this, 'selector, 'f) }
   }
 
   transparent inline def withFieldComputedPartial[T, U](
       inline selector: To => T,
       inline f: From => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldComputedPartial(selector, f))
+    ${ PartialTransformerIntoImpl.withFieldComputedPartialImpl('this, 'selector, 'f) }
   }
 
   transparent inline def withFieldRenamed[T, U](
       inline selectorFrom: From => T,
       inline selectorTo: To => U
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withFieldRenamed(selectorFrom, selectorTo))
+    ${ PartialTransformerIntoImpl.withFieldRenamedImpl('this, 'selectorFrom, 'selectorTo) }
   }
 
   transparent inline def withCoproductInstance[Inst](
       inline f: Inst => To
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withCoproductInstance(f))
+    ${ PartialTransformerIntoImpl.withCoproductInstanceImpl('this, 'f) }
   }
 
   transparent inline def withCoproductInstancePartial[Inst](
       inline f: Inst => partial.Result[To]
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] = {
-    new PartialTransformerInto(source, td.withCoproductInstancePartial(f))
+    ${ PartialTransformerIntoImpl.withCoproductInstancePartialImpl('this, 'f) }
   }
 
   inline def transform[ScopeFlags <: TransformerFlags](using

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -60,15 +60,13 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   inline def transform[ScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ScopeFlags]
   ): partial.Result[To] = {
-    // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
-    td.buildTransformer.transform(source, failFast = false)
+    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ScopeFlags]('source, 'td, failFast = false) }
+
   }
 
   inline def transformFailFast[ScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ScopeFlags]
   ): partial.Result[To] = {
-    // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
-    td.buildTransformer.transform(source, failFast = true)
+    ${ PartialTransformerIntoImpl.transform[From, To, Cfg, Flags, ScopeFlags]('source, 'td, failFast = true) }
   }
-
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -61,7 +61,14 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
       tc: TransformerConfiguration[ScopeFlags]
   ): partial.Result[To] = {
     // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
-    td.buildTransformer.transform(source)
+    td.buildTransformer.transform(source, failFast = false)
+  }
+
+  inline def transformFailFast[ScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ScopeFlags]
+  ): partial.Result[To] = {
+    // TODO: rewrite to avoid instantiating a transformer by just inlining transformer body
+    td.buildTransformer.transform(source, failFast = true)
   }
 
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -54,13 +54,12 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
     }
   }
 
-  implicit class UntypedTypeOps[T](private val tpe: Type[T]) {
+  extension [T <: String](tpe: Type[T]) {
 
-    /** Assumes that this `tpe` is String singleton type and extracts its value */
     def asStringSingletonType: String = {
       import quotes.reflect.*
 
-      quoted.Type.valueOfConstant[T](using tpe)(using quotes).map(_.toString) match {
+      quoted.Type.valueOfConstant[T](using tpe)(using quotes) match {
         case Some(str) => str
         case None      => reportError(s"Invalid string literal type: ${tpe}")
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -57,6 +57,7 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
   implicit class UntypedTypeOps[T](private val tpe: Type[T]) {
 
     /** Assumes that this `tpe` is String singleton type and extracts its value */
-    def asStringSingletonType: String = ???
+    def asStringSingletonType: String = s"TODO impl (${tpe.toString})"
+    // TODO: provide real implementation
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -57,7 +57,13 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
   implicit class UntypedTypeOps[T](private val tpe: Type[T]) {
 
     /** Assumes that this `tpe` is String singleton type and extracts its value */
-    def asStringSingletonType: String = s"TODO impl (${tpe.toString})"
-    // TODO: provide real implementation
+    def asStringSingletonType: String = {
+      import quotes.reflect.*
+
+      quoted.Type.valueOfConstant[T](using tpe)(using quotes).map(_.toString) match {
+        case Some(str) => str
+        case None      => reportError(s"Invalid string literal type: ${tpe}")
+      }
+    }
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -103,6 +103,18 @@ object TransformerMacros {
   )(using quotes: Quotes): Expr[Transformer[From, To]] =
     new TransformerMacros(quotes).deriveTotalTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
 
+  final def deriveTotalTransformerResultWithConfig[
+      From: Type,
+      To: Type,
+      Cfg <: internal.TransformerCfg: Type,
+      Flags <: internal.TransformerFlags: Type,
+      ScopeFlags <: internal.TransformerFlags: Type
+  ](source: Expr[From], td: Expr[TransformerDefinition[From, To, Cfg, Flags]])(using quotes: Quotes): Expr[To] =
+    new TransformerMacros(quotes).deriveTotalTransformationResult[From, To, Cfg, Flags, ScopeFlags](
+      source,
+      Some('{ ${ td }.runtimeData })
+    )
+
   final def derivePartialTransformerWithDefaults[
       From: Type,
       To: Type

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -131,4 +131,20 @@ object TransformerMacros {
       td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]]
   )(using quotes: Quotes): Expr[PartialTransformer[From, To]] =
     new TransformerMacros(quotes).derivePartialTransformerWithConfig[From, To, Cfg, Flags, ScopeFlags](td)
+
+  final def derivePartialTransformerResultWithConfig[
+      From: Type,
+      To: Type,
+      Cfg <: internal.TransformerCfg: Type,
+      Flags <: internal.TransformerFlags: Type,
+      ScopeFlags <: internal.TransformerFlags: Type
+  ](source: Expr[From], td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]], failFast: Boolean)(using
+      quotes: Quotes
+  ): Expr[partial.Result[To]] =
+    new TransformerMacros(quotes).derivePartialTransformationResult[From, To, Cfg, Flags, ScopeFlags](
+      source,
+      Expr(failFast),
+      Some('{ ${ td }.runtimeData })
+    )
+
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
@@ -139,9 +139,13 @@ object PartialTransformerIntoImpl {
       ScopeFlags <: TransformerFlags: Type
   ](
       source: Expr[From],
-      td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
-  )(using Quotes): Expr[To] = {
-    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](source, td)
+      td: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]],
+      failFast: Boolean
+  )(using Quotes): Expr[partial.Result[To]] = {
+    TransformerMacros.derivePartialTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](
+      source,
+      td,
+      failFast
+    )
   }
-
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoImpl.scala
@@ -1,0 +1,147 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.*
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.*
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
+
+import scala.quoted.*
+
+object PartialTransformerIntoImpl {
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      valueExpr: Expr[U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldConstImpl('{ ${ tiExpr }.td }, selectorExpr, valueExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldConstPartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      valueExpr: Expr[partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldConstPartialImpl('{ ${ tiExpr }.td }, selectorExpr, valueExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      fExpr: Expr[From => U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldComputedImpl('{ ${ tiExpr }.td }, selectorExpr, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldComputedPartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      fExpr: Expr[From => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldComputedPartialImpl('{ ${ tiExpr }.td }, selectorExpr, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      selectorFromExpr: Expr[From => T],
+      selectorToExpr: Expr[To => U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withFieldRenamed('{ ${ tiExpr }.td }, selectorFromExpr, selectorToExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withCoproductInstanceImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Inst: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      fExpr: Expr[Inst => To]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withCoproductInstance('{ ${ tiExpr }.td }, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withCoproductInstancePartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Inst: Type
+  ](
+      tiExpr: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      fExpr: Expr[Inst => partial.Result[To]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    PartialTransformerDefinitionImpl.withCoproductInstancePartial('{ ${ tiExpr }.td }, fExpr) match {
+      case '{ $td: PartialTransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new PartialTransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def transform[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      ScopeFlags <: TransformerFlags: Type
+  ](
+      source: Expr[From],
+      td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
+  )(using Quotes): Expr[To] = {
+    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](source, td)
+  }
+
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoImpl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoImpl.scala
@@ -1,0 +1,96 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import scala.quoted.*
+import io.scalaland.chimney.*
+import io.scalaland.chimney.internal.*
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
+
+import scala.quoted.*
+
+object TransformerIntoImpl {
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      valueExpr: Expr[U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withFieldConstImpl('{ ${ tiExpr }.td }, selectorExpr, valueExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      selectorExpr: Expr[To => T],
+      fExpr: Expr[From => U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withFieldComputedImpl('{ ${ tiExpr }.td }, selectorExpr, fExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      selectorFromExpr: Expr[From => T],
+      selectorToExpr: Expr[To => U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withFieldRenamed('{ ${ tiExpr }.td }, selectorFromExpr, selectorToExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def withCoproductInstanceImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Inst: Type
+  ](
+      tiExpr: Expr[TransformerInto[From, To, Cfg, Flags]],
+      fExpr: Expr[Inst => To]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerCfg, Flags]] = {
+    TransformerDefinitionImpl.withCoproductInstance('{ ${ tiExpr }.td }, fExpr) match {
+      case '{ $td: TransformerDefinition[From, To, cfg, Flags] } =>
+        '{ new TransformerInto[From, To, cfg, Flags](${ tiExpr }.source, ${ td }) }
+    }
+  }
+
+  def transform[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      ScopeFlags <: TransformerFlags: Type
+  ](
+      source: Expr[From],
+      td: Expr[TransformerDefinition[From, To, Cfg, Flags]]
+  )(using Quotes): Expr[To] = {
+    TransformerMacros.deriveTotalTransformerResultWithConfig[From, To, Cfg, Flags, ScopeFlags](source, td)
+  }
+
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
@@ -53,5 +53,16 @@ object PartialTransformerSpec extends TestSuite {
         // no second error due to fail fast mode
       )
     }
+
+    test("fail fast transform with dsl") {
+      import io.scalaland.chimney.dsl.*
+
+      implicit val strToInt: PartialTransformer[String, Int] = pt1
+
+      FooStr("abc", "xyz").intoPartial[Foo].transformFailFast.asErrorPathMessageStrings ==> Iterable(
+        ("s1", """For input string: "abc"""")
+        // no second error due to fail fast mode
+      )
+    }
   }
 }


### PR DESCRIPTION
This PR addresses issue with Scala 3 DSL implementation which was causing bad shapes when reading type-level config, after using `TransformerInto` and `PartialTransformerInto`. As a result we witnessed `TypeBox[Nothing, TransformerCfg]` instead of proper config type. 

The reason for that was improper chaining of transparent inline macros, which caused that proper, macro-refined types computed by `TransformerDefinition`/`PartialTransformerDefinition` macros were forgot during inlining at *Into level. Unfortunately, we have to call *Definition macros directly and recover their precisely computed types by hand, but at least now they seem to work properly.

Moreover, added few things:
- wiring `.transform` and `.transformFailFast` without instantiating a type class 
- properly implemented instantiating string literal types in Scala 3 `TypesPlatform`
- bumped Scala 3.3.0 to the latest RC version