### PR TITLE
Test that Java Bean getters can be used in withFieldRenamed for renaming into setter

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -216,7 +216,7 @@ private[compiletime] trait Configurations { this: Derivation =>
           )
       case ChimneyType.TransformerCfg.FieldRelabelled(fromName, toName, cfg) =>
         import fromName.Underlying as FromName, toName.Underlying as ToName, cfg.Underlying as Cfg
-        extractTransformerConfig[cfg.Underlying](1 + runtimeDataIdx)
+        extractTransformerConfig[cfg.Underlying](runtimeDataIdx)
           .addFieldOverride(
             Type[toName.Underlying].extractStringSingleton,
             RuntimeFieldOverride.RenamedFrom(Type[fromName.Underlying].extractStringSingleton)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -192,7 +192,9 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                         if (
                           ctorParam.value.targetType == Product.Parameter.TargetType.SetterParameter && !flags.beanSetters
                         )
-                          DerivationResult.notSupportedTransformerDerivation(ctx)
+                          DerivationResult
+                            .notSupportedTransformerDerivation(ctx)
+                            .log(s"Matched $fromName to $toName but $toName is setter and they are disabled")
                         else {
                           import getter.Underlying, getter.value.get
                           DerivationResult.namedScope(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
@@ -20,7 +20,14 @@ private[compiletime] trait TransformTypeToValueClassRuleModule {
             }
             // fall back to case classes expansion; see https://github.com/scalalandio/chimney/issues/297 for more info
             .orElse(TransformProductToProductRule.expand(ctx))
-            .orElse(DerivationResult.notSupportedTransformerDerivationForField(valueTo.fieldName)(ctx))
+            .orElse(
+              DerivationResult
+                .notSupportedTransformerDerivationForField(valueTo.fieldName)(ctx)
+                .log(
+                  s"Failed to resolve derivation from ${Type.prettyPrint[From]} to ${Type
+                      .prettyPrint[to2.Underlying]} (wrapped by ${Type.prettyPrint[To]})"
+                )
+            )
         case _ => DerivationResult.attemptNextRule
       }
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
@@ -18,7 +18,14 @@ private[compiletime] trait TransformValueClassToTypeRuleModule {
             .flatMap(DerivationResult.expanded)
             // fall back to case classes expansion; see https://github.com/scalalandio/chimney/issues/297 for more info
             .orElse(TransformProductToProductRule.expand(ctx))
-            .orElse(DerivationResult.notSupportedTransformerDerivationForField(valueFrom.fieldName)(ctx))
+            .orElse(
+              DerivationResult
+                .notSupportedTransformerDerivationForField(valueFrom.fieldName)(ctx)
+                .log(
+                  s"Failed to resolve derivation from ${Type.prettyPrint[from2.Underlying]} (wrapped by ${Type
+                      .prettyPrint[From]}) to ${Type.prettyPrint[To]}"
+                )
+            )
         case _ => DerivationResult.attemptNextRule
       }
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformationRules.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformationRules.scala
@@ -29,7 +29,7 @@ private[compiletime] trait TransformationRules { this: Derivation =>
         rules: List[Rule]
     )(implicit ctx: TransformationContext[From, To]): DerivationResult[TransformationExpr[To]] = rules match {
       case Nil =>
-        DerivationResult.notSupportedTransformerDerivation(ctx)
+        DerivationResult.notSupportedTransformerDerivation(ctx).log("Tested all derivation rules, none matched")
       case rule :: nextRules =>
         DerivationResult
           .namedScope(s"Attempting expansion of rule ${rule.name}")(

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
@@ -63,6 +63,14 @@ class PartialTransformerJavaBeanSpec extends ChimneySpec {
       target.getName ==> source.name
       target.isFlag ==> source.renamedFlag
     }
+
+    test("should fail to compile when getter is not paired with the right setter") {
+      compileErrorsFixed(
+        """CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true).intoPartial[JavaBeanTargetNoIdSetter].withFieldRenamed(_.id, _.getId).transform"""
+      ).check(
+        "Assumed that parameter/setter getId is a part of io.scalaland.chimney.fixtures.javabeans.JavaBeanTargetNoIdSetter, but wasn't found"
+      )
+    }
   }
 
   group("""flag .enableBeanGetters""") {

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
@@ -46,6 +46,24 @@ class PartialTransformerJavaBeanSpec extends ChimneySpec {
     }
   }
 
+  group("""setting .withFieldRenamed(_.from, _.getTo)""") {
+
+    test("transform case class to Java Bean, allowing using getters as a way to rename into matching setters") {
+      val source = CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true)
+      val target = source
+        .intoPartial[JavaBeanTarget]
+        .withFieldRenamed(_.renamedFlag, _.isFlag)
+        .enableBeanSetters
+        .transform
+        .asOption
+        .get
+
+      target.getId ==> source.id
+      target.getName ==> source.name
+      target.isFlag ==> source.renamedFlag
+    }
+  }
+
   group("""flag .enableBeanGetters""") {
 
     test("should enable automatic reading from Java Bean getters") {

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
@@ -46,14 +46,15 @@ class PartialTransformerJavaBeanSpec extends ChimneySpec {
     }
   }
 
-  group("""setting .withFieldRenamed(_.from, _.getTo)""") {
+  group("""settings .withField*(_.getTo, ...) and .withFieldRenamed(_.from, _.getTo)""") {
 
     test("transform case class to Java Bean, allowing using getters as a way to rename into matching setters") {
       val source = CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true)
       val target = source
         .intoPartial[JavaBeanTarget]
+        .withFieldConstPartial(_.getId, partial.Result.fromValue(source.id))
+        .withFieldComputedPartial(_.getName, cc => partial.Result.fromCatching(cc.name))
         .withFieldRenamed(_.renamedFlag, _.isFlag)
-        .enableBeanSetters
         .transform
         .asOption
         .get

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
@@ -44,14 +44,15 @@ class TotalTransformerJavaBeansSpec extends ChimneySpec {
     }
   }
 
-  group("""setting .withFieldRenamed(_.from, _.getTo)""") {
+  group("""settings .withField*(_.getTo, ...) and .withFieldRenamed(_.from, _.getTo)""") {
 
     test("transform case class to Java Bean, allowing using getters as a way to rename into matching setters") {
       val source = CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true)
       val target = source
         .into[JavaBeanTarget]
+        .withFieldConst(_.getId, source.id)
+        .withFieldComputed(_.getName, _.name)
         .withFieldRenamed(_.renamedFlag, _.isFlag)
-        .enableBeanSetters
         .transform
 
       target.getId ==> source.id

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
@@ -44,6 +44,22 @@ class TotalTransformerJavaBeansSpec extends ChimneySpec {
     }
   }
 
+  group("""setting .withFieldRenamed(_.from, _.getTo)""") {
+
+    test("transform case class to Java Bean, allowing using getters as a way to rename into matching setters") {
+      val source = CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true)
+      val target = source
+        .into[JavaBeanTarget]
+        .withFieldRenamed(_.renamedFlag, _.isFlag)
+        .enableBeanSetters
+        .transform
+
+      target.getId ==> source.id
+      target.getName ==> source.name
+      target.isFlag ==> source.renamedFlag
+    }
+  }
+
   group("""flag .enableBeanGetters""") {
 
     test("should enable automatic reading from Java Bean getters") {

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeansSpec.scala
@@ -59,6 +59,14 @@ class TotalTransformerJavaBeansSpec extends ChimneySpec {
       target.getName ==> source.name
       target.isFlag ==> source.renamedFlag
     }
+
+    test("should fail to compile when getter is not paired with the right setter") {
+      compileErrorsFixed(
+        """CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true).into[JavaBeanTargetNoIdSetter].withFieldRenamed(_.id, _.getId).transform"""
+      ).check(
+        "Assumed that parameter/setter getId is a part of io.scalaland.chimney.fixtures.javabeans.JavaBeanTargetNoIdSetter, but wasn't found"
+      )
+    }
   }
 
   group("""flag .enableBeanGetters""") {

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
@@ -12,6 +12,8 @@ case class CaseClassWithFlag(id: String, name: String, flag: Boolean) {
   }
 }
 
+case class CaseClassWithFlagRenamed(id: String, name: String, renamedFlag: Boolean)
+
 class JavaBeanSource(id: String, name: String) {
   def getId: String = id
 

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
@@ -65,6 +65,29 @@ class JavaBeanTarget {
     }
   }
 }
+class JavaBeanTargetNoIdSetter {
+  private var id: String = _
+
+  def withId(id: String): Unit = {
+    this.id = id
+  }
+
+  // make sure that only public setters are taken into account
+  protected def setFoo(foo: Unit): Unit = ()
+
+  private def setBar(bar: Int): Unit = ()
+
+  def getId: String = id
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case jbt: JavaBeanTarget =>
+        this.id == jbt.getId
+      case _ =>
+        false
+    }
+  }
+}
 
 case class EnclosingCaseClass(ccNoFlag: CaseClassNoFlag)
 


### PR DESCRIPTION
Added test which shows that the current architecture allow `withFieldRenamed` and other `withField*` methods to use Java Beans getter name as a way of selecting Java Bean setter that should be used in derivation e.g.

```scala
caseClass.into[JavaBean]
  .withFieldRenamed(_.name, _.getSurname) // will use setSurname(caseClass.name)
  .transform
```

It should showcase that most common cases of #110 and #175 are already handled (the only unsupported case would be if target had a setter without matching getter).

While writing these test I found and fixed a but occurring when withFieldRenamed was used toether with other withField and messed up their RuntimeDataStore index calculation