### PR TITLE
[Issue 252] Add MiMa to track binary incompatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,17 @@ val publishSettings = Seq(
   )
 )
 
+val mimaSettings = Seq(
+  mimaPreviousArtifacts := {
+    name.value match {
+      case nameValue =>
+        Set(
+          organization.value %% moduleName.value % "0.7.5"
+        )
+    }
+  }
+)
+
 val noPublishSettings =
   Seq(publish / skip := true, publishArtifact := false)
 
@@ -219,6 +230,7 @@ lazy val chimney = projectMatrix
   .settings(settings*)
   .settings(versionSchemeSettings*)
   .settings(publishSettings*)
+  .settings(mimaSettings*)
   .settings(dependencies*)
   .dependsOn(protos % "test->test")
 
@@ -234,6 +246,7 @@ lazy val chimneyCats = projectMatrix
   .settings(settings*)
   .settings(versionSchemeSettings*)
   .settings(publishSettings*)
+  .settings(mimaSettings*)
   .settings(dependencies*)
   .settings(libraryDependencies += "org.typelevel" %%% "cats-core" % "2.9.0" % "provided")
   .dependsOn(chimney % "test->test;compile->compile")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,8 @@ addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.12")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.17")
+// MiMa
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")
 // benchmarks
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.4")
 // disabling projects in IDE


### PR DESCRIPTION
Should resolve https://github.com/scalalandio/chimney/issues/252
I've added MiMa plugin, and `mimaSettings` to `chimney` and `chimneyCats` modules.

Running `mimaReportBinaryIssues` with specific project name shows no issues:
```
[IJ]chimney-build(master)> chimney2_12/mimaReportBinaryIssues
[success] Total time: 2 s, completed 8 Jul 2023, 18:03:19
[IJ]chimney-build(master)> chimneyCats/mimaReportBinaryIssues
[success] Total time: 1 s, completed 8 Jul 2023, 18:03:52
[IJ]chimney-build(master)> chimney/mimaReportBinaryIssues
[success] Total time: 0 s, completed 8 Jul 2023, 18:04:04
```

Running it in `root` reports that no previous version is set (but this can be disabled, I think)
```
[IJ]chimney-build(master)> mimaReportBinaryIssues
[error] stack trace is suppressed; run last mimaReportBinaryIssues for the full output
[error] (mimaReportBinaryIssues) mimaPreviousArtifacts not set, not analyzing binary compatibility
[error] Total time: 3 s, completed 8 Jul 2023, 18:03:25
```