### PR TITLE
Remove workarounds for Scala 3 error message checks in tests

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -37,15 +37,16 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
 
     private def freshTermName(prefix: String): ExprPromiseName =
       c.internal.reificationSupport.freshTermName(prefix.toLowerCase + "$")
+
     private def freshTermName(tpe: c.Type): ExprPromiseName =
       freshTermName(tpe.typeSymbol.name.decodedName.toString.toLowerCase)
     private def freshTermName(srcPrefixTree: Expr[?]): ExprPromiseName =
-      freshTermName(toFieldName(srcPrefixTree))
+      freshTermName(dropMacroSuffix(srcPrefixTree.tree.toString))
 
     // Undoes the encoding of freshTermName so that generated value would not contain $1, $2, ...
-    // - this makes generated fresh names more readable as it prevents e.g. typename$macro$1$2$3
-    private def toFieldName[A](srcPrefixTree: Expr[A]): String =
-      srcPrefixTree.tree.toString.replaceAll("\\$\\d+", "")
+    // - this makes generated fresh names more readable as it prevents e.g. typename$1, typename$2
+    private def dropMacroSuffix[A](freshName: String): String =
+      freshName.replaceAll("\\$\\d+", "")
   }
 
   protected object PatternMatchCase extends PatternMatchCaseModule {

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -35,11 +35,9 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
     ): Expr[(From, From2) => To] =
       c.Expr[(From, From2) => To](q"($fromName: ${Type[From]}, $from2Name: ${Type[From2]}) => $to")
 
-    private def freshTermName(prefix: String): ExprPromiseName = {
-      val alignedPrefix = prefix.toLowerCase + "$macro"
-      // Scala 3 generate prefix$macro$n while Scala 2 prefix$n and we want to align the behavior
-      c.internal.reificationSupport.freshTermName(alignedPrefix + "$")
-    }
+    private def freshTermName(prefix: String): ExprPromiseName =
+      // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
+      c.internal.reificationSupport.freshTermName(prefix.toLowerCase + "$macro$")
     private def freshTermName(tpe: c.Type): ExprPromiseName =
       freshTermName(tpe.typeSymbol.name.decodedName.toString.toLowerCase)
     private def freshTermName(srcPrefixTree: Expr[?]): ExprPromiseName =

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -145,8 +145,10 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     def prettyPrint[A](expr: Expr[A]): String =
       expr.tree
         .toString()
+        // removes $macro$n from freshterms to make it easier to test and read
+        .replaceAll("\\$macro", "")
         .replaceAll("\\$\\d+", "")
-        .replace("$u002E", ".")
+        // color expression for better UX (not as good as Scala 3 coloring but better than none)
         .split('\n')
         .map(line => Console.MAGENTA + line + Console.RESET)
         .mkString("\n")

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -155,7 +155,7 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
     def prettyPrint[A: Type]: String = {
       def helper(tpe: c.Type): String = {
         val tpes = tpe.typeArgs.map(helper)
-        tpe.typeSymbol.fullName + (if (tpes.isEmpty) "" else s"[${tpes.mkString(", ")}]")
+        tpe.dealias.typeSymbol.fullName + (if (tpes.isEmpty) "" else s"[${tpes.mkString(", ")}]")
       }
       Console.MAGENTA + helper(Type[A].tpe) + Console.RESET
     }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -49,7 +49,6 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
       }
     }
 
-    import scala.util.chaining.*
     private def freshTermName[A: Type](
         prefix: String,
         usageHint: UsageHint

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -52,12 +52,11 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
     import scala.util.chaining.*
     private def freshTermName[A: Type](
         prefix: String,
-        usageHint: UsageHint,
-        dropSuffix: Boolean = false
+        usageHint: UsageHint
     ): ExprPromiseName = Symbol
       .newVal(
         Symbol.spliceOwner,
-        FreshTerm.generate(prefix).pipe(name => if dropSuffix then dropMacroSuffix(name) else name),
+        FreshTerm.generate(prefix),
         TypeRepr.of[A],
         usageHint match
           case UsageHint.None => Flags.EmptyFlags
@@ -72,15 +71,10 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
       val repr = TypeRepr.of[A] match
         case AppliedType(repr, _) => repr
         case otherwise            => otherwise
-      freshTermName(repr.show(using Printer.TypeReprShortCode).toLowerCase, usageHint, dropSuffix = true)
+      freshTermName(repr.show(using Printer.TypeReprShortCode).toLowerCase, usageHint)
     }
     private def freshTermName[A: Type](expr: Expr[?], usageHint: UsageHint): ExprPromiseName =
-      freshTermName[A](expr.asTerm.toString, usageHint, dropSuffix = true)
-
-    // Undoes the encoding of freshTermName so that generated value would not contain $1, $2, ...
-    // - this makes generated fresh names more readable as it prevents e.g. typename$macro$1, typename$macro$2
-    private def dropMacroSuffix[A](freshName: String): String =
-      freshName.replaceAll("\\$macro\\$\\d+", "")
+      freshTermName[A](expr.asTerm.toString, usageHint)
   }
 
   protected object PrependDefinitionsTo extends PrependDefinitionsToModule {

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -138,7 +138,12 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
 
     def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] = '{ val _ = ${ expr } }
 
