### PR TITLE
Fix passing `failFast` flags to implicit partial transformers

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/Model.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/Model.scala
@@ -23,6 +23,16 @@ trait Model extends TransformerConfigSupport {
     def isLiftedTarget: Boolean = target.isInstanceOf[DerivationTarget.LiftedTransformer]
 
     def mapTree(f: Tree => Tree): DerivedTree = copy(tree = f(tree))
+    def callTransform(input: Tree): DerivedTree = mapTree { tree =>
+      target match {
+        case DerivationTarget.TotalTransformer =>
+          tree.callTransform(input)
+        case DerivationTarget.PartialTransformer(failFastTermName) =>
+          tree.callPartialTransform(input, q"$failFastTermName")
+        case _: DerivationTarget.LiftedTransformer =>
+          tree.callTransform(input)
+      }
+    }
   }
   object DerivedTree {
     def fromTotalTree(tree: Tree): DerivedTree = DerivedTree(tree, DerivationTarget.TotalTransformer)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -146,7 +146,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
 
     resolveImplicitTransformer(config)(From, To)
       .map { localImplicitDerivedTree =>
-        Right(localImplicitDerivedTree.mapTree(_.callTransform(config.srcPrefixTree)))
+        Right(localImplicitDerivedTree.callTransform(config.srcPrefixTree))
       }
       .getOrElse {
         deriveTransformerTree(config)(From, To)
@@ -698,7 +698,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
                     .map { implicitTransformerTree =>
                       val fn = freshTermName(instName)
                       Right(
-                        InstanceClause(Some(fn), instTpe, implicitTransformerTree.mapTree(_.callTransform(Ident(fn))))
+                        InstanceClause(Some(fn), instTpe, implicitTransformerTree.callTransform(Ident(fn)))
                       )
                     }
                 }
@@ -734,7 +734,7 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
                             InstanceClause(
                               Some(fn),
                               instTpe,
-                              implicitTransformerTree.mapTree(_.callTransform(Ident(fn)))
+                              implicitTransformerTree.callTransform(Ident(fn))
                             )
                           )
                         }
@@ -1007,9 +1007,9 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
                  |""".stripMargin
             )
           case (Some(localImplicitTreeF), None) =>
-            Right(localImplicitTreeF.mapTree(_.callTransform(config.srcPrefixTree)))
+            Right(localImplicitTreeF.callTransform(config.srcPrefixTree))
           case (None, Some(localImplicitTree)) =>
-            Right(localImplicitTree.mapTree(_.callTransform(config.srcPrefixTree)))
+            Right(localImplicitTree.callTransform(config.srcPrefixTree))
           case (None, None) =>
             deriveTransformerTree(config)(From, To)
         }
@@ -1019,15 +1019,15 @@ trait TransformerMacros extends MappingMacros with TargetConstructorMacros with 
 
         (implicitPartialTransformer, implicitTransformer) match {
           case (Some(localImplicitTreePartial), None) =>
-            Right(localImplicitTreePartial.mapTree(_.callTransform(config.srcPrefixTree)))
+            Right(localImplicitTreePartial.callTransform(config.srcPrefixTree))
           case (Some(localImplicitTreePartial), Some(_))
               if config.flags.implicitConflictResolution.contains(PreferPartialTransformer) =>
-            Right(localImplicitTreePartial.mapTree(_.callTransform(config.srcPrefixTree)))
+            Right(localImplicitTreePartial.callTransform(config.srcPrefixTree))
           case (None, Some(localImplicitTree)) =>
-            Right(localImplicitTree.mapTree(_.callTransform(config.srcPrefixTree)))
+            Right(localImplicitTree.callTransform(config.srcPrefixTree))
           case (Some(_), Some(localImplicitTree))
               if config.flags.implicitConflictResolution.contains(PreferTotalTransformer) =>
-            Right(localImplicitTree.mapTree(_.callTransform(config.srcPrefixTree)))
+            Right(localImplicitTree.callTransform(config.srcPrefixTree))
           case (Some(localImplicitTreePartial), Some(localImplicitTree)) =>
             c.abort(
               c.enclosingPosition,

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
@@ -18,6 +18,11 @@ object PartialTransformerSpec extends TestSuite {
     PartialTransformer.derive[FooStr, Foo]
   }
 
+  val pt5 = {
+    implicit val fooStrToFoo = pt4
+    PartialTransformer.derive[List[FooStr], List[Foo]]
+  }
+
   val tests = Tests {
 
     test("transform") {
@@ -35,6 +40,11 @@ object PartialTransformerSpec extends TestSuite {
         ("s1", """For input string: "abc""""),
         ("s2", """For input string: "xyz"""")
       )
+
+      pt5.transform(List(FooStr("abc", "xyz"))).asErrorPathMessageStrings ==> Iterable(
+        ("(0).s1", """For input string: "abc""""),
+        ("(0).s2", """For input string: "xyz"""")
+      )
     }
 
     test("transformFailFast") {
@@ -51,6 +61,10 @@ object PartialTransformerSpec extends TestSuite {
       pt4.transformFailFast(FooStr("abc", "xyz")).asErrorPathMessageStrings ==> Iterable(
         ("s1", """For input string: "abc"""")
         // no second error due to fail fast mode
+      )
+
+      pt5.transformFailFast(List(FooStr("abc", "xyz"))).asErrorPathMessageStrings ==> Iterable(
+        ("(0).s1", """For input string: "abc"""")
       )
     }
   }


### PR DESCRIPTION
Added test that proved incorrect calling of implicitly found partial transformers.
They were accidentally always passed `failFast` flag set to `false`, regardless of the flag value passed by the caller.

This PR fixes the issue and makes sure we always propagate correct `failFast` flag value.
