### PR TITLE
Add quickfix for munit `compileErrors` issue

### DIFF
--- a/chimney/src/test/scala-2/io/scalaland/chimney/VersionCompat.scala
+++ b/chimney/src/test/scala-2/io/scalaland/chimney/VersionCompat.scala
@@ -1,0 +1,12 @@
+package io.scalaland.chimney
+
+import scala.language.experimental.macros
+import munit.internal.MacroCompatScala2
+
+trait VersionCompat {
+  /* Directly used compileErrors from munit.
+   * For reasoning, see the Scala 3 version of the file.
+   */
+  def compileErrorsFixed(code: String): String =
+    macro MacroCompatScala2.compileErrorsImpl
+}

--- a/chimney/src/test/scala-3/io/scalaland/chimney/VersionCompat.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/VersionCompat.scala
@@ -1,0 +1,24 @@
+package io.scalaland.chimney
+
+trait VersionCompat {
+
+  /* Copy/Paste from munit, with transparent keyword added. 
+   * Without the keyword some unexpected error reports would be collected
+   */
+  transparent inline def compileErrorsFixed(inline code: String): String = {
+    val errors = scala.compiletime.testing.typeCheckErrors(code)
+    errors
+      .map { error =>
+        val indent = " " * (error.column - 1)
+        val trimMessage = error.message.linesIterator
+          .map { line =>
+            if line.matches(" +") then ""
+            else line
+          }
+          .mkString("\n")
+        val separator = if error.message.contains('\n') then "\n" else " "
+        s"error:${separator}${trimMessage}\n${error.lineContent}\n${indent}^"
+      }
+      .mkString("\n")
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
@@ -4,7 +4,7 @@ import munit.{Location, TestOptions}
 
 import scala.util.matching.Regex
 
-trait ChimneySpec extends munit.BaseFunSuite { self =>
+trait ChimneySpec extends munit.BaseFunSuite with VersionCompat { self =>
 
   private var prefix = ""
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -37,14 +37,14 @@ class PartialTransformerProductSpec extends ChimneySpec {
 
 //    Bar(3, (3.14, 3.14)).intoPartial[Foo].transform
 
-    compileErrors("Bar(3, (3.14, 3.14)).intoPartial[Foo].transform").check(
+    compileErrorsFixed("Bar(3, (3.14, 3.14)).intoPartial[Foo].transform").check(
       "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Bar to io.scalaland.chimney.fixtures.products.Foo",
       "io.scalaland.chimney.fixtures.products.Foo",
       "y: java.lang.String - no accessor named y in source type io.scalaland.chimney.fixtures.products.Bar",
       "Consult https://scalalandio.github.io/chimney for usage examples."
     )
 
-    compileErrors("Bar(3, (3.14, 3.14)).transformIntoPartial[Foo]").check(
+    compileErrorsFixed("Bar(3, (3.14, 3.14)).transformIntoPartial[Foo]").check(
       "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Bar to io.scalaland.chimney.fixtures.products.Foo",
       "io.scalaland.chimney.fixtures.products.Foo",
       "y: java.lang.String - no accessor named y in source type io.scalaland.chimney.fixtures.products.Bar",


### PR DESCRIPTION
Will require renaming compileErrors to compileErrorsFixed (but probably can be done easily with find/replace)