### PR TITLE
Cleanup after -Xcheck-macros fix

### DIFF
--- a/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/Coproduct.scala
+++ b/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/Coproduct.scala
@@ -19,13 +19,12 @@ class Coproduct extends CommonBenchmarkSettings {
   var color: Color = Color.Red
 
   @Setup(Level.Iteration)
-  def nextColor(): Unit = {
+  def nextColor(): Unit =
     color = color match {
       case Color.Red   => Color.Green
       case Color.Green => Color.Blue
       case Color.Blue  => Color.Red
     }
-  }
 
   @Benchmark
   def coproductIsomorphismChimneyInto: Color =

--- a/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/fixtures.scala
+++ b/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/fixtures.scala
@@ -250,7 +250,7 @@ object fixtures {
       fb: Double => M[Double],
       fc: String => M[String],
       fd: Option[String] => M[Option[String]]
-  ): M[SimpleOutput] = {
+  ): M[SimpleOutput] =
     fa(simple.a) match {
       case Right(a) =>
         fb(simple.b) match {
@@ -311,7 +311,6 @@ object fixtures {
             }
         }
     }
-  }
 
   object transformers {
 

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -94,7 +94,7 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
   protected object PatternMatchCase extends PatternMatchCaseModule {
 
     def matchOn[From: Type, To: Type](src: Expr[From], cases: List[PatternMatchCase[To]]): Expr[To] = Match(
-      src.asTerm.changeOwner(Symbol.spliceOwner),
+      '{ ${ src.asTerm.changeOwner(Symbol.spliceOwner).asExprOf[From] }: @scala.unchecked }.asTerm,
       cases.map { case PatternMatchCase(someFrom, usage, fromName, isCaseObject) =>
         import someFrom.Underlying as SomeFrom
         // Unfortunately, we cannot do

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -9,6 +9,15 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
 
   final override protected type Expr[A] = quoted.Expr[A]
   protected object Expr extends ExprModule {
+
+    object platformSpecific {
+
+      // Required by -Xcheck-macros to pass.
+      def resetOwner[T: Type](a: Expr[T]): Expr[T] =
+        a.asTerm.changeOwner(Symbol.spliceOwner).asExprOf[T]
+    }
+    import platformSpecific.resetOwner
+
     val Nothing: Expr[Nothing] = '{ ??? }
     val Null: Expr[Null] = '{ null }
     val Unit: Expr[Unit] = '{ () }
@@ -132,9 +141,5 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     def prettyPrint[A](expr: Expr[A]): String = expr.asTerm.show(using Printer.TreeAnsiCode)
 
     def typeOf[A](expr: Expr[A]): Type[A] = Type.platformSpecific.fromUntyped[A](expr.asTerm.tpe)
-
-    def resetOwner[T: Type](using quotes: quoted.Quotes)(a: Expr[T]): Expr[T] =
-      import quotes.reflect.*
-      a.asTerm.changeOwner(Symbol.spliceOwner).asExprOf[T]
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -8,11 +8,9 @@ import scala.quoted
 
 private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: ChimneyDefinitionsPlatform =>
 
-  def resetOwner[T: Type](using quotes: scala.quoted.Quotes)(a: Expr[T]): Expr[T] =
-    import quotes.reflect.*
-    a.asTerm.changeOwner(Symbol.spliceOwner).asExprOf[T]
-
   object ChimneyExpr extends ChimneyExprModule {
+
+    import Expr.platformSpecific.resetOwner
 
     object Transformer extends TransformerModule {
 


### PR DESCRIPTION
* restore `src: @scala.unchecked` in pattern matching to remove warnings
* move `resetOwner` to Expr.platformSpecific