-    def prettyPrint[A](expr: Expr[A]): String = expr.asTerm.show(using Printer.TreeAnsiCode)
+    def prettyPrint[A](expr: Expr[A]): String =
+      expr.asTerm
+        .show(using Printer.TreeAnsiCode)
+        // remove $macro$n from freshterms to make it easier to test and read
+        .replaceAll("\\$macro", "")
+        .replaceAll("\\$\\d+", "")
 
     def typeOf[A](expr: Expr[A]): Type[A] = Type.platformSpecific.fromUntyped[A](expr.asTerm.tpe)
   }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -16,7 +16,8 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
         sym.flags.is(Flags.Abstract) || sym.flags.is(Flags.Trait)
 
       def isPublic(sym: Symbol): Boolean =
-        !(sym.flags.is(Flags.Private) || sym.flags.is(Flags.PrivateLocal) || sym.flags.is(Flags.Protected))
+        !(sym.flags.is(Flags.Private) || sym.flags.is(Flags.PrivateLocal) || sym.flags.is(Flags.Protected) ||
+          sym.privateWithin.isDefined || sym.protectedWithin.isDefined)
 
       def isParameterless(method: Symbol): Boolean =
         method.paramSymss.filterNot(_.exists(_.isType)).flatten.isEmpty

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationResult.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationResult.scala
@@ -45,7 +45,7 @@ sealed private[compiletime] trait DerivationResult[+A] {
       catch {
         case fatal @ FatalError(_, _) => throw fatal // unwind stack, we already saved the cause and last state
         case NonFatal(err)            => DerivationResult.fromException(err) // recoverable, turn into DerivationResult
-        case fatal => throw FatalError(fatal, this.state) // save last state and cause of a fatal error
+        case fatal: Throwable => throw FatalError(fatal, this.state) // save last state and cause of a fatal error
       }
 
     result.updateState(_.appendedTo(state))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Gateway.scala
@@ -46,10 +46,14 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
   }
 
   private def enableLoggingIfFlagEnabled[A](
-      result: DerivationResult[A],
+      result: => DerivationResult[A],
       ctx: PatcherContext[?, ?]
   ): DerivationResult[A] =
-    enableLoggingIfFlagEnabled[A](result, ctx.config.displayMacrosLogging, ctx.derivationStartedAt)
+    enableLoggingIfFlagEnabled[A](
+      DerivationResult.catchFatalErrors(result),
+      ctx.config.displayMacrosLogging,
+      ctx.derivationStartedAt
+    )
 
   private def extractExprAndLog[A: Type, Patch: Type, Out: Type](result: DerivationResult[Expr[Out]]): Expr[Out] =
     extractExprAndLog[Out](

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -18,26 +18,43 @@ private[compiletime] trait Derivation
   final protected def deriveTransformationResultExpr[From, To](implicit
       ctx: TransformationContext[From, To]
   ): DerivationResult[TransformationExpr[To]] =
+    deriveTransformationResultExprUpdatingRules[From, To](identity)
+
+  /** Intended use case: shared logic between what Gateway uses and recursive derivation uses */
+  final private def deriveTransformationResultExprUpdatingRules[From, To](
+      updateRules: List[Rule] => List[Rule]
+  )(implicit
+      ctx: TransformationContext[From, To]
+  ): DerivationResult[TransformationExpr[To]] =
     DerivationResult.namedScope(
       ctx.fold(_ => s"Deriving Total Transformer expression from ${Type.prettyPrint[From]} to ${Type.prettyPrint[To]}")(
         _ => s"Deriving Partial Transformer expression from ${Type.prettyPrint[From]} to ${Type.prettyPrint[To]}"
       )
     ) {
-      Rule.expandRules[From, To](rulesAvailableForPlatform)
+      Rule.expandRules[From, To](updateRules(rulesAvailableForPlatform))
     }
 
   /** Intended use case: recursive derivation within rules */
   final protected def deriveRecursiveTransformationExpr[NewFrom: Type, NewTo: Type](
       newSrc: Expr[NewFrom]
+  )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] =
+    deriveRecursiveTransformationExprUpdatingRules[NewFrom, NewTo](newSrc)(identity)
+
+  /** Intended use case: recursive derivation within rules which should remove some rules from consideration */
+  final protected def deriveRecursiveTransformationExprUpdatingRules[NewFrom: Type, NewTo: Type](
+      newSrc: Expr[NewFrom]
+  )(
+      updateRules: List[Rule] => List[Rule]
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] = {
     val newCtx: TransformationContext[NewFrom, NewTo] = ctx.updateFromTo[NewFrom, NewTo](newSrc).updateConfig {
       _.prepareForRecursiveCall
     }
-    deriveTransformationResultExpr(newCtx)
+    deriveTransformationResultExprUpdatingRules(updateRules)(newCtx)
       .logSuccess {
         case TransformationExpr.TotalExpr(expr)   => s"Derived recursively total expression ${Expr.prettyPrint(expr)}"
         case TransformationExpr.PartialExpr(expr) => s"Derived recursively partial expression ${Expr.prettyPrint(expr)}"
       }
       .logFailure(errors => s"Errors at recursive derivation: ${errors.prettyPrint}")
   }
