### PR TITLE
Re-enable -Xfatal-warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,13 @@ import commandmatrix.extra.*
 lazy val isCI = sys.env.get("CI").contains("true")
 ThisBuild / scalafmtOnCompile := !isCI
 
+// publishSigned emits
+//   Could not find any member to link for "scala.None".
+// and similar, and we cannot turn them off in any other way than by removing -Xfatal-warnings
+// so at least we can remove them ONLY when building a release from a commit which already
+// passed the tests.
+lazy val isRelease = sys.env.get("RELEASE").contains("true")
+
 // versions
 
 val versions = new {
@@ -201,9 +208,8 @@ val publishSettings = Seq(
         <url>http://github.com/MateuszKubuszok</url>
       </developer>
     </developers>
-  ),
-  scalacOptions -= "-Xfatal-warnings"
-)
+  )
+) ++ (if (isRelease) Seq(scalacOptions -= "-Xfatal-warnings") else Seq.empty)
 
 val mimaSettings = Seq(
   mimaPreviousArtifacts := {

--- a/protobufs/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
+++ b/protobufs/src/test/scala/io/scalaland/chimney/PBTransformationSpec.scala
@@ -5,7 +5,6 @@ import io.scalaland.chimney.dsl._
 // format: on
 import io.scalaland.chimney.examples.pb
 import io.scalaland.chimney.fixtures.{addressbook, order}
-import io.scalaland.chimney.{partial, ChimneySpec, PartialTransformer}
 
 class PBTransformationSpec extends ChimneySpec {
 


### PR DESCRIPTION
We once disabled -Xfatal-warnings since `publishSigned` (required for the release) ends up with

```
chimney-build(restore-fatal-warnings)> chimney/publishSigned
[info] Wrote /Users/dev/Workspaces/GitHub/chimney/chimney/target/jvm-2.13/chimney_2.13-699a436c4f137c415906b250539313a4af1c8e45.pom
[info] Main Scala API documentation to /Users/dev/Workspaces/GitHub/chimney/chimney/target/jvm-2.13/api...
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:139:3: Could not find any member to link for "scala.Either".
[error]   /** Lifts [[scala.Either]] into [[io.scalaland.chimney.partial.Result]].
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:110:3: Could not find any member to link for "scala.Option".
[error]   /** Lifts [[scala.Option]] into [[io.scalaland.chimney.partial.Result]].
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:158:3: Could not find any member to link for "scala.util.Try".
[error]   /** Lifts [[scala.util.Try]] into [[io.scalaland.chimney.partial.Result]].
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:167:5: Could not find any member to link for "scala.util.Success".
[error]     /** Converts Try to Result, using Throwable from Failure as failed result.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:148:5: Could not find any member to link for "scala.Right".
[error]     /** Converts Either to Result, using an error message from Left as failed result.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:119:5: Could not find any member to link for "scala.Some".
[error]     /** Converts Option to Result, using EmptyValue error if None.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:128:5: Could not find any member to link for "scala.None".
[error]     /** Converts Option to Result, using provided error message if None.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:93:5: Could not find any member to link for "io.scalaland.chimney.dsl.PatcherOps#using".
[error]     /** Performs in-place patching of wrapped object with provided value.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:65:5: Could not find any member to link for "io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial".
[error]     /** Performs in-place partial transformation of captured source value to target type.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:48:5: Could not find any member to link for "io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial".
[error]     /** Performs in-place partial transformation of captured source value to target type.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala:23:5: Could not find any member to link for "io.scalaland.chimney.dsl.TransformerOps#into".
[error]     /** Performs in-place transformation of captured source value to target type.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala:119:5: Could not find any member to link for "io.scalaland.chimney.dsl.PatcherOps#using".
[error]     /** Performs in-place patching of wrapped object with provided value.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala:91:5: Could not find any member to link for "io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial".
[error]     /** Performs in-place partial transformation of captured source value to target type.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala:74:5: Could not find any member to link for "io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial".
[error]     /** Performs in-place partial transformation of captured source value to target type.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala:49:5: Could not find any member to link for "io.scalaland.chimney.dsl.TransformerOps#into".
[error]     /** Performs in-place transformation of captured source value to target type.
[error]     ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:356:3: Could not find any member to link for "scala.Right".
[error]   /** Converts Either to Result, using Errors from Left as failed result.
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:369:3: Could not find any member to link for "scala.Right".
[error]   /** Converts Either to Result, using an error message from Left as failed result.
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:302:3: Could not find any member to link for "scala.Some".
[error]   /** Converts Option to Result, using EmptyValue error if None.
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:315:3: Could not find any member to link for "scala.None".
[error]   /** Converts Option to Result, using provided Error if None.
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:328:3: Could not find any member to link for "scala.None".
[error]   /** Converts Option to Result, using provided error message if None.
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:342:3: Could not find any member to link for "scala.None".
[error]   /** Converts Option to Result, using provided Throwable if None.
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:380:3: Could not find any member to link for "scala.util.Success".
[error]   /** Converts Try to Result, using Throwable from Failure as failed result.
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:26:3: Could not find any member to link for "scala.Either".
[error]   /** Converts a partial result to an [[scala.Either]].
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:48:3: Could not find any member to link for "scala.collection.Iterable".
[error]   /** Returns (possibly empty) collection of tuples with conventional string representation of path
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:38:3: Could not find any member to link for "scala.collection.Iterable".
[error]   /** Returns (possibly empty) collection of tuples with conventional string representation of path
[error]   ^
[error] /Users/dev/Workspaces/GitHub/chimney/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala:15:3: Could not find any member to link for "scala.Some".
[error]   /** Converts a partial result to an optional value.
[error]   ^
[error] 26 errors found
[error] stack trace is suppressed; run last chimney / Compile / doc for the full output
[error] (chimney / Compile / doc) Scaladoc generation failed
[error] Total time: 19 s, completed Sep 14, 2023, 1:25:23 PM
```

I don't know any way of removing these warnings, I can only make them non-fatal, and `doc` task ignores things like `doc / scalacOptions -= "-Xfatal-warnings"`, it apparently copy-pastes options from the compilation.

The only workaround I can think of now, which allows use fatal-warnings but also not requires disabling before each release and reenabling right after, is to control that with an environment flag. Then build which passes CI can be restarted with

```bash
RELEASE=true sbt
```

