### PR TITLE
Add linters to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ val settings = Seq(
           // format: off
           "-source", "3.3-migration",
           // format: on
+          "-Xfatal-warnings",
           // "-Wunused:imports", // import x.Underlying as X is marked as unused even though it is!
           "-Wunused:privates",
           "-Wunused:locals",

--- a/build.sbt
+++ b/build.sbt
@@ -45,12 +45,18 @@ val settings = Seq(
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, _)) =>
         Seq(
-          // TODO: add linters
           // "-explain",
           "-rewrite",
           // format: off
           "-source", "3.3-migration",
           // format: on
+          // "-Wunused:imports", // import x.Underlying as X is marked as unused even though it is!
+          "-Wunused:privates",
+          "-Wunused:locals",
+          "-Wunused:explicits",
+          "-Wunused:implicits",
+          "-Wunused:params",
+          "-Wvalue-discard",
           "-Ykind-projector:underscores"
         )
       case Some((2, 13)) =>

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -97,7 +97,7 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
   protected object PatternMatchCase extends PatternMatchCaseModule {
 
     def matchOn[From: Type, To: Type](src: Expr[From], cases: List[PatternMatchCase[To]]): Expr[To] = Match(
-      src.asTerm,
+      '{ ${ src }: @scala.unchecked }.asTerm,
       cases.map { case PatternMatchCase(someFrom, usage, fromName, isCaseObject) =>
         import someFrom.Underlying as SomeFrom
         // Unfortunately, we cannot do

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -12,16 +12,11 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
     object platformSpecific {
 
-      private val abstractFlags = Flags.Abstract | Flags.Trait
-      private val privateFlags = Flags.Private | Flags.PrivateLocal | Flags.Protected
-
       def isAbstract(sym: Symbol): Boolean =
         sym.flags.is(Flags.Abstract) || sym.flags.is(Flags.Trait)
-        // (sym.flags & abstractFlags).is(abstractFlags)
 
       def isPublic(sym: Symbol): Boolean =
         !(sym.flags.is(Flags.Private) || sym.flags.is(Flags.PrivateLocal) || sym.flags.is(Flags.Protected))
-        // (sym.flags & privateFlags).is(privateFlags)
 
       def isParameterless(method: Symbol): Boolean =
         method.paramSymss.filterNot(_.exists(_.isType)).flatten.isEmpty
@@ -52,7 +47,6 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
     def isPOJO[A](implicit A: Type[A]): Boolean = {
       val sym = TypeRepr.of(using A).typeSymbol
-      val mem = sym.declarations
       !A.isPrimitive && !(A <:< Type[String]) && sym.isClassDef && !isAbstract(sym) && isPublic(sym.primaryConstructor)
     }
     def isCaseClass[A](implicit A: Type[A]): Boolean = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.internal.compiletime.DerivationResult
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
 import io.scalaland.chimney.partial
 
+import scala.annotation.unused
 import scala.collection.compat.Factory
 
 private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivation =>
@@ -128,7 +129,7 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
           DerivationResult.attemptNextRule
       }
 
-    implicit private class IorAOps[M: Type, A: Type](private val iora: IterableOrArray[M, A]) {
+    implicit private class IorAOps[M: Type, A: Type](@unused private val iora: IterableOrArray[M, A]) {
 
       def factory: DerivationResult[Expr[Factory[A, M]]] = DerivationResult.summonImplicit[Factory[A, M]]
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -509,9 +509,6 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
         case _ => DerivationResult.attemptNextRule
       }
 
-    private val isUsingSetter: ((String, Existential[Product.Parameter])) => Boolean =
-      _._2.value.targetType == Product.Parameter.TargetType.SetterParameter
-
     // If we derived partial.Result[$ctorParam] we are appending
     //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
     private def appendPath[A: Type](expr: TransformationExpr[A], path: String): TransformationExpr[A] =

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -3,6 +3,8 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 
+import scala.annotation.unused
+
 class IssuesSpec extends ChimneySpec {
 
   test("fix issue #19") {
@@ -59,7 +61,7 @@ class IssuesSpec extends ChimneySpec {
   group("fix issue #66") {
 
     case class Foo1(y: String)
-    case class Foo2(y: String, x: Int)
+    @unused case class Foo2(y: String, x: Int)
     case class Foo3(x: Int)
 
     test("fix for `withFieldConst`") {
@@ -207,10 +209,10 @@ class IssuesSpec extends ChimneySpec {
 
   test("fix issue #121") {
     case class FooNested(num: Option[Int])
-    case class Foo(maybeString: Option[Set[String]], nested: FooNested)
+    @unused case class Foo(maybeString: Option[Set[String]], nested: FooNested)
 
     case class BarNested(num: String)
-    case class Bar(maybeString: scala.collection.immutable.Seq[String], nested: BarNested)
+    @unused case class Bar(maybeString: scala.collection.immutable.Seq[String], nested: BarNested)
 
     compileErrorsFixed("Foo(None, FooNested(None)).into[Bar].transform")
       .check(
@@ -412,7 +414,7 @@ class IssuesSpec extends ChimneySpec {
 
   test("fix issue #185 (rewritten as partial)") {
 
-    def blackIsRed(b: colors2.Black.type): colors1.Color =
+    @unused def blackIsRed(b: colors2.Black.type): colors1.Color =
       colors1.Red
 
     (colors2.Black: colors2.Color)
@@ -480,9 +482,9 @@ class IssuesSpec extends ChimneySpec {
     import Issue212.*
 
     test("partial transformers") {
-      implicit val somethingPartialTransformer: PartialTransformer[proto.Something, OneOf] =
+      @unused implicit val somethingPartialTransformer: PartialTransformer[proto.Something, OneOf] =
         PartialTransformer(_.value.transformIntoPartial[Something])
-      implicit val somethingElsePartialTransformer: PartialTransformer[proto.SomethingElse, OneOf] =
+      @unused implicit val somethingElsePartialTransformer: PartialTransformer[proto.SomethingElse, OneOf] =
         PartialTransformer(_.value.transformIntoPartial[SomethingElse])
 
       implicit val oneOfPartialTransformer: PartialTransformer[proto.OneOf, OneOf] =

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
@@ -3,14 +3,15 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.utils.OptionUtils.*
 
+import scala.annotation.unused
 import scala.collection.immutable.Queue
 import scala.collection.mutable.ArrayBuffer
 
 class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
   test("not support converting non-Unit field to Unit field if there is no implicit converter allowing that") {
-    case class Buzz(value: String)
-    case class ConflictingFooBuzz(value: Unit)
+    @unused case class Buzz(value: String)
+    @unused case class ConflictingFooBuzz(value: Unit)
 
     compileErrorsFixed("""Buzz("a").transformIntoPartial[ConflictingFooBuzz]""").check(
       "Chimney can't derive transformation from io.scalaland.chimney.PartialTransformerStdLibTypesSpec.Buzz to io.scalaland.chimney.PartialTransformerStdLibTypesSpec.ConflictingFooBuzz",
@@ -25,8 +26,8 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
   test("support automatically filling of scala.Unit") {
     case class Buzz(value: String)
     case class NewBuzz(value: String, unit: Unit)
-    case class FooBuzz(unit: Unit)
-    case class ConflictingFooBuzz(value: Unit)
+    @unused case class FooBuzz(unit: Unit)
+    @unused case class ConflictingFooBuzz(value: Unit)
 
     Buzz("a").transformIntoPartial[NewBuzz].asOption ==> Some(NewBuzz("a", ()))
     Buzz("a").transformIntoPartial[FooBuzz].asOption ==> Some(FooBuzz(()))

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSumTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSumTypeSpec.scala
@@ -4,6 +4,8 @@ import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 import io.scalaland.chimney.utils.OptionUtils.*
 
+import scala.annotation.unused
+
 class PartialTransformerSumTypeSpec extends ChimneySpec {
 
   test(
@@ -139,7 +141,7 @@ class PartialTransformerSumTypeSpec extends ChimneySpec {
     test(
       """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
     ) {
-      def blackIsRed(b: colors2.Black.type): colors1.Color =
+      @unused def blackIsRed(b: colors2.Black.type): colors1.Color =
         colors1.Red
 
       (colors2.Black: colors2.Color)

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherSpec.scala
@@ -2,6 +2,8 @@ package io.scalaland.chimney
 
 import io.scalaland.chimney.dsl.*
 
+import scala.annotation.unused
+
 class PatcherSpec extends ChimneySpec {
 
   test("patch simple objects") {
@@ -108,7 +110,7 @@ class PatcherSpec extends ChimneySpec {
 
     import TestDomain.*
 
-    case class UserWithOptional(id: Int, email: Email, phone: Option[Phone])
+    @unused case class UserWithOptional(id: Int, email: Email, phone: Option[Phone])
 
     case class UserPatch(email: String, phone: Option[Option[Phone]])
     val update = UserPatch(email = "updated@example.com", phone = None)
@@ -121,7 +123,6 @@ class PatcherSpec extends ChimneySpec {
 
     import TestDomain.*
 
-    case class Foo(x: Option[Int])
     case class PhonePatch(phone: Option[Phone])
     case class IntPatch(phone: Option[Long])
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -503,7 +503,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
     }
 
     test("method is disabled by default") {
-      case class Foobar5(
+      @unused case class Foobar5(
           param: String,
           valField: String,
           lazyValField: String,
@@ -534,7 +534,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
     }
 
     test("protected and private methods are not considered (even if accessible)") {
-      case class Foo2(param: String, protect: String, priv: String)
+      @unused case class Foo2(param: String, protect: String, priv: String)
 
       compileErrorsFixed("""Foobar("param").into[Foo2].enableMethodAccessors.transform""").check(
         "",

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
@@ -2,6 +2,8 @@ package io.scalaland.chimney
 
 import io.scalaland.chimney.dsl.*
 
+import scala.annotation.unused
+
 class TotalTransformerStdLibTypesSpec extends ChimneySpec {
 
   import TotalTransformerStdLibTypesSpec.*
@@ -15,8 +17,8 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
   }
 
   test("not support converting non-Unit field to Unit field if there is no implicit converter allowing that") {
-    case class Buzz(value: String)
-    case class ConflictingFooBuzz(value: Unit)
+    @unused case class Buzz(value: String)
+    @unused case class ConflictingFooBuzz(value: Unit)
 
     compileErrorsFixed("""Buzz("a").transformInto[ConflictingFooBuzz]""").check(
       "Chimney can't derive transformation from io.scalaland.chimney.TotalTransformerStdLibTypesSpec.Buzz to io.scalaland.chimney.TotalTransformerStdLibTypesSpec.ConflictingFooBuzz",
@@ -32,7 +34,7 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
     case class Buzz(value: String)
     case class NewBuzz(value: String, unit: Unit)
     case class FooBuzz(unit: Unit)
-    case class ConflictingFooBuzz(value: Unit)
+    @unused case class ConflictingFooBuzz(value: Unit)
 
     Buzz("a").transformInto[NewBuzz] ==> NewBuzz("a", ())
     Buzz("a").transformInto[FooBuzz] ==> FooBuzz(())
@@ -52,7 +54,7 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
       "derivation from some: scala.Some[java.lang.String] to scala.None is not supported in Chimney!",
       "Consult https://chimney.readthedocs.io for usage examples."
     )
-    case class BarNone(value: None.type)
+    @unused case class BarNone(value: None.type)
     compileErrorsFixed("""Foo("a").into[BarNone].transform""").check(
       "Chimney can't derive transformation from io.scalaland.chimney.TotalTransformerStdLibTypesSpec.Foo to io.scalaland.chimney.TotalTransformerStdLibTypesSpec.BarNone",
       "io.scalaland.chimney.TotalTransformerStdLibTypesSpec.BarNone",

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSumTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSumTypeSpec.scala
@@ -3,6 +3,8 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 
+import scala.annotation.unused
+
 class TotalTransformerSumTypeSpec extends ChimneySpec {
 
   test(
@@ -125,7 +127,7 @@ class TotalTransformerSumTypeSpec extends ChimneySpec {
     test(
       """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
     ) {
-      def blackIsRed(b: colors2.Black.type): colors1.Color =
+      @unused def blackIsRed(b: colors2.Black.type): colors1.Color =
         colors1.Red
 
       (colors2.Black: colors2.Color)

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
@@ -1,5 +1,7 @@
 package io.scalaland.chimney.fixtures.javabeans
 
+import scala.annotation.unused
+
 case class CaseClassNoFlag(id: String, name: String)
 
 case class CaseClassWithFlagMethod(id: String, name: String) {
@@ -44,7 +46,7 @@ class JavaBeanTarget {
   // make sure that only public setters are taken into account
   protected def setFoo(foo: Unit): Unit = ()
 
-  private def setBar(bar: Int): Unit = ()
+  @unused private def setBar(bar: Int): Unit = ()
 
   def getId: String = id
 
@@ -69,7 +71,7 @@ class JavaBeanTargetNoIdSetter {
   // make sure that only public setters are taken into account
   protected def setFoo(foo: Unit): Unit = ()
 
-  private def setBar(bar: Int): Unit = ()
+  @unused private def setBar(bar: Int): Unit = ()
 
   def getId: String = id
 


### PR DESCRIPTION
It is missing `-Xfatal-warning` as:
 - there are some "unused" warnings which cannot be suppressed with `@unused`
   ```
   [warn] -- Warning: /Users/dev/Workspaces/GitHub/chimney/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala:417:27
   [warn] 417 |    @unused def blackIsRed(b: colors2.Black.type): colors1.Color =
   [warn]     |                           ^
   [warn]     |                           unused local definition
   [warn] -- Warning: /Users/dev/Workspaces/GitHub/chimney/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSumTypeSpec.scala:144:29
   [warn] 144 |      @unused def blackIsRed(b: colors2.Black.type): colors1.Color =
   [warn]     |                             ^
   [warn]     |                             unused local definition
   [warn] -- Warning: /Users/dev/Workspaces/GitHub/chimney/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSumTypeSpec.scala:130:29
   [warn] 130 |      @unused def blackIsRed(b: colors2.Black.type): colors1.Color =
   [warn]     |                             ^
   [warn]     |                             unused local definition
   ```
 - there are some warnings which should be suppressed in generated source code
    ```
   [warn] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala:34:32: the type test for io.scalaland.chimney.fixtures.numbers.short.Billion[A] cannot be checked at runtime because its type arguments can't be determined from io.scalaland.chimney.fixtures.numbers.short.NumScale[A, Nothing]
   [warn]       ): Expr[partial.Result[To]] = '{ ${ transformer }.transform(${ src }, ${ failFast }) }
   [warn]                                ^
   [warn] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala:48:47: the type test for io.scalaland.chimney.fixtures.numbers.short.Billion[A] cannot be checked at runtime because its type arguments can't be determined from io.scalaland.chimney.fixtures.numbers.short.NumScale[A, Nothing]
   [warn]         def apply[T: Type](value: Expr[T]): Expr[partial.Result.Value[T]] =
   ```
 - additionally, it is still missing `-Xcheck-macros` which we should use eventually