+
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
@@ -141,10 +141,14 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
         }
 
   private def enableLoggingIfFlagEnabled[A](
-      result: DerivationResult[A],
+      result: => DerivationResult[A],
       ctx: TransformationContext[?, ?]
   ): DerivationResult[A] =
-    enableLoggingIfFlagEnabled[A](result, ctx.config.flags.displayMacrosLogging, ctx.derivationStartedAt)
+    enableLoggingIfFlagEnabled[A](
+      DerivationResult.catchFatalErrors(result),
+      ctx.config.flags.displayMacrosLogging,
+      ctx.derivationStartedAt
+    )
 
   private def extractExprAndLog[From: Type, To: Type, Out: Type](result: DerivationResult[Expr[Out]]): Expr[Out] =
     extractExprAndLog[Out](

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -166,8 +166,8 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
           DerivationResult.log(
             s"Falling back on ${Type.prettyPrint[FromSubtype]} to ${Type.prettyPrint[To]} (target upcasted)"
           ) >>
-            deriveRecursiveTransformationExprUpdatingRules[fromSubtype.Underlying, To](fromSubtypeExpr)(
-              rules => rules.filter(rule => rule.name == "Implicit")
+            deriveRecursiveTransformationExprUpdatingRules[fromSubtype.Underlying, To](fromSubtypeExpr)(rules =>
+              rules.filter(rule => rule.name == "Implicit")
             )
         }
         .map(Existential[ExprPromise[*, TransformationExpr[To]], FromSubtype](_))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -166,7 +166,9 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
           DerivationResult.log(
             s"Falling back on ${Type.prettyPrint[FromSubtype]} to ${Type.prettyPrint[To]} (target upcasted)"
           ) >>
-            deriveRecursiveTransformationExpr[FromSubtype, To](fromSubtypeExpr)
+            deriveRecursiveTransformationExprUpdatingRules[fromSubtype.Underlying, To](fromSubtypeExpr)(
+              rules => rules.filter(rule => rule.name == "Implicit")
+            )
         }
         .map(Existential[ExprPromise[*, TransformationExpr[To]], FromSubtype](_))
     }

--- a/chimney/src/test/scala-2/io/scalaland/chimney/VersionCompat.scala
+++ b/chimney/src/test/scala-2/io/scalaland/chimney/VersionCompat.scala
@@ -5,17 +5,12 @@ import munit.internal.MacroCompatScala2
 
 trait VersionCompat {
 
-  def isScala3 = false
-
   /* Directly used compileErrors from munit.
    * For reasoning, see the Scala 3 version of the file.
    */
   def compileErrorsFixed(code: String): String =
     macro MacroCompatScala2.compileErrorsImpl
 
-  /* Compilation errors that should be checked in Scala 2-only as currently Scala 3 has some issues
-   * (which we don't want to comment out but also which we don't want to fail compilation and prevent us for other checks)
-   */
   def compileErrorsScala2(code: String): String =
     macro MacroCompatScala2.compileErrorsImpl
 }

