### PR TITLE
Add into*Safe methods which disable auto-derivation

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
@@ -37,12 +37,29 @@ package object dsl {
       * @see [[io.scalaland.chimney.Transformer#derive]] for default implicit instance
       *
       * @tparam To target type
-      * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
+      * @param transformer implicit instance of [[io.scalaland.chimney.Transformer.AutoDerived]] type class -
+     *                     provided by user (as [[io.scalaland.chimney.Transformer]]) or auto-derived
       * @return transformed value of target type `To`
       *
       * @since 0.1.0
       */
     final def transformInto[To](implicit transformer: Transformer.AutoDerived[From, To]): To =
+      transformer.transform(source)
+
+    /** Performs in-place transformation of captured source value to target type which uses only implicits already existing in scope.
+      *
+      * If you want to customize transformer behavior, consider using
+      * [[io.scalaland.chimney.dsl.TransformerOps#into]] method.
+      *
+      * @see [[io.scalaland.chimney.Transformer#derive]] for default implicit instance
+      *
+      * @tparam To target type
+      * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
+      * @return transformed value of target type `To`
+      *
+      * @since 0.8.0
+      */
+    final def transformIntoSafe[To](implicit transformer: Transformer[From, To]): To =
       transformer.transform(source)
   }
 
@@ -76,7 +93,8 @@ package object dsl {
       * @see [[io.scalaland.chimney.PartialTransformer#derive]] for default implicit instance
       *
       * @tparam To result target type of partial transformation
-      * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
+      * @param transformer implicit instance of [[io.scalaland.chimney.PartialTransformer.AutoDerived]] type class -
+     *                     provided by user (as [[io.scalaland.chimney.PartialTransformer]]) or auto-derived
       * @return partial transformation result value of target type `To`
       *
       * @since 0.7.0
@@ -95,13 +113,49 @@ package object dsl {
       *
       * @tparam To result target type of partial transformation
       * @param failFast should fail as early as the first set of errors appear
-      * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
+      * @param transformer implicit instance of [[io.scalaland.chimney.PartialTransformer.AutoDerived]] type class -
+     *                     provided by user (as [[io.scalaland.chimney.PartialTransformer]]) or auto-derived
       * @return partial transformation result value of target type `To`
       *
       * @since 0.7.0
       */
     final def transformIntoPartial[To](failFast: Boolean)(implicit
         transformer: PartialTransformer.AutoDerived[From, To]
+    ): partial.Result[To] =
+      transformer.transform(source, failFast)
+
+    /** Performs in-place partial transformation of captured source value to target type.
+      *
+      * If you want to customize transformer behavior, consider using
+      * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
+      *
+      * @see [[io.scalaland.chimney.PartialTransformer#derive]] for default implicit instance
+      *
+      * @tparam To result target type of partial transformation
+      * @param transformer implicit instance of [[io.scalaland.chimney.PartialTransformer]] type class
+      * @return partial transformation result value of target type `To`
+      *
+      * @since 0.8.0
+      */
+    final def transformIntoPartialSafe[To](implicit transformer: PartialTransformer[From, To]): partial.Result[To] =
+      transformIntoPartial(failFast = false)
+
+    /** Performs in-place partial transformation of captured source value to target type.
+      *
+      * If you want to customize transformer behavior, consider using
+      * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
+      *
+      * @see [[io.scalaland.chimney.PartialTransformer#derive]] for default implicit instance
+      *
+      * @tparam To result target type of partial transformation
+      * @param failFast should fail as early as the first set of errors appear
+      * @param transformer implicit instance of [[io.scalaland.chimney.PartialTransformer]] type class
+      * @return partial transformation result value of target type `To`
+      *
+      * @since 0.8.0
+      */
+    final def transformIntoPartialSafe[To](failFast: Boolean)(implicit
+        transformer: PartialTransformer[From, To]
     ): partial.Result[To] =
       transformer.transform(source, failFast)
   }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/extensions.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/extensions.scala
@@ -14,6 +14,9 @@ extension [From](source: From) {
 
   def transformInto[To](implicit transformer: Transformer.AutoDerived[From, To]): To =
     transformer.transform(source)
+
+  def transformIntoSafe[To](implicit transformer: Transformer[From, To]): To =
+    transformer.transform(source)
 }
 
 extension [From](source: From) {
@@ -31,6 +34,16 @@ extension [From](source: From) {
 
   def transformIntoPartial[To](failFast: Boolean)(implicit
       transformer: PartialTransformer.AutoDerived[From, To]
+  ): partial.Result[To] =
+    transformer.transform(source, failFast)
+
+  def transformIntoPartialSafe[To](implicit
+      transformer: PartialTransformer[From, To]
+  ): partial.Result[To] =
+    transformIntoPartial(failFast = false)
+
+  def transformIntoPartialSafe[To](failFast: Boolean)(implicit
+      transformer: PartialTransformer[From, To]
   ): partial.Result[To] =
     transformer.transform(source, failFast)
 }
@@ -51,7 +64,6 @@ extension [T](option: Option[T]) {
 
   def toPartialResultOrString(ifEmpty: => String): partial.Result[T] =
     partial.Result.fromOptionOrString(option, ifEmpty)
-
 }
 
 extension [T](either: Either[String, T]) {

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerImplicitResolutionSpec.scala
@@ -68,4 +68,27 @@ class PartialTransformerImplicitResolutionSpec extends ChimneySpec {
     result2.asEither ==> Right(expected)
     result2.asErrorPathMessageStrings ==> Iterable.empty
   }
+
+  test("safe transform should only use user-provided implicit and not derive anything") {
+    import trip.*
+
+    compileErrorsFixed("""Person("John", 10, 140).transformIntoSafe[User]""").arePresent()
+    compileErrorsFixed("""Person("John", 10, 140).transformIntoSafe[User](true)""").arePresent()
+
+    locally {
+      implicit val transformer: PartialTransformer[Person, User] = PartialTransformer.derive[Person, User]
+
+      val expected = User("John", 10, 140)
+
+      val result = Person("John", 10, 140).transformIntoPartialSafe[User]
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = Person("John", 10, 140).transformIntoPartialSafe[User](true)
+      result2.asOption ==> Some(expected)
+      result2.asEither ==> Right(expected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+    }
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerImplicitResolutionSpec.scala
@@ -29,4 +29,16 @@ class TotalTransformerImplicitResolutionSpec extends ChimneySpec {
     Person("John", 10, 140).into[User].transform ==> User("John", 10, 140)
     Person("John", 10, 140).transformInto[User] ==> User("John", 10, 140)
   }
+
+  test("safe transform should only use user-provided implicit and not derive anything") {
+    import trip.*
+
+    compileErrorsFixed("""Person("John", 10, 140).transformIntoSafe[User]""").arePresent()
+
+    locally {
+      implicit val transformer: Transformer[Person, User] = Transformer.derive[Person, User]
+
+      Person("John", 10, 140).transformIntoSafe[User] ==> User("John", 10, 140)
+    }
+  }
 }


### PR DESCRIPTION
Since we already split derivation into automatic and configured, we might as well reflect it in the interface and fix some long overdue issue.

I didn't have a better name than `*Safe` but we might think of something better.