### PR TITLE
Standardize types platform specific API

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -5,7 +5,7 @@ import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
 trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPlatform =>
 
   import c.universe.{internal as _, Transformer as _, *}
-  import Type.platformSpecific.fromUntyped
+  import Type.platformSpecific.*
 
   protected object SealedHierarchy extends SealedHierarchyModule {
 
@@ -14,7 +14,6 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
       sym.isClass && sym.asClass.isSealed
     }
 
-    type Subtype
     def parse[A: Type]: Option[Enum[A]] = if (isSealed(Type[A])) {
       // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
       val elements = extractSubclasses(Type[A].tpe.typeSymbol.asType).distinct
@@ -34,17 +33,5 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
       else List(t)
 
     private def subtypeName(subtype: TypeSymbol): String = subtype.name.toString
-
-    private def subtypeTypeOf[A: Type](subtype: TypeSymbol): ?<[A] = {
-      subtype.typeSignature // Workaround for <https://issues.scala-lang.org/browse/SI-7755>
-
-      val sEta = subtype.toType.etaExpand
-      fromUntyped[A](
-        sEta.finalResultType.substituteTypes(
-          sEta.baseType(Type[A].tpe.typeSymbol).typeArgs.map(_.typeSymbol),
-          Type[A].tpe.typeArgs
-        )
-      ).as_?<[A]
-    }
   }
 }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -127,6 +127,6 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
 
     def prettyPrint[A](expr: Expr[A]): String = expr.asTerm.show(using Printer.TreeAnsiCode)
 
-    def typeOf[A](expr: Expr[A]): Type[A] = expr.asTerm.tpe.asType.asInstanceOf[Type[A]]
+    def typeOf[A](expr: Expr[A]): Type[A] = Type.platformSpecific.fromUntyped[A](expr.asTerm.tpe)
   }
 }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -16,7 +16,7 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
       val getterOpt: Option[Symbol] = sym.declarations.filter(isPublic).headOption
       val primaryConstructorOpt: Option[Symbol] = Option(sym.primaryConstructor).filter(_.isClassConstructor)
       val argumentOpt: Option[Symbol] = primaryConstructorOpt.flatMap { primaryConstructor =>
-        paramListsOf(primaryConstructor).flatten match {
+        paramListsOf(A, primaryConstructor).flatten match {
           case argument :: Nil => Some(argument)
           case _               => None
         }
@@ -25,9 +25,8 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
       (getterOpt, primaryConstructorOpt, argumentOpt) match {
         case (Some(getter), Some(primaryConstructor), Some(argument))
             if !Type[A].isPrimitive && getter.name == argument.name =>
-          val Argument =
-            paramsWithTypes(A, primaryConstructor, isConstructor = true)(argument.name).asType.asInstanceOf[Type[Any]]
-          val inner = returnTypeOf[Any](A.memberType(getter)).as_??
+          val Argument = fromUntyped[Any](paramsWithTypes(A, primaryConstructor, isConstructor = true)(argument.name))
+          val inner = returnTypeOf[Any](A, getter).as_??
           import inner.Underlying as Inner
           assert(
             Argument =:= Inner,


### PR DESCRIPTION
Make it easier to follow what each Type.platformSpecific API tries to achieve by having the same conventions.