--- a/chimney/src/test/scala-2/io/scalaland/chimney/VersionCompat.scala
+++ b/chimney/src/test/scala-2/io/scalaland/chimney/VersionCompat.scala
@@ -11,6 +11,10 @@ trait VersionCompat {
   def compileErrorsFixed(code: String): String =
     macro MacroCompatScala2.compileErrorsImpl
 
+  // TODO: I wish to remove these one day
+
   def compileErrorsScala2(code: String): String =
     macro MacroCompatScala2.compileErrorsImpl
+
+  def isScala3: Boolean = false
 }

--- a/chimney/src/test/scala-3/io/scalaland/chimney/PartialTransformerEnumSpec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/PartialTransformerEnumSpec.scala
@@ -187,7 +187,7 @@ class PartialTransformerEnumSpec extends ChimneySpec {
         .check(
           "Chimney can't derive transformation from io.scalaland.chimney.fixtures.colors2enums.Color to io.scalaland.chimney.fixtures.colors1enums.Color",
           "io.scalaland.chimney.fixtures.colors1enums.Color",
-          "can't transform coproduct instance io.scalaland.chimney.fixtures.colors2enums.Black to io.scalaland.chimney.fixtures.colors1enums.Color",
+          "can't transform coproduct instance io.scalaland.chimney.fixtures.colors2enums.Color.Black to io.scalaland.chimney.fixtures.colors1enums.Color",
           "Consult https://chimney.readthedocs.io for usage examples."
         )
     }

