### PR TITLE
Allow declarations inherited from parents

### DIFF
--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -97,7 +97,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
           .filterNot(isGarbageSymbol)
           .filterNot(isCaseFieldName)
           .filter(isAccessor)
-        val localDefinitions = sym.declaredMethods.toSet
+        val localDefinitions = (sym.declaredMethods ++ sym.declaredFields).toSet
 
         // if we are taking caseFields but then we also are using ALL fieldMembers shouldn't we just use fieldMembers?
         (caseFields ++ sym.fieldMembers ++ accessorsAndGetters).filter(isPublic).distinct.map { getter =>

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -97,6 +97,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
           .filterNot(isGarbageSymbol)
           .filterNot(isCaseFieldName)
           .filter(isAccessor)
+        val localDefinitions = sym.declaredMethods.toSet
 
         // if we are taking caseFields but then we also are using ALL fieldMembers shouldn't we just use fieldMembers?
         (caseFields ++ sym.fieldMembers ++ accessorsAndGetters).filter(isPublic).distinct.map { getter =>
@@ -110,6 +111,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
                 else if isJavaGetter(getter) && conformToIsGetters then Product.Getter.SourceType.JavaBeanGetter
                 else if getter.isValDef then Product.Getter.SourceType.ConstructorVal
                 else Product.Getter.SourceType.AccessorMethod,
+              isLocal = localDefinitions(getter),
               get =
                 // TODO: pathological cases like def foo[Unused]()()()
                 if getter.paramSymss.isEmpty then

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -25,7 +25,7 @@ trait ProductTypes { this: Definitions =>
   final protected case class Product[A](extraction: Product.Extraction[A], construction: Product.Constructor[A])
   protected object Product {
 
-    final case class Getter[From, A](sourceType: Getter.SourceType, get: Expr[From] => Expr[A])
+    final case class Getter[From, A](sourceType: Getter.SourceType, isLocal: Boolean, get: Expr[From] => Expr[A])
     object Getter {
 
       /** Let us decide whether or now we can use the getter based on configuration */

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -137,14 +137,16 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       }
 
       object Flags extends FlagsModule {
+        val InheritedAccessors: Type[runtime.TransformerFlags.InheritedAccessors] =
+          weakTypeTag[runtime.TransformerFlags.InheritedAccessors]
+        val MethodAccessors: Type[runtime.TransformerFlags.MethodAccessors] =
+          weakTypeTag[runtime.TransformerFlags.MethodAccessors]
         val DefaultValues: Type[runtime.TransformerFlags.DefaultValues] =
           weakTypeTag[runtime.TransformerFlags.DefaultValues]
         val BeanGetters: Type[runtime.TransformerFlags.BeanGetters] =
           weakTypeTag[runtime.TransformerFlags.BeanGetters]
         val BeanSetters: Type[runtime.TransformerFlags.BeanSetters] =
           weakTypeTag[runtime.TransformerFlags.BeanSetters]
-        val MethodAccessors: Type[runtime.TransformerFlags.MethodAccessors] =
-          weakTypeTag[runtime.TransformerFlags.MethodAccessors]
         val OptionDefaultsToNone: Type[runtime.TransformerFlags.OptionDefaultsToNone] =
           weakTypeTag[runtime.TransformerFlags.OptionDefaultsToNone]
         object ImplicitConflictResolution extends ImplicitConflictResolutionModule {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -136,14 +136,16 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       }
 
       object Flags extends FlagsModule {
+        val InheritedAccessors: Type[runtime.TransformerFlags.InheritedAccessors] =
+          quoted.Type.of[runtime.TransformerFlags.InheritedAccessors]
+        val MethodAccessors: Type[runtime.TransformerFlags.MethodAccessors] =
+          quoted.Type.of[runtime.TransformerFlags.MethodAccessors]
         val DefaultValues: Type[runtime.TransformerFlags.DefaultValues] =
           quoted.Type.of[runtime.TransformerFlags.DefaultValues]
         val BeanGetters: Type[runtime.TransformerFlags.BeanGetters] =
           quoted.Type.of[runtime.TransformerFlags.BeanGetters]
         val BeanSetters: Type[runtime.TransformerFlags.BeanSetters] =
           quoted.Type.of[runtime.TransformerFlags.BeanSetters]
-        val MethodAccessors: Type[runtime.TransformerFlags.MethodAccessors] =
-          quoted.Type.of[runtime.TransformerFlags.MethodAccessors]
         val OptionDefaultsToNone: Type[runtime.TransformerFlags.OptionDefaultsToNone] =
           quoted.Type.of[runtime.TransformerFlags.OptionDefaultsToNone]
         object ImplicitConflictResolution extends ImplicitConflictResolutionModule {

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -11,6 +11,26 @@ import scala.annotation.unused
   */
 private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags <: TransformerFlags] {
 
+  /** Enable lookup in definitions inherited from supertype.
+    *
+    * By default only values defined directly in the type are considered. With this flag supertype methods would not be filtered out
+    *
+    * @see TODO
+    *
+    * @since 0.8.0
+    */
+  def enableInheritedAccessors: UpdateFlag[Enable[InheritedAccessors, Flags]] =
+    enableFlag[InheritedAccessors]
+
+  /** Disable inherited accessors lookup that was previously enabled by `enableInheritedAccessors`
+    *
+    * @see TODO
+    *
+    * @since 0.8.0
+    */
+  def disableInheritedAccessors: UpdateFlag[Disable[InheritedAccessors, Flags]] =
+    disableFlag[InheritedAccessors]
+
   /** Enable values to be supplied from method calls. Source method must be public and have no parameter list.
     *
     * By default this is disabled because method calls may perform side effects (e.g. mutations)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -122,10 +122,11 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
 
       val Flags: FlagsModule
       trait FlagsModule { this: Flags.type =>
+        val InheritedAccessors: Type[runtime.TransformerFlags.InheritedAccessors]
+        val MethodAccessors: Type[runtime.TransformerFlags.MethodAccessors]
         val DefaultValues: Type[runtime.TransformerFlags.DefaultValues]
         val BeanGetters: Type[runtime.TransformerFlags.BeanGetters]
         val BeanSetters: Type[runtime.TransformerFlags.BeanSetters]
-        val MethodAccessors: Type[runtime.TransformerFlags.MethodAccessors]
         val OptionDefaultsToNone: Type[runtime.TransformerFlags.OptionDefaultsToNone]
         val ImplicitConflictResolution: ImplicitConflictResolutionModule
         trait ImplicitConflictResolutionModule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -7,24 +7,27 @@ import io.scalaland.chimney.internal.runtime
 private[compiletime] trait Configurations { this: Derivation =>
 
   final protected case class TransformerFlags(
+      inheritedAccessors: Boolean = false,
+      methodAccessors: Boolean = false,
       processDefaultValues: Boolean = false,
       beanSetters: Boolean = false,
       beanGetters: Boolean = false,
-      methodAccessors: Boolean = false,
       optionDefaultsToNone: Boolean = false,
       implicitConflictResolution: Option[ImplicitTransformerPreference] = None,
       displayMacrosLogging: Boolean = false
   ) {
 
     def setBoolFlag[Flag <: runtime.TransformerFlags.Flag: Type](value: Boolean): TransformerFlags =
-      if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.DefaultValues) {
+      if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.InheritedAccessors) {
+        copy(inheritedAccessors = value)
+      } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.MethodAccessors) {
+        copy(methodAccessors = value)
+      } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.DefaultValues) {
         copy(processDefaultValues = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.BeanSetters) {
         copy(beanSetters = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.BeanGetters) {
         copy(beanGetters = value)
-      } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.MethodAccessors) {
-        copy(methodAccessors = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.OptionDefaultsToNone) {
         copy(optionDefaultsToNone = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.MacrosLogging) {
@@ -39,10 +42,11 @@ private[compiletime] trait Configurations { this: Derivation =>
       copy(implicitConflictResolution = preference)
 
     override def toString: String = s"Flags(${Vector(
+        if (inheritedAccessors) Vector("inheritedAccessors") else Vector.empty,
+        if (methodAccessors) Vector("methodAccessors") else Vector.empty,
         if (processDefaultValues) Vector("processDefaultValues") else Vector.empty,
         if (beanSetters) Vector("beanSetters") else Vector.empty,
         if (beanGetters) Vector("beanGetters") else Vector.empty,
-        if (methodAccessors) Vector("methodAccessors") else Vector.empty,
         if (optionDefaultsToNone) Vector("optionDefaultsToNone") else Vector.empty,
         implicitConflictResolution.map(r => s"ImplicitTransformerPreference=$r").toList.toVector,
         if (displayMacrosLogging) Vector("displayMacrosLogging") else Vector.empty

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
@@ -9,6 +9,7 @@ object TransformerFlags {
   final class Disable[F <: Flag, Flags <: TransformerFlags] extends TransformerFlags
 
   sealed abstract class Flag
+  final class InheritedAccessors extends Flag
   final class MethodAccessors extends Flag
   final class DefaultValues extends Flag
   final class BeanSetters extends Flag

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -690,6 +690,66 @@ class PartialTransformerProductSpec extends ChimneySpec {
     }
   }
 
+  group("flag .enableInheritedAccessors") {
+
+    test("should be disabled by default") {
+      import products.Inherited.*
+
+      compileErrorsFixed("(new Source).transformIntoPartial[Target]").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Inherited.Source to io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "value: java.lang.String - no accessor named value in source type io.scalaland.chimney.fixtures.products.Inherited.Source",
+        "There are methods in io.scalaland.chimney.fixtures.products.Inherited.Source that might be used as accessors for `value` fields in io.scalaland.chimney.fixtures.products.Inherited.Target. Consider using `.enableMethodAccessors`.",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+
+      compileErrorsFixed("(new Source).intoPartial[Target].transform").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Inherited.Source to io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "value: java.lang.String - no accessor named value in source type io.scalaland.chimney.fixtures.products.Inherited.Source",
+        "There are methods in io.scalaland.chimney.fixtures.products.Inherited.Source that might be used as accessors for `value` fields in io.scalaland.chimney.fixtures.products.Inherited.Target. Consider using `.enableMethodAccessors`.",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+
+    test("should enable using inherited accessors") {
+      import products.Inherited.*
+
+      val expected = Target("value")
+
+      val result = (new Source).intoPartial[Target].enableInheritedAccessors.transform
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      locally {
+        implicit val cfg = TransformerConfiguration.default.enableInheritedAccessors
+
+        val result2 = (new Source).transformIntoPartial[Target]
+        result2.asOption ==> Some(expected)
+        result2.asEither ==> Right(expected)
+        result2.asErrorPathMessageStrings ==> Iterable.empty
+      }
+    }
+  }
+
+  group("flag .disableInheritedAccessors") {
+
+    test("should disable globally enabled .enableInheritedAccessors") {
+      import products.Inherited.*
+
+      @unused implicit val cfg = TransformerConfiguration.default.enableInheritedAccessors
+
+      compileErrorsFixed("(new Source).intoPartial[Target].disableInheritedAccessors.transform").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Inherited.Source to io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "value: java.lang.String - no accessor named value in source type io.scalaland.chimney.fixtures.products.Inherited.Source",
+        "There are methods in io.scalaland.chimney.fixtures.products.Inherited.Source that might be used as accessors for `value` fields in io.scalaland.chimney.fixtures.products.Inherited.Target. Consider using `.enableMethodAccessors`.",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+  }
+
   group("flag .enableMethodAccessors") {
 
     test("should be disabled by default") {

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -363,6 +363,58 @@ class TotalTransformerProductSpec extends ChimneySpec {
     }
   }
 
+  group("flag .enableInheritedAccessors") {
+
+    test("should be disabled by default") {
+      import products.Inherited.*
+
+      compileErrorsFixed("(new Source).transformInto[Target]").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Inherited.Source to io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "value: java.lang.String - no accessor named value in source type io.scalaland.chimney.fixtures.products.Inherited.Source",
+        "There are methods in io.scalaland.chimney.fixtures.products.Inherited.Source that might be used as accessors for `value` fields in io.scalaland.chimney.fixtures.products.Inherited.Target. Consider using `.enableMethodAccessors`.",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+
+      compileErrorsFixed("(new Source).intoPartial[Target].transform").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Inherited.Source to io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "value: java.lang.String - no accessor named value in source type io.scalaland.chimney.fixtures.products.Inherited.Source",
+        "There are methods in io.scalaland.chimney.fixtures.products.Inherited.Source that might be used as accessors for `value` fields in io.scalaland.chimney.fixtures.products.Inherited.Target. Consider using `.enableMethodAccessors`.",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+
+    test("should enable using inherited accessors") {
+      import products.Inherited.*
+
+      (new Source).into[Target].enableInheritedAccessors.transform ==> Target("value")
+
+      locally {
+        implicit val cfg = TransformerConfiguration.default.enableInheritedAccessors
+
+        (new Source).transformInto[Target] ==> Target("value")
+      }
+    }
+  }
+
+  group("flag .disableInheritedAccessors") {
+
+    test("should disable globally enabled .enableInheritedAccessors") {
+      import products.Inherited.*
+
+      @unused implicit val cfg = TransformerConfiguration.default.enableInheritedAccessors
+
+      compileErrorsFixed("(new Source).into[Target].disableInheritedAccessors.transform").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Inherited.Source to io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "io.scalaland.chimney.fixtures.products.Inherited.Target",
+        "value: java.lang.String - no accessor named value in source type io.scalaland.chimney.fixtures.products.Inherited.Source",
+        "There are methods in io.scalaland.chimney.fixtures.products.Inherited.Source that might be used as accessors for `value` fields in io.scalaland.chimney.fixtures.products.Inherited.Target. Consider using `.enableMethodAccessors`.",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+  }
+
   group("flag .enableMethodAccessors") {
 
     test("should be disabled by default") {

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
@@ -68,6 +68,16 @@ object Defaults {
   case class Nested[A](value: A)
 }
 
+object Inherited {
+
+  trait SourceParent {
+    val value: String = "value"
+  }
+  class Source extends SourceParent
+
+  case class Target(value: String)
+}
+
 object Accessors {
 
   case class Source(x: Int) {

--- a/docs/source/transformers/customizing-transformers.rst
+++ b/docs/source/transformers/customizing-transformers.rst
@@ -102,6 +102,32 @@ and have no parameter list are considered.
   // FooV2(1, "m")
 
 
+Using inherited accessors
+-------------------------
+
+By default, Chimney will only consider ``val`` and ``lazy val`` (and ``def`` if you enable method accessors) defined
+directly within the source type, because it might be surprising to lookup all possible method inherited by supertypes or
+mixins.
+
+You can ask Chimney to consider inherited ``val`` and ``lazy val`` (and ``def`` if methods accessors are enabled) with
+``.enableInheritedAccessors``. Note that only methods that are public and have no parameter list are considered.
+
+.. code-block:: scala
+
+  trait SourceParent {
+    val value: String = "value"
+  }
+  class Source extends SourceParent
+
+  case class Target(value: String)
+
+  (new Source)
+    .into[Target]
+    .enableInheritedAccessors
+    .transform
+  // Target("value")
+
+
 Transforming coproducts
 -----------------------
 


### PR DESCRIPTION
When I was copy-pasting my solution from pipez I accidentally have one Scala version use only local definitions and the other one using all available definitions (inherited or not).

Since I need to fix this before releasing 0.8.0, to keep the old behavior I might as well fix it by allowing inherited declarations, but requiring a flag to use them. It would implement #144.

TODO:

 - [x] new flag
 - [x] keeping tab whether getter is local or inherited
 - [x] filtering out inherited definitions is flag is disabled
 - [x] tests of a new functionality
 - [x] documentation