### PR TITLE
Draft: Transform Option to option derivation rule and Summon Implicit derivation rule, fixes #303

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -11,14 +11,7 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Def
 
     object Transformer extends TransformerModule {
 
-      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.Transformer[From, To]]] =
-        scala.util
-          .Try(c.inferImplicitValue(ChimneyType.Transformer[From, To], silent = true, withMacrosDisabled = false))
-          .toOption
-          .filterNot(_ == EmptyTree)
-          .map(c.Expr[io.scalaland.chimney.Transformer[From, To]](_))
-
-      def transform[From: Type, To: Type](
+      def callTransform[From: Type, To: Type](
           transformer: Expr[io.scalaland.chimney.Transformer[From, To]],
           src: Expr[From]
       ): Expr[To] = c.Expr(q"$transformer.transform($src)")
@@ -26,16 +19,7 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Def
 
     object PartialTransformer extends PartialTransformerModule {
 
-      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
-        scala.util
-          .Try(
-            c.inferImplicitValue(ChimneyType.PartialTransformer[From, To], silent = true, withMacrosDisabled = false)
-          )
-          .toOption
-          .filterNot(_ == EmptyTree)
-          .map(c.Expr[io.scalaland.chimney.PartialTransformer[From, To]](_))
-
-      def transform[From: Type, To: Type](
+      def callTransform[From: Type, To: Type](
           transformer: Expr[io.scalaland.chimney.PartialTransformer[From, To]],
           src: Expr[From],
           failFast: Expr[Boolean]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -5,8 +5,10 @@ import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
 private[derivation] trait DerivationPlatform
     extends Derivation
     with rules.TransformSubtypesRuleModule
+    with rules.TransformOptionToOptionRuleModule
     with rules.LegacyMacrosFallbackRuleModule {
   this: DefinitionsPlatform =>
 
-  override protected val rulesAvailableForPlatform: List[Rule] = List(TransformSubtypesRule, LegacyMacrosFallbackRule)
+  override protected val rulesAvailableForPlatform: List[Rule] =
+    List(TransformSubtypesRule, TransformOptionToOptionRule, LegacyMacrosFallbackRule)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -46,6 +46,25 @@ private[derivation] trait DerivationPlatform
     }
   }
 
+  protected object DeferredExprInit extends DeferredExprInitModule {
+
+    // TODO: freshName with extra steps in Scala 2, random in Scala 3 since freshName is experimental
+    protected def provideFreshName(): String = ???
+
+    protected def refToTypedName[T](typedName: TypedName[T]): Expr[T] = ???
+
+    // TODO:
+    // val $freshName1: $tpe = $expr1
+    // ...
+    // $value
+    protected def initializeVals[To](init: InitializedAsVal[DerivedExpr[To]]): DerivedExpr[To] = ???
+
+    // TODO:
+    // { $freshName: $tpe => $value }
+    protected def useLambda[From, To, B](param: InitializedAsParam[From, Expr[To]], usage: Expr[From => To] => B): B =
+      ???
+  }
+
   final override protected val rulesAvailableForPlatform: List[Rule] =
     List(TransformImplicitRule, TransformSubtypesRule, TransformOptionToOptionRule, LegacyMacrosFallbackRule)
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -1,14 +1,73 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer
 
-import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
+import io.scalaland.chimney.internal.compiletime.{DefinitionsPlatform, DerivationResult}
 
+import scala.annotation.nowarn
+
+@nowarn("msg=The outer reference in this type test cannot be checked at run time.")
 private[derivation] trait DerivationPlatform
     extends Derivation
+    with DefinitionsPlatform
+    with ImplicitSummoningPlatform
+    with rules.TransformImplicitRuleModule
     with rules.TransformSubtypesRuleModule
     with rules.TransformOptionToOptionRuleModule
     with rules.LegacyMacrosFallbackRuleModule {
-  this: DefinitionsPlatform =>
 
-  override protected val rulesAvailableForPlatform: List[Rule] =
-    List(TransformSubtypesRule, TransformOptionToOptionRule, LegacyMacrosFallbackRule)
+  import c.universe.{internal as _, Transformer as _, *}
+
+  protected def deriveFold[NewFrom: Type, NewTo: Type, To: Type](
+      deriveFromSrc: Expr[NewFrom] => DerivationResult[Rule.ExpansionResult[NewTo]]
+  )(
+      provideSrcForTotal: (Expr[NewFrom] => Expr[NewTo]) => DerivedExpr[To]
+  )(
+      provideSrcForPartial: (Expr[NewFrom] => Expr[io.scalaland.chimney.partial.Result[NewTo]]) => DerivedExpr[To]
+  ): DerivationResult[Rule.ExpansionResult[To]] = {
+    val newFromTermName = freshTermName(Type[NewFrom])
+    val newFromExpr = c.Expr[NewFrom](q"$newFromTermName")
+
+    deriveFromSrc(newFromExpr).map {
+      case Rule.ExpansionResult.Expanded(DerivedExpr.TotalExpr(total)) =>
+        Rule.ExpansionResult.Expanded(
+          provideSrcForTotal { newFromValue =>
+            c.Expr[NewTo](q"""val $newFromExpr: ${Type[NewFrom]} = $newFromValue; $total""")
+          }
+        )
+      case Rule.ExpansionResult.Expanded(DerivedExpr.PartialExpr(partial)) =>
+        Rule.ExpansionResult.Expanded(
+          provideSrcForPartial { newFromValue =>
+            c.Expr[io.scalaland.chimney.partial.Result[NewTo]](
+              q"""val $newFromExpr: ${Type[NewFrom]} = $newFromValue; $partial"""
+            )
+          }
+        )
+      case Rule.ExpansionResult.Continue =>
+        Rule.ExpansionResult.Continue
+    }
+  }
+
+  final override protected val rulesAvailableForPlatform: List[Rule] =
+    List(TransformImplicitRule, TransformSubtypesRule, TransformOptionToOptionRule, LegacyMacrosFallbackRule)
+
+  // TODO: copy pasted from GatewayPlatform, find a better solution
+
+  private def freshTermName(srcPrefixTree: Tree): c.universe.TermName = {
+    freshTermName(toFieldName(srcPrefixTree))
+  }
+
+  private def freshTermName(tpe: c.Type): c.universe.TermName = {
+    freshTermName(tpe.typeSymbol.name.decodedName.toString.toLowerCase)
+  }
+
+  private def freshTermName(prefix: String): c.universe.TermName = {
+    c.internal.reificationSupport.freshTermName(prefix.toLowerCase + "$")
+  }
+
+  private def toFieldName(srcPrefixTree: Tree): String = {
+    // undo the encoding of freshTermName
+    srcPrefixTree
+      .toString()
+      .replaceAll("\\$\\d+", "")
+      .replace("$u002E", ".")
+  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/GatewayPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/GatewayPlatform.scala
@@ -1,10 +1,8 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer
 
-import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
 import io.scalaland.chimney.{partial, PartialTransformer, Transformer}
 
-trait GatewayPlatform extends Gateway {
-  this: DefinitionsPlatform & DerivationPlatform =>
+private[derivation] trait GatewayPlatform extends Gateway { this: DerivationPlatform =>
 
   import c.universe.{internal as _, Transformer as _, *}
   import typeUtils.fromWeakConversion.*

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoningPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoningPlatform.scala
@@ -1,0 +1,23 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer
+
+private[derivation] trait ImplicitSummoningPlatform { this: DerivationPlatform =>
+
+  import c.universe.{internal as _, Transformer as _, *}
+
+  final override protected def summonTransformerUnchecked[From: Type, To: Type]
+      : Option[Expr[io.scalaland.chimney.Transformer[From, To]]] = scala.util
+    .Try(c.inferImplicitValue(ChimneyType.Transformer[From, To], silent = true, withMacrosDisabled = false))
+    .toOption
+    .filterNot(_ == EmptyTree)
+    .map(c.Expr[io.scalaland.chimney.Transformer[From, To]](_))
+
+  final override protected def summonPartialTransformerUnchecked[From: Type, To: Type]
+      : Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
+    scala.util
+      .Try(
+        c.inferImplicitValue(ChimneyType.PartialTransformer[From, To], silent = true, withMacrosDisabled = false)
+      )
+      .toOption
+      .filterNot(_ == EmptyTree)
+      .map(c.Expr[io.scalaland.chimney.PartialTransformer[From, To]](_))
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -3,14 +3,10 @@ package io.scalaland.chimney.internal.compiletime.derivation.transformer
 import io.scalaland.chimney.internal.TransformerCfg.Empty
 import io.scalaland.chimney.internal.TransformerFlags.Default
 import io.scalaland.chimney.{internal, PartialTransformer, Transformer}
-import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
 
 import scala.reflect.macros.blackbox
 
-final class TransformerMacros(val c: blackbox.Context)
-    extends DefinitionsPlatform
-    with DerivationPlatform
-    with GatewayPlatform {
+final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatform with GatewayPlatform {
 
   type ImplicitScopeFlagsType <: internal.TransformerFlags
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/LegacyMacrosFallbackRuleModule.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/LegacyMacrosFallbackRuleModule.scala
@@ -1,12 +1,7 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
 
 import io.scalaland.chimney.internal.TransformerDerivationError
-import io.scalaland.chimney.internal.compiletime.{
-  DefinitionsPlatform,
-  DerivationError,
-  DerivationErrors,
-  DerivationResult
-}
+import io.scalaland.chimney.internal.compiletime.{DerivationError, DerivationErrors, DerivationResult}
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.DerivationPlatform
 import io.scalaland.chimney.internal.macros.dsl.TransformerBlackboxMacros
 import io.scalaland.chimney.partial
@@ -14,8 +9,7 @@ import io.scalaland.chimney.partial
 import scala.annotation.nowarn
 
 @nowarn("msg=The outer reference in this type test cannot be checked at run time.")
-private[compiletime] trait LegacyMacrosFallbackRuleModule {
-  this: DefinitionsPlatform & DerivationPlatform =>
+private[compiletime] trait LegacyMacrosFallbackRuleModule { this: DerivationPlatform =>
 
   // TODO: remove this rule once all rules are migrated; it's here only to make the Scala 2 tests pass during migration
   protected object LegacyMacrosFallbackRule extends Rule("LegacyMacrosFallback") {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -10,6 +10,29 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Def
 
   object ChimneyExpr extends ChimneyExprModule {
 
+    object Transformer extends TransformerModule {
+
+      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.Transformer[From, To]]] =
+        scala.quoted.Expr.summon(using ChimneyType.Transformer[From, To])
+
+      def transform[From: Type, To: Type](
+          transformer: Expr[io.scalaland.chimney.Transformer[From, To]],
+          src: Expr[From]
+      ): Expr[To] = '{ ${ transformer }.transform(${ src }) }
+    }
+
+    object PartialTransformer extends PartialTransformerModule {
+
+      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
+        scala.quoted.Expr.summon(using ChimneyType.PartialTransformer[From, To])
+
+      def transform[From: Type, To: Type](
+          transformer: Expr[io.scalaland.chimney.PartialTransformer[From, To]],
+          src: Expr[From],
+          failFast: Expr[Boolean]
+      ): Expr[partial.Result[To]] = '{ ${ transformer }.transform(${ src }, ${ failFast }) }
+    }
+
     object PartialResult extends PartialResultModule {
       def Value[T: Type](value: Expr[T]): Expr[partial.Result.Value[T]] =
         '{ partial.Result.Value[T](${ value }) }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -12,10 +12,7 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Def
 
     object Transformer extends TransformerModule {
 
-      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.Transformer[From, To]]] =
-        scala.quoted.Expr.summon(using ChimneyType.Transformer[From, To])
-
-      def transform[From: Type, To: Type](
+      def callTransform[From: Type, To: Type](
           transformer: Expr[io.scalaland.chimney.Transformer[From, To]],
           src: Expr[From]
       ): Expr[To] = '{ ${ transformer }.transform(${ src }) }
@@ -23,10 +20,7 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Def
 
     object PartialTransformer extends PartialTransformerModule {
 
-      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
-        scala.quoted.Expr.summon(using ChimneyType.PartialTransformer[From, To])
-
-      def transform[From: Type, To: Type](
+      def callTransform[From: Type, To: Type](
           transformer: Expr[io.scalaland.chimney.PartialTransformer[From, To]],
           src: Expr[From],
           failFast: Expr[Boolean]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/DefinitionsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/DefinitionsPlatform.scala
@@ -6,7 +6,7 @@ import io.scalaland.chimney.{partial, PartialTransformer, Patcher, Transformer}
 
 import scala.quoted
 
-private[compiletime] trait DefinitionsPlatform(using val quotes: quoted.Quotes)
+abstract private[compiletime] class DefinitionsPlatform(using val quotes: quoted.Quotes)
     extends Definitions
     with TypesPlatform
     with ChimneyTypesPlatform

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -42,7 +42,14 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
       def apply[T: Type]: Type[Array[T]] = fromTC[Array[*], Array[T]](Type[T])
     }
 
-    def Option[T: Type]: Type[Option[T]] = fromTC[Option[*], Option[T]](Type[T])
+    object Option extends OptionModule {
+
+      def apply[T: Type]: Type[Option[T]] = fromTC[Option[*], Option[T]](Type[T])
+      def unapply[T](tpe: Type[T]): Option[ComputedType] = tpe match {
+        case '[Option[inner]] => Some(ComputedType(Type[inner]))
+        case _                => None
+      }
+    }
     def Either[L: Type, R: Type]: Type[Either[L, R]] = fromTC[Either[*, *], Either[L, R]](Type[L], Type[R])
 
     def isSubtypeOf[S, T](S: Type[S], T: Type[T]): Boolean = TypeRepr.of(using S) <:< TypeRepr.of(using T)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -21,6 +21,25 @@ abstract private[derivation] class DerivationPlatform(q: scala.quoted.Quotes)
   ): DerivationResult[Rule.ExpansionResult[To]] =
     DerivationResult.notYetImplemented("deriveFrom")
 
+  protected object DeferredExprInit extends DeferredExprInitModule {
+
+    // TODO: freshName with extra steps in Scala 2, random in Scala 3 since freshName is experimental
+    protected def provideFreshName(): String = ???
+
+    protected def refToTypedName[T](typedName: TypedName[T]): Expr[T] = ???
+
+    // TODO:
+    // val $freshName1: $tpe = $expr1
+    // ...
+    // $value
+    protected def initializeVals[To](init: InitializedAsVal[DerivedExpr[To]]): DerivedExpr[To] = ???
+
+    // TODO:
+    // { $freshName: $tpe => $value }
+    protected def useLambda[From, To, B](param: InitializedAsParam[From, Expr[To]], usage: Expr[From => To] => B): B =
+      ???
+  }
+
   final override protected val rulesAvailableForPlatform: List[Rule] =
     List(TransformImplicitRule, TransformSubtypesRule, TransformOptionToOptionRule, NotImplementedFallbackRule)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -3,13 +3,24 @@ package io.scalaland.chimney.internal.compiletime.derivation.transformer
 import io.scalaland.chimney.internal.compiletime.{DefinitionsPlatform, DerivationResult}
 import io.scalaland.chimney.{partial, PartialTransformer, Transformer}
 
-private[derivation] trait DerivationPlatform
-    extends Derivation
+abstract private[derivation] class DerivationPlatform(q: scala.quoted.Quotes)
+    extends DefinitionsPlatform(using q)
+    with Derivation
+    with ImplicitSummoningPlatform
+    with rules.TransformImplicitRuleModule
     with rules.TransformSubtypesRuleModule
     with rules.TransformOptionToOptionRuleModule
     with rules.NotImplementedFallbackRuleModule {
-  this: DefinitionsPlatform =>
 
-  override protected val rulesAvailableForPlatform: List[Rule] =
-    List(TransformSubtypesRule, TransformOptionToOptionRule, NotImplementedFallbackRule)
+  final override protected def deriveFold[NewFrom: Type, NewTo: Type, To: Type](
+      deriveFromSrc: Expr[NewFrom] => DerivationResult[Rule.ExpansionResult[NewTo]]
+  )(
+      provideSrcForTotal: (Expr[NewFrom] => Expr[NewTo]) => DerivedExpr[To]
+  )(
+      provideSrcForPartial: (Expr[NewFrom] => Expr[partial.Result[NewTo]]) => DerivedExpr[To]
+  ): DerivationResult[Rule.ExpansionResult[To]] =
+    DerivationResult.notYetImplemented("deriveFrom")
+
+  final override protected val rulesAvailableForPlatform: List[Rule] =
+    List(TransformImplicitRule, TransformSubtypesRule, TransformOptionToOptionRule, NotImplementedFallbackRule)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -6,9 +6,10 @@ import io.scalaland.chimney.{partial, PartialTransformer, Transformer}
 private[derivation] trait DerivationPlatform
     extends Derivation
     with rules.TransformSubtypesRuleModule
+    with rules.TransformOptionToOptionRuleModule
     with rules.NotImplementedFallbackRuleModule {
   this: DefinitionsPlatform =>
 
   override protected val rulesAvailableForPlatform: List[Rule] =
-    List(TransformSubtypesRule, NotImplementedFallbackRule)
+    List(TransformSubtypesRule, TransformOptionToOptionRule, NotImplementedFallbackRule)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/GatewayPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/GatewayPlatform.scala
@@ -1,9 +1,9 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer
 
-import io.scalaland.chimney.internal.compiletime.{DefinitionsPlatform, DerivationResult}
+import io.scalaland.chimney.internal.compiletime.DerivationResult
 import io.scalaland.chimney.{internal, partial, PartialTransformer, Transformer}
 
-private[derivation] trait GatewayPlatform extends Gateway { this: DefinitionsPlatform & DerivationPlatform =>
+private[derivation] trait GatewayPlatform extends Gateway { this: DerivationPlatform =>
 
   override protected def instantiateTotalTransformer[From: Type, To: Type](
       toExpr: Expr[From] => Expr[To]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoningPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoningPlatform.scala
@@ -1,0 +1,16 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer
+
+import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
+
+private[derivation] trait ImplicitSummoningPlatform { this: DerivationPlatform =>
+
+  import quotes.*, quotes.reflect.*
+
+  protected def summonTransformerUnchecked[From: Type, To: Type]
+      : Option[Expr[io.scalaland.chimney.Transformer[From, To]]] =
+    scala.quoted.Expr.summon(using ChimneyType.Transformer[From, To])
+
+  protected def summonPartialTransformerUnchecked[From: Type, To: Type]
+      : Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
+    scala.quoted.Expr.summon(using ChimneyType.PartialTransformer[From, To])
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -8,10 +8,7 @@ import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
 
 import scala.quoted.{Expr, Quotes, Type}
 
-final class TransformerMacros(q: Quotes)
-    extends DefinitionsPlatform(using q)
-    with DerivationPlatform
-    with GatewayPlatform {
+final class TransformerMacros(q: Quotes) extends DerivationPlatform(q) with GatewayPlatform {
 
   type ImplicitScopeFlagsType <: internal.TransformerFlags
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/NotImplementedFallbackRuleModule.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/NotImplementedFallbackRuleModule.scala
@@ -1,9 +1,9 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
 
 import io.scalaland.chimney.internal.compiletime.{Definitions, DefinitionsPlatform, DerivationResult}
-import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.{Derivation, DerivationPlatform}
 
-trait NotImplementedFallbackRuleModule { this: DefinitionsPlatform & Derivation =>
+trait NotImplementedFallbackRuleModule { this: DerivationPlatform =>
 
   // TODO: remove this rule once all rules are migrated; it's here only to make the Scala 3 tests compile
   object NotImplementedFallbackRule extends Rule("NotImplementedFallback") {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
@@ -14,9 +14,7 @@ private[compiletime] trait ChimneyExprs { this: Definitions =>
     val Transformer: TransformerModule
     trait TransformerModule { this: Transformer.type =>
 
-      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.Transformer[From, To]]]
-
-      def transform[From: Type, To: Type](
+      def callTransform[From: Type, To: Type](
           transformer: Expr[io.scalaland.chimney.Transformer[From, To]],
           src: Expr[From]
       ): Expr[To]
@@ -25,9 +23,7 @@ private[compiletime] trait ChimneyExprs { this: Definitions =>
     val PartialTransformer: PartialTransformerModule
     trait PartialTransformerModule { this: PartialTransformer.type =>
 
-      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]]
-
-      def transform[From: Type, To: Type](
+      def callTransform[From: Type, To: Type](
           transformer: Expr[io.scalaland.chimney.PartialTransformer[From, To]],
           src: Expr[From],
           failFast: Expr[Boolean]
@@ -101,5 +97,20 @@ private[compiletime] trait ChimneyExprs { this: Definitions =>
           index: Int
       ): Expr[Any]
     }
+  }
+
+  implicit class TransformerExprOps[From: Type, To: Type](
+      private val transformer: Expr[io.scalaland.chimney.Transformer[From, To]]
+  ) {
+
+    def callTransform(src: Expr[From]): Expr[To] = ChimneyExpr.Transformer.callTransform(transformer, src)
+  }
+
+  implicit class PartialTransformerExprOps[From: Type, To: Type](
+      private val transformer: Expr[io.scalaland.chimney.PartialTransformer[From, To]]
+  ) {
+
+    def callTransform(src: Expr[From], failFast: Expr[Boolean]): Expr[partial.Result[To]] =
+      ChimneyExpr.PartialTransformer.callTransform(transformer, src, failFast)
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
@@ -11,6 +11,29 @@ private[compiletime] trait ChimneyExprs { this: Definitions =>
   val ChimneyExpr: ChimneyExprModule
   trait ChimneyExprModule { this: ChimneyExpr.type =>
 
+    val Transformer: TransformerModule
+    trait TransformerModule { this: Transformer.type =>
+
+      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.Transformer[From, To]]]
+
+      def transform[From: Type, To: Type](
+          transformer: Expr[io.scalaland.chimney.Transformer[From, To]],
+          src: Expr[From]
+      ): Expr[To]
+    }
+
+    val PartialTransformer: PartialTransformerModule
+    trait PartialTransformerModule { this: PartialTransformer.type =>
+
+      def summon[From: Type, To: Type]: Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]]
+
+      def transform[From: Type, To: Type](
+          transformer: Expr[io.scalaland.chimney.PartialTransformer[From, To]],
+          src: Expr[From],
+          failFast: Expr[Boolean]
+      ): Expr[partial.Result[To]]
+    }
+
     val PartialResult: PartialResultModule
     trait PartialResultModule { this: PartialResult.type =>
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
@@ -23,6 +23,19 @@ private[compiletime] trait Contexts { this: Definitions & Configurations =>
     val TypeClass: Type[TypeClass]
 
     val derivationStartedAt: java.time.Instant
+
+    def updateFromTo[NewFrom: Type, NewTo: Type](newSrc: Expr[NewFrom]): TransformerContext[NewFrom, NewTo] =
+      this match {
+        case total: TransformerContext.ForTotal[?, ?] =>
+          total.copy(From = Type[NewFrom], To = Type[NewTo], src = newSrc)
+        case partial: TransformerContext.ForPartial[?, ?] =>
+          partial.copy(From = Type[NewFrom], To = Type[NewTo], src = newSrc)
+      }
+
+    def updateConfig(f: TransformerConfig => TransformerConfig): TransformerContext[From, To] = this match {
+      case total: TransformerContext.ForTotal[?, ?]     => total.copy(config = f(total.config))
+      case partial: TransformerContext.ForPartial[?, ?] => partial.copy(config = f(partial.config))
+    }
   }
   protected object TransformerContext {
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Contexts.scala
@@ -9,6 +9,7 @@ import scala.annotation.nowarn
 @nowarn("msg=The outer reference in this type test cannot be checked at run time.")
 private[compiletime] trait Contexts { this: Definitions & Configurations =>
 
+  // TODO: rename to TransformationContext
   sealed protected trait TransformerContext[From, To] extends Product with Serializable {
     val From: Type[From]
     val To: Type[To]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Definitions.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Definitions.scala
@@ -2,8 +2,10 @@ package io.scalaland.chimney.internal.compiletime
 
 private[compiletime] trait Definitions
     extends Types
-    with ChimneyTypes
     with Exprs
+    with Stmts
+    with Fresh
+    with ChimneyTypes
     with ChimneyExprs
     with Configurations
     with Contexts

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Fresh.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Fresh.scala
@@ -1,0 +1,14 @@
+package io.scalaland.chimney.internal.compiletime
+
+private[compiletime] trait Fresh { this: Definitions =>
+
+  abstract class FreshIdent[T](ident: String) {
+    def asIdentExpr: Expr[T] // using "ident" as expr
+    def asValDef[U <: T](initExpr: Expr[U]): ValDef[T] // "val ident = initExpr"
+    def asFunctionExpr[U](funBodyExpr: Expr[U]): Expr[T] => Expr[U] // "{ ident => funBodyExpr }"
+  }
+
+  def newFreshIdent[T: Type](namePrefix: String): FreshIdent[T]
+  // ident = namePrefix + separator + random suffix; impl might be platform-dependent
+
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Stmts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Stmts.scala
@@ -1,0 +1,11 @@
+package io.scalaland.chimney.internal.compiletime
+
+private[compiletime] trait Stmts { this: Definitions =>
+
+  type Stmt[T]
+  type ValDef[T] <: Stmt[T]
+  type VarDef[T] <: Stmt[T]
+  type LazyValDef[T] <: Stmt[T]
+
+  def blockExpr(stats: Seq[Stmt[_]], expr: Expr[T]): Expr[T]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
@@ -41,6 +41,10 @@ private[compiletime] trait Types {
 
     final def <:<[S](another: Type[S]): Boolean = Type.isSubtypeOf(tpe, another)
     final def =:=[S](another: Type[S]): Boolean = Type.isSameAs(tpe, another)
+
+    final def isOption: Boolean = tpe <:< Type.Option(Type.Any)
+
+    final def asComputed: ComputedType = ComputedType(tpe)
   }
 
   /** Used to erase the type of Type, while providing the utilities to still make it useful */
@@ -50,10 +54,11 @@ private[compiletime] trait Types {
     def apply[T](tpe: Type[T]): ComputedType = tpe.asInstanceOf[ComputedType]
 
     def prettyPrint(computedType: ComputedType): String = Type.prettyPrint(computedType.Type)
+
+    def use[Out](ct: ComputedType)(thunk: Type[ct.Underlying] => Out): Out = thunk(ct.asInstanceOf[Type[ct.Underlying]])
   }
 
   implicit class ComputedTypeOps(val ct: ComputedType) {
     def Type: Type[ct.Underlying] = ct.asInstanceOf[Type[ct.Underlying]]
-    def use[Out](thunk: Type[ct.Underlying] => Out): Out = thunk(Type)
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
@@ -23,7 +23,12 @@ private[compiletime] trait Types {
       val Any: Type[Array[Any]] = apply(Type.Any)
     }
 
-    def Option[T: Type]: Type[Option[T]]
+    val Option: OptionModule
+    trait OptionModule { this: Option.type =>
+
+      def apply[T: Type]: Type[Option[T]]
+      def unapply[T](tpe: Type[T]): Option[ComputedType]
+    }
     def Either[L: Type, R: Type]: Type[Either[L, R]]
 
     def isSubtypeOf[S, T](S: Type[S], T: Type[T]): Boolean

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -26,6 +26,7 @@ private[compiletime] trait Derivation extends Definitions with ResultOps with Im
   final protected def deriveRecursiveTransformationExpr[NewFrom: Type, NewTo: Type](
       newSrc: Expr[NewFrom]
   )(implicit ctx: TransformerContext[?, ?]): DerivationResult[DerivedExpr[NewTo]] = {
+    // TODO: log that we're entering the recrusion?
     val newCtx: TransformerContext[NewFrom, NewTo] = ctx.updateFromTo[NewFrom, NewTo](newSrc).updateConfig {
       _.prepareForRecursiveCall
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -1,5 +1,6 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer
 
+import io.scalaland.chimney.dsl.{PreferPartialTransformer, PreferTotalTransformer}
 import io.scalaland.chimney.internal.compiletime.{Definitions, DerivationResult}
 import io.scalaland.chimney.partial
 
@@ -7,6 +8,35 @@ import scala.annotation.nowarn
 
 @nowarn("msg=The outer reference in this type test cannot be checked at run time.")
 private[compiletime] trait Derivation extends Definitions with ResultOps {
+
+  final protected def summonTransformerForTransformationResultExpr[From, To](implicit
+      ctx: TransformerContext[From, To]
+  ): Option[DerivedExpr[To]] = ctx match {
+    case totalCtx: TransformerContext.ForTotal[?, ?] =>
+      ChimneyExpr.Transformer.summon[From, To].map { transformer =>
+        DerivedExpr.TotalExpr(ChimneyExpr.Transformer.transform(transformer, totalCtx.src))
+      }
+    case partialCtx: TransformerContext.ForPartial[?, ?] =>
+      import partialCtx.{src, failFast}
+      import partialCtx.config.flags.implicitConflictResolution
+      (ChimneyExpr.Transformer.summon[From, To], ChimneyExpr.PartialTransformer.summon[From, To]) match {
+        case (Some(total), Some(partial)) if implicitConflictResolution.isEmpty =>
+          reportError(
+            s"""Ambiguous implicits while resolving Chimney recursive transformation:
+               |
+               |PartialTransformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(total)}
+               |Transformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(partial)}
+               |
+               |Please eliminate ambiguity from implicit scope or use enableImplicitConflictResolution/withFieldComputed/withFieldComputedPartial to decide which one should be used
+               |""".stripMargin
+          )
+        case (Some(total), partialOpt) if partialOpt.isEmpty || implicitConflictResolution == PreferTotalTransformer =>
+          Some(DerivedExpr.TotalExpr(ChimneyExpr.Transformer.transform(total, src)))
+        case (totalOpt, Some(partial)) if totalOpt.isEmpty || implicitConflictResolution == PreferPartialTransformer =>
+          Some(DerivedExpr.PartialExpr(ChimneyExpr.PartialTransformer.transform(partial, src, failFast)))
+        case _ => None
+      }
+  }
 
   /** Intended use case: recursive derivation */
   final protected def deriveTransformationResultExpr[From, To](implicit
@@ -27,6 +57,14 @@ private[compiletime] trait Derivation extends Definitions with ResultOps {
 //          case DerivedExpr.PartialExpr(expr) => s"Derived partial expression ${Expr.prettyPrint(expr)}"
 //        }
     }
+
+  /** Intended use case: recursive derivation when we want to attempt summoning first */
+  final protected def summonOrElseDeriveTransformationResultExpr[From, To](implicit
+      ctx: TransformerContext[From, To]
+  ): DerivationResult[DerivedExpr[To]] = summonTransformerForTransformationResultExpr[From, To] match {
+    case Some(derivedExpr) => DerivationResult.pure(derivedExpr)
+    case None              => deriveTransformationResultExpr[From, To]
+  }
 
   abstract protected class Rule(val name: String) {
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
@@ -1,0 +1,22 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer
+
+trait ImplicitSummoning { this: Derivation =>
+
+  final protected def summonTransformer[From, To](implicit
+      ctx: TransformerContext[From, To]
+  ): Option[Expr[io.scalaland.chimney.Transformer[From, To]]] =
+    if (ctx.config.preventResolutionForTypes.contains((Type[From].asComputed, Type[From].asComputed))) None
+    else summonTransformerUnchecked[From, To]
+
+  final protected def summonPartialTransformer[From, To](implicit
+      ctx: TransformerContext[From, To]
+  ): Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
+    if (ctx.config.preventResolutionForTypes.contains((Type[From].asComputed, Type[From].asComputed))) None
+    else summonPartialTransformerUnchecked[From, To]
+
+  protected def summonTransformerUnchecked[From: Type, To: Type]
+      : Option[Expr[io.scalaland.chimney.Transformer[From, To]]]
+
+  protected def summonPartialTransformerUnchecked[From: Type, To: Type]
+      : Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
@@ -1,0 +1,44 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
+
+import io.scalaland.chimney.dsl.{PreferPartialTransformer, PreferTotalTransformer}
+import io.scalaland.chimney.internal.compiletime.DerivationResult
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+
+import scala.annotation.nowarn
+
+@nowarn("msg=The outer reference in this type test cannot be checked at run time.")
+trait TransformImplicitRuleModule { this: Derivation =>
+
+  object TransformImplicitRule extends Rule("Implicit") {
+
+    def expand[From, To](implicit ctx: TransformerContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
+      ctx match {
+        case totalCtx: TransformerContext.ForTotal[?, ?] =>
+          summonTransformer[From, To].fold(DerivationResult.continue[To]) { transformer =>
+            DerivationResult.totalExpr(transformer.callTransform(totalCtx.src))
+          }
+        case partialCtx: TransformerContext.ForPartial[?, ?] =>
+          import partialCtx.{src, failFast}
+          import partialCtx.config.flags.implicitConflictResolution
+          (summonTransformer[From, To], summonPartialTransformer[From, To]) match {
+            case (Some(total), Some(partial)) if implicitConflictResolution.isEmpty =>
+              reportError(
+                s"""Ambiguous implicits while resolving Chimney recursive transformation:
+                   |
+                   |PartialTransformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(total)}
+                   |Transformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(partial)}
+                   |
+                   |Please eliminate ambiguity from implicit scope or use enableImplicitConflictResolution/withFieldComputed/withFieldComputedPartial to decide which one should be used
+                   |""".stripMargin
+              )
+            case (Some(total), partialOpt)
+                if partialOpt.isEmpty || implicitConflictResolution == PreferTotalTransformer =>
+              DerivationResult.totalExpr(total.callTransform(src))
+            case (totalOpt, Some(partial))
+                if totalOpt.isEmpty || implicitConflictResolution == PreferPartialTransformer =>
+              DerivationResult.partialExpr(partial.callTransform(src, failFast))
+            case _ => DerivationResult.continue
+          }
+      }
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -8,10 +8,32 @@ trait TransformOptionToOptionRuleModule { this: Derivation =>
   object TransformOptionToOptionRule extends Rule("OptionToOption") {
 
     def expand[From, To](implicit ctx: TransformerContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
-      if ((Type[From] <:< Type.Option(Type.Any)) && (Type[To] <:< Type.Option(Type.Any))) {
-        DerivationResult.totalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
-      } else {
-        DerivationResult.continue
+      (Type[From], Type[To]) match {
+        case (Type.Option(innerFrom), Type.Option(innerTo)) =>
+          ComputedType.use(innerFrom) { implicit InnerFrom: Type[innerFrom.Underlying] =>
+            ComputedType.use(innerTo) { implicit InnerTo: Type[innerTo.Underlying] =>
+              deriveFold[innerFrom.Underlying, innerTo.Underlying, To] { (newFromExpr: Expr[innerFrom.Underlying]) =>
+                deriveRecursiveTransformationExpr[innerFrom.Underlying, innerTo.Underlying](newFromExpr)
+                  .map(Rule.ExpansionResult.Expanded(_))
+              } { provideFromTotal =>
+                // TODO:
+                // sth like: DerivedExpr.Total('{ ${ ctx.src }.map(from => ${ provideFromTotal('{ from }) }) })
+                DerivedExpr.TotalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
+              } { provideFromPartial =>
+                // TODO:
+                // sth like: DerivedExpr.Partial('{
+                //   ${ src.src }.fold[$To](
+                //      partial.Result.Value(None : Option[$To])
+                //   )(
+                //     (from: $InnerFrom) => ${ provideFromPartial('{ from }) }.map(Option[$InnerTo](_))
+                //   )
+                // })
+                DerivedExpr.TotalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
+              }
+            }
+          }
+        case _ =>
+          DerivationResult.continue
       }
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -12,24 +12,55 @@ trait TransformOptionToOptionRuleModule { this: Derivation =>
         case (Type.Option(innerFrom), Type.Option(innerTo)) =>
           ComputedType.use(innerFrom) { implicit InnerFrom: Type[innerFrom.Underlying] =>
             ComputedType.use(innerTo) { implicit InnerTo: Type[innerTo.Underlying] =>
-              deriveFold[innerFrom.Underlying, innerTo.Underlying, To] { (newFromExpr: Expr[innerFrom.Underlying]) =>
-                deriveRecursiveTransformationExpr[innerFrom.Underlying, innerTo.Underlying](newFromExpr)
-                  .map(Rule.ExpansionResult.Expanded(_))
-              } { provideFromTotal =>
-                // TODO:
-                // sth like: DerivedExpr.Total('{ ${ ctx.src }.map(from => ${ provideFromTotal('{ from }) }) })
-                DerivedExpr.TotalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
-              } { provideFromPartial =>
-                // TODO:
-                // sth like: DerivedExpr.Partial('{
-                //   ${ src.src }.fold[$To](
-                //      partial.Result.Value(None : Option[$To])
-                //   )(
-                //     (from: $InnerFrom) => ${ provideFromPartial('{ from }) }.map(Option[$InnerTo](_))
-                //   )
-                // })
-                DerivedExpr.TotalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
-              }
+
+              val optionArgFT = newFreshIdent[innerFrom.Underlying]("optionInner")
+              // generates new name like optionInner$1234
+
+              deriveRecursiveTransformationExpr[innerFrom.Underlying, innerTo.Underlying](
+                newSrc = optionArgFT.asIdentExpr[innerFrom.Underlying] // reference to optionInner$1234 as expr
+              ).map {
+                case DerivedExpr.TotalExpr(innerTransformExpr) => // innerTransformExpr may contain references to optionInner$1234, passed as newSrc
+                  DerivedExpr.TotalExpr(
+                    ctx.srcExpr // Expr[Option[From]]
+                      .mapOptionExpr( // needs Expr[From] => Expr[To]
+                        optionArgFT.asFunctionExpr(
+                          innerTransformExpr // needs Expr[To]
+                        ) // returns Expr[From] => Expr[To], equivalent to '{ optionInner$1234 => $innerTransformExpr }
+                      ) // Expr[Option[To]]
+                  ) // TotalExpr
+
+                case DerivedExpr.PartialExpr(innerPartialTransformExpr) =>
+                  DerivedExpr.PartialExpr(
+                    ctx.srcExpr // Expr[Option[From]]
+                      .foldOptionExpr( // needs 2 exprs:
+                        ifEmptyExpr = ChimneyExpr.PartialResult.Value[Option[To]](Expr.Option.empty[To]),
+                        fExpr = // Expr[From] => Expr[partial.Result[Option[To]]]
+                          optionArgFT.asFunctionExpr(
+                            innerPartialTransformExpr
+                              .partialMapExpr(Exprs.Option.apply) // Expr[partial.Result[Option[To]]]
+                          ) // Expr[From] => Expr[partial.Result[Option[To]]]
+                      ) // Expr[partial.Result[Option[To]]]
+                  ) // PartialExpr
+              }.map(Rule.ExpansionResult.Expanded(_))
+
+//              deriveFold[innerFrom.Underlying, innerTo.Underlying, To] { (newFromExpr: Expr[innerFrom.Underlying]) =>
+//                deriveRecursiveTransformationExpr[innerFrom.Underlying, innerTo.Underlying](newFromExpr)
+//                  .map(Rule.ExpansionResult.Expanded(_))
+//              } { provideFromTotal =>
+//                // TODO:
+//                // sth like: DerivedExpr.Total('{ ${ ctx.src }.map(from => ${ provideFromTotal('{ from }) }) })
+//                DerivedExpr.TotalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
+//              } { provideFromPartial =>
+//                // TODO:
+//                // sth like: DerivedExpr.Partial('{
+//                //   ${ src.src }.fold[$To](
+//                //      partial.Result.Value(None : Option[$To])
+//                //   )(
+//                //     (from: $InnerFrom) => ${ provideFromPartial('{ from }) }.map(Option[$InnerTo](_))
+//                //   )
+//                // })
+//                DerivedExpr.TotalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
+//              }
             }
           }
         case _ =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -1,0 +1,17 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
+
+import io.scalaland.chimney.internal.compiletime.DerivationResult
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+
+trait TransformOptionToOptionRuleModule { this: Derivation =>
+
+  object TransformOptionToOptionRule extends Rule("OptionToOption") {
+
+    def expand[From, To](implicit ctx: TransformerContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
+      if ((Type[From] <:< Type.Option(Type.Any)) && (Type[To] <:< Type.Option(Type.Any))) {
+        DerivationResult.totalExpr(Expr.asInstanceOf[Nothing, To](Expr.Nothing)(Type.Nothing, Type[To]))
+      } else {
+        DerivationResult.continue
+      }
+  }
+}


### PR DESCRIPTION
- [x] check if both types are Option's 
- [x] extract inner type
  - [x] create inner option type extracting utilities 
- [ ] call directive which attempts summoning
  - [x] create summoning utilities
  - [x] create utilities for calling summoned transformers
- [ ] and then recursive derivation if failed
  - [ ] create utilities which attempt the above 
- [ ] use this transformation within Option.map
  - [ ] create Option.map utilities