--- a/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
@@ -122,8 +122,7 @@ class TotalTransformerEnumSpec extends ChimneySpec {
   }
 
   test("not allow transformation of of sealed hierarchies when the transformation would be ambiguous") {
-    assume(!isScala3, "not be executed in Scala 3")
-    val error = compileErrorsScala2(
+    val error = compileErrorsFixed(
       """
            (shapes1enums.Triangle(shapes1enums.Point(0, 0), shapes1enums.Point(2, 2), shapes1enums.Point(2, 0)): shapes1enums.Shape)
              .transformInto[shapes5enums.Shape]

--- a/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
@@ -124,7 +124,7 @@ class TotalTransformerEnumSpec extends ChimneySpec {
   test("not allow transformation of of sealed hierarchies when the transformation would be ambiguous") {
     val error = compileErrorsFixed(
       """
-           (shapes1enums.Triangle(shapes1enums.Point(0, 0), shapes1enums.Point(2, 2), shapes1enums.Point(2, 0)): shapes1enums.Shape)
+           (shapes1enums.Shape.Triangle(shapes1enums.Point(0, 0), shapes1enums.Point(2, 2), shapes1enums.Point(2, 0)): shapes1enums.Shape)
              .transformInto[shapes5enums.Shape]
         """
     )

--- a/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
@@ -137,8 +137,8 @@ class TotalTransformerEnumSpec extends ChimneySpec {
       "Consult https://chimney.readthedocs.io for usage examples."
     )
 
-    assert(
-      !error.contains("coproduct instance Circle of io.scalaland.chimney.fixtures.shapes5enums.Shape is ambiguous")
+    error.checkNot(
+      "coproduct instance Circle of io.scalaland.chimney.fixtures.shapes5enums.Shape is ambiguous"
     )
   }
 

--- a/chimney/src/test/scala-3/io/scalaland/chimney/VersionCompat.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/VersionCompat.scala
@@ -22,5 +22,9 @@ trait VersionCompat {
       .mkString("\n")
   }
 
+  // TODO: I wish to remove these one day :/
+
   transparent inline def compileErrorsScala2(inline code: String): String = ""
+
+  def isScala3: Boolean = true
 }

--- a/chimney/src/test/scala-3/io/scalaland/chimney/VersionCompat.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/VersionCompat.scala
@@ -2,8 +2,6 @@ package io.scalaland.chimney
 
 trait VersionCompat {
 
-  def isScala3 = true
-
   /* Copy/Paste from munit, with transparent keyword added.
    * Without the keyword some unexpected error reports would be collected
    */
@@ -24,8 +22,5 @@ trait VersionCompat {
       .mkString("\n")
   }
 
-  /* Compilation errors that should be checked in Scala 2-only as currently Scala 3 has some issues
-   * (which we don't want to comment out but also which we don't want to fail compilation and prevent us for other checks)
-   */
   transparent inline def compileErrorsScala2(inline code: String): String = ""
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
@@ -37,11 +37,8 @@ trait ChimneySpec extends munit.BaseFunSuite with VersionCompat { self =>
   }
 
   implicit class CompileErrorsCheck(msg: String) {
-
-    // FIXME: temporary workaround to disable checking compilation errors format on Scala 3 until we fix them
-    def check(msgs: String*): Unit = if (isScala3) arePresent() else check2(msgs*)
-
-    def check2(msgs: String*): Unit = for (msg <- msgs)
+    
+    def check(msgs: String*): Unit = for (msg <- msgs)
       Predef.assert(
         ChimneySpec.AnsiControlCode.replaceAllIn(this.msg, "").contains(msg),
         "Error message did not contain expected snippet\n" +

--- a/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
@@ -37,7 +37,7 @@ trait ChimneySpec extends munit.BaseFunSuite with VersionCompat { self =>
   }
 
   implicit class CompileErrorsCheck(msg: String) {
-    
+
     def check(msgs: String*): Unit = for (msg <- msgs)
       Predef.assert(
         ChimneySpec.AnsiControlCode.replaceAllIn(this.msg, "").contains(msg),

--- a/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/ChimneySpec.scala
@@ -38,15 +38,31 @@ trait ChimneySpec extends munit.BaseFunSuite with VersionCompat { self =>
 
   implicit class CompileErrorsCheck(msg: String) {
 
-    def check(msgs: String*): Unit = for (msg <- msgs)
-      Predef.assert(
-        ChimneySpec.AnsiControlCode.replaceAllIn(this.msg, "").contains(msg),
-        "Error message did not contain expected snippet\n" +
-          "Error message\n" +
-          this.msg + "\n" +
-          "Expected Snippet\n" +
-          msg
-      )
+    def check(msgs: String*): Unit = {
+      val msgNoColors = ChimneySpec.AnsiControlCode.replaceAllIn(this.msg, "")
+      for (msg <- msgs)
+        Predef.assert(
+          msgNoColors.contains(msg),
+          s"""Error message did not contain expected snippet
+            |Error message
+            |${this.msg}
+            |Expected Snippet
+            |$msg""".stripMargin
+        )
+    }
+
+    def checkNot(msgs: String*): Unit = {
+      val msgNoColors = ChimneySpec.AnsiControlCode.replaceAllIn(this.msg, "")
+      for (msg <- msgs)
+        Predef.assert(
+          !msgNoColors.contains(msg),
+          s"""Error message contain snippet that was expected to be not there
+            |Error message
+            |${this.msg}
+            |Not Expected Snippet
+            |$msg""".stripMargin
+        )
+    }
 
     def arePresent(): Unit = Predef.assert(msg.nonEmpty, "Expected compilation errors")
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -87,7 +87,7 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
     rectangle.transformInto[shapes1.Shape] ==>
       shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
   }
-
+  
   test("not allow transformation of of sealed hierarchies when the transformation would be ambiguous".ignore) {
     val error = compileErrorsScala2(
       """

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -104,8 +104,8 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
       "Consult https://chimney.readthedocs.io for usage examples."
     )
 
-    assert(
-      !error.contains("coproduct instance Circle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous")
+    error.checkNot(
+      "coproduct instance Circle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous"
     )
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -88,7 +88,12 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
       shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
   }
 
-  test("not allow transformation of of sealed hierarchies when the transformation would be ambiguous".ignore) {
+  test(
+    "not allow transformation of of sealed hierarchies when the transformation would be ambiguous".withTags(
+      if (isScala3) Set(munit.Ignore)
+      else Set.empty // ignore only on Scala 3 until https://github.com/lampepfl/dotty/issues/18484 is fixed
+    )
+  ) {
     val error = compileErrorsScala2(
       """
            (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -87,7 +87,7 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
     rectangle.transformInto[shapes1.Shape] ==>
       shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
   }
-  
+
   test("not allow transformation of of sealed hierarchies when the transformation would be ambiguous".ignore) {
     val error = compileErrorsScala2(
       """


### PR DESCRIPTION
TODO:

 * [x] manually align the behavior of `Type.prettyPrint[T]` between Scala 2 and Scala 3
 * [x] fix methods generating `Transformer` and `PartialTransformer` type classes in Scala 3 - currently the pass `src` as the name of the expr, while they should use fresh name based on type
   * [x] ditto for Patcher 
 * [x] manually drop the suffix `$macro$1` from some freshterms on Scala 3 to align the behavior with Scala 2
   * [x] or better - change Scala 2 to add `$macro` to prefix so that both implementations would generate `$prefix$macro$n`, remove special cases in dropping `$macro$n` and add this suffix in tests 
 * [ ] await fixing https://github.com/lampepfl/dotty/issues/18484