### PR TITLE
Introduce Path type intended for storing nested path in type level

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -174,7 +174,6 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
         def apply[F <: runtime.PatcherFlags.Flag: Type, Flags <: runtime.PatcherFlags: Type]
             : Type[runtime.PatcherFlags.Enable[F, Flags]] =
           weakTypeTag[runtime.PatcherFlags.Enable[F, Flags]]
-
         def unapply[A](A: Type[A]): Option[(?<[runtime.PatcherFlags.Flag], ?<[runtime.PatcherFlags])] =
           if (A.isCtor[runtime.PatcherFlags.Enable[?, ?]])
             Some(A.param_<[runtime.PatcherFlags.Flag](0) -> A.param_<[runtime.PatcherFlags](1))
@@ -184,7 +183,6 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
         def apply[F <: runtime.PatcherFlags.Flag: Type, Flags <: runtime.PatcherFlags: Type]
             : Type[runtime.PatcherFlags.Disable[F, Flags]] =
           weakTypeTag[runtime.PatcherFlags.Disable[F, Flags]]
-
         def unapply[A](A: Type[A]): Option[(?<[runtime.PatcherFlags.Flag], ?<[runtime.PatcherFlags])] =
           if (A.isCtor[runtime.PatcherFlags.Disable[?, ?]])
             Some(A.param_<[runtime.PatcherFlags.Flag](0) -> A.param_<[runtime.PatcherFlags](1))
@@ -197,6 +195,17 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
         val IgnoreRedundantPatcherFields: Type[runtime.PatcherFlags.IgnoreRedundantPatcherFields] =
           weakTypeTag[runtime.PatcherFlags.IgnoreRedundantPatcherFields]
         val MacrosLogging: Type[runtime.PatcherFlags.MacrosLogging] = weakTypeTag[runtime.PatcherFlags.MacrosLogging]
+      }
+    }
+
+    object Path extends PathModule {
+      val Root: Type[runtime.Path.Root] = weakTypeTag[runtime.Path.Root]
+      object Select extends SelectModule {
+        def apply[Name <: String: Type, Instance <: runtime.Path: Type]: Type[runtime.Path.Select[Name, Instance]] =
+          weakTypeTag[runtime.Path.Select[Name, Instance]]
+        def unapply[A](A: Type[A]): Option[(?<[String], ?<[runtime.Path])] =
+          if (A.isCtor[runtime.Path.Select[?, ?]]) Some(A.param_<[String](0) -> A.param_<[runtime.Path](1))
+          else scala.None
       }
     }
   }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -50,48 +50,48 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
     object TransformerCfg extends TransformerCfgModule {
       val Empty: Type[runtime.TransformerCfg.Empty] = weakTypeTag[runtime.TransformerCfg.Empty]
       object FieldConst extends FieldConstModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldConst[Name, Cfg]] =
           weakTypeTag[runtime.TransformerCfg.FieldConst[Name, Cfg]]
-        def unapply[A](A: Type[A]): Option[(?<[String], ?<[runtime.TransformerCfg])] =
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerCfg])] =
           if (A.isCtor[runtime.TransformerCfg.FieldConst[?, ?]])
-            Some(A.param_<[String](0) -> A.param_<[runtime.TransformerCfg](1))
+            Some(A.param_<[runtime.Path](0) -> A.param_<[runtime.TransformerCfg](1))
           else scala.None
       }
       object FieldConstPartial extends FieldConstPartialModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldConstPartial[Name, Cfg]] =
           weakTypeTag[runtime.TransformerCfg.FieldConstPartial[Name, Cfg]]
-        def unapply[A](A: Type[A]): Option[(?<[String], ?<[runtime.TransformerCfg])] =
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerCfg])] =
           if (A.isCtor[runtime.TransformerCfg.FieldConstPartial[?, ?]])
-            Some(A.param_<[String](0) -> A.param_<[runtime.TransformerCfg](1))
+            Some(A.param_<[runtime.Path](0) -> A.param_<[runtime.TransformerCfg](1))
           else scala.None
       }
       object FieldComputed extends FieldComputedModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldComputed[Name, Cfg]] =
           weakTypeTag[runtime.TransformerCfg.FieldComputed[Name, Cfg]]
-        def unapply[A](A: Type[A]): Option[(?<[String], ?<[runtime.TransformerCfg])] =
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerCfg])] =
           if (A.isCtor[runtime.TransformerCfg.FieldComputed[?, ?]])
-            Some(A.param_<[String](0) -> A.param_<[runtime.TransformerCfg](1))
+            Some(A.param_<[runtime.Path](0) -> A.param_<[runtime.TransformerCfg](1))
           else scala.None
       }
       object FieldComputedPartial extends FieldComputedPartialModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldComputedPartial[Name, Cfg]] =
           weakTypeTag[runtime.TransformerCfg.FieldComputedPartial[Name, Cfg]]
-        def unapply[A](A: Type[A]): Option[(?<[String], ?<[runtime.TransformerCfg])] =
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerCfg])] =
           if (A.isCtor[runtime.TransformerCfg.FieldComputedPartial[?, ?]])
-            Some(A.param_<[String](0) -> A.param_<[runtime.TransformerCfg](1))
+            Some(A.param_<[runtime.Path](0) -> A.param_<[runtime.TransformerCfg](1))
           else scala.None
       }
       object FieldRelabelled extends FieldRelabelledModule {
-        def apply[FromName <: String: Type, ToName <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[FromName <: runtime.Path: Type, ToName <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldRelabelled[FromName, ToName, Cfg]] =
           weakTypeTag[runtime.TransformerCfg.FieldRelabelled[FromName, ToName, Cfg]]
-        def unapply[A](A: Type[A]): Option[(?<[String], ?<[String], ?<[runtime.TransformerCfg])] =
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerCfg])] =
           if (A.isCtor[runtime.TransformerCfg.FieldRelabelled[?, ?, ?]])
-            Some((A.param_<[String](0), A.param_<[String](1), A.param_<[runtime.TransformerCfg](2)))
+            Some((A.param_<[runtime.Path](0), A.param_<[runtime.Path](1), A.param_<[runtime.TransformerCfg](2)))
           else scala.None
       }
       object CoproductInstance extends CoproductInstanceModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.PartialTransformerDefinition
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -9,7 +10,7 @@ import scala.reflect.macros.whitebox
 
 class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
 
-  import c.universe.*
+  import c.universe.{Select as _, *}
 
   def withFieldConstImpl[
       From: WeakTypeTag,
@@ -21,7 +22,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerDefinition[From, To, FieldConst[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerDefinition[From, To, FieldConst[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -35,7 +36,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerDefinition[From, To, FieldConstPartial[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerDefinition[From, To, FieldConstPartial[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
   def withFieldComputedImpl[
@@ -48,7 +49,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerDefinition[From, To, FieldComputed[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerDefinition[From, To, FieldComputed[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -62,7 +63,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerDefinition[From, To, FieldComputedPartial[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerDefinition[From, To, FieldComputedPartial[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -75,7 +76,12 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
         def apply[FromField <: String: WeakTypeTag, ToField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerDefinition[From, To, FieldRelabelled[FromField, ToField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerDefinition[
+            From,
+            To,
+            FieldRelabelled[Select[FromField, Root], Select[ToField, Root], Cfg],
+            Flags
+          ]]
       }.applyFromSelectors(selectorFrom, selectorTo)
     )
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.PartialTransformerInto
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -9,7 +10,7 @@ import scala.reflect.macros.whitebox
 
 class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
 
-  import c.universe.*
+  import c.universe.{Select as _, *}
 
   def withFieldConstImpl[
       From: WeakTypeTag,
@@ -21,7 +22,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerInto[From, To, FieldConst[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerInto[From, To, FieldConst[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -35,7 +36,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerInto[From, To, FieldConstPartial[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerInto[From, To, FieldConstPartial[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -49,7 +50,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerInto[From, To, FieldComputed[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerInto[From, To, FieldComputed[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -63,7 +64,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerInto[From, To, FieldComputedPartial[FromField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerInto[From, To, FieldComputedPartial[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -76,7 +77,12 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
         def apply[FromField <: String: WeakTypeTag, ToField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[PartialTransformerInto[From, To, FieldRelabelled[FromField, ToField, Cfg], Flags]]
+          weakTypeTag[PartialTransformerInto[
+            From,
+            To,
+            FieldRelabelled[Select[FromField, Root], Select[ToField, Root], Cfg],
+            Flags
+          ]]
       }.applyFromSelectors(selectorFrom, selectorTo)
     )
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.TransformerDefinition
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -9,7 +10,7 @@ import scala.reflect.macros.whitebox
 
 class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
 
-  import c.universe.*
+  import c.universe.{Select as _, *}
 
   def withFieldConstImpl[
       From: WeakTypeTag,
@@ -21,7 +22,7 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[TransformerDefinition[From, To, FieldConst[FromField, Cfg], Flags]]
+          weakTypeTag[TransformerDefinition[From, To, FieldConst[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -35,7 +36,7 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[TransformerDefinition[From, To, FieldComputed[FromField, Cfg], Flags]]
+          weakTypeTag[TransformerDefinition[From, To, FieldComputed[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -48,7 +49,9 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
         def apply[FromField <: String: WeakTypeTag, ToField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[TransformerDefinition[From, To, FieldRelabelled[FromField, ToField, Cfg], Flags]]
+          weakTypeTag[
+            TransformerDefinition[From, To, FieldRelabelled[Select[FromField, Root], Select[ToField, Root], Cfg], Flags]
+          ]
       }.applyFromSelectors(selectorFrom, selectorTo)
     )
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.TransformerInto
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -9,7 +10,7 @@ import scala.reflect.macros.whitebox
 
 class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
 
-  import c.universe.*
+  import c.universe.{Select as _, *}
 
   def withFieldConstImpl[
       From: WeakTypeTag,
@@ -21,7 +22,7 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[TransformerInto[From, To, FieldConst[FromField, Cfg], Flags]]
+          weakTypeTag[TransformerInto[From, To, FieldConst[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -35,7 +36,7 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
     .asInstanceOfExpr(
       new ApplyFieldNameType {
         def apply[FromField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[TransformerInto[From, To, FieldComputed[FromField, Cfg], Flags]]
+          weakTypeTag[TransformerInto[From, To, FieldComputed[Select[FromField, Root], Cfg], Flags]]
       }.applyFromSelector(selector)
     )
 
@@ -48,7 +49,9 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
         def apply[FromField <: String: WeakTypeTag, ToField <: String: WeakTypeTag]: c.WeakTypeTag[?] =
-          weakTypeTag[TransformerInto[From, To, FieldRelabelled[FromField, ToField, Cfg], Flags]]
+          weakTypeTag[
+            TransformerInto[From, To, FieldRelabelled[Select[FromField, Root], Select[ToField, Root], Cfg], Flags]
+          ]
       }.applyFromSelectors(selectorFrom, selectorTo)
     )
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -200,5 +200,17 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
         val MacrosLogging: Type[runtime.PatcherFlags.MacrosLogging] = quoted.Type.of[runtime.PatcherFlags.MacrosLogging]
       }
     }
+
+    object Path extends PathModule {
+      val Root: Type[runtime.Path.Root] = quoted.Type.of[runtime.Path.Root]
+      object Select extends SelectModule {
+        def apply[Name <: String: Type, Instance <: runtime.Path: Type]: Type[runtime.Path.Select[Name, Instance]] =
+          quoted.Type.of[runtime.Path.Select[Name, Instance]]
+        def unapply[A](tpe: Type[A]): Option[(?<[String], ?<[runtime.Path])] = tpe match
+          case '[runtime.Path.Select[name, instance]] =>
+            Some((Type[name].as_?<[String], Type[instance].as_?<[runtime.Path]))
+          case _ => scala.None
+      }
+    }
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -47,49 +47,56 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
     object TransformerCfg extends TransformerCfgModule {
       val Empty: Type[runtime.TransformerCfg.Empty] = quoted.Type.of[runtime.TransformerCfg.Empty]
       object FieldConst extends FieldConstModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldConst[Name, Cfg]] =
           quoted.Type.of[runtime.TransformerCfg.FieldConst[Name, Cfg]]
-        def unapply[A](tpe: Type[A]): Option[(?<[String], ?<[runtime.TransformerCfg])] = tpe match
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerCfg])] = tpe match
           case '[runtime.TransformerCfg.FieldConst[name, c]] =>
-            Some((Type[name].as_?<[String], Type[c].as_?<[runtime.TransformerCfg]))
+            Some((Type[name].as_?<[runtime.Path], Type[c].as_?<[runtime.TransformerCfg]))
           case _ => scala.None
       }
       object FieldConstPartial extends FieldConstPartialModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldConstPartial[Name, Cfg]] =
           quoted.Type.of[runtime.TransformerCfg.FieldConstPartial[Name, Cfg]]
-        def unapply[A](tpe: Type[A]): Option[(?<[String], ?<[runtime.TransformerCfg])] = tpe match
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerCfg])] = tpe match
           case '[runtime.TransformerCfg.FieldConstPartial[name, c]] =>
-            Some((Type[name].as_>?<[Nothing, String], Type[c].as_>?<[Nothing, runtime.TransformerCfg]))
+            Some((Type[name].as_>?<[Nothing, runtime.Path], Type[c].as_>?<[Nothing, runtime.TransformerCfg]))
           case _ => scala.None
       }
       object FieldComputed extends FieldComputedModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldComputed[Name, Cfg]] =
           quoted.Type.of[runtime.TransformerCfg.FieldComputed[Name, Cfg]]
-        def unapply[A](tpe: Type[A]): Option[(?<[String], ?<[runtime.TransformerCfg])] = tpe match
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerCfg])] = tpe match
           case '[runtime.TransformerCfg.FieldComputed[name, c]] =>
-            Some((Type[name].as_?<[String], Type[c].as_?<[runtime.TransformerCfg]))
+            Some((Type[name].as_?<[runtime.Path], Type[c].as_?<[runtime.TransformerCfg]))
           case _ => scala.None
       }
       object FieldComputedPartial extends FieldComputedPartialModule {
-        def apply[Name <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[Name <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldComputedPartial[Name, Cfg]] =
           quoted.Type.of[runtime.TransformerCfg.FieldComputedPartial[Name, Cfg]]
-        def unapply[A](tpe: Type[A]): Option[(Nothing >?< String, Nothing >?< runtime.TransformerCfg)] = tpe match
+        def unapply[A](tpe: Type[A]): Option[(Nothing >?< runtime.Path, Nothing >?< runtime.TransformerCfg)] = tpe match
           case '[runtime.TransformerCfg.FieldComputedPartial[name, c]] =>
-            Some((Type[name].as_?<[String], Type[c].as_?<[runtime.TransformerCfg]))
+            Some((Type[name].as_?<[runtime.Path], Type[c].as_?<[runtime.TransformerCfg]))
           case _ => scala.None
       }
       object FieldRelabelled extends FieldRelabelledModule {
-        def apply[FromName <: String: Type, ToName <: String: Type, Cfg <: runtime.TransformerCfg: Type]
+        def apply[FromName <: runtime.Path: Type, ToName <: runtime.Path: Type, Cfg <: runtime.TransformerCfg: Type]
             : Type[runtime.TransformerCfg.FieldRelabelled[FromName, ToName, Cfg]] =
           quoted.Type.of[runtime.TransformerCfg.FieldRelabelled[FromName, ToName, Cfg]]
-        def unapply[A](tpe: Type[A]): Option[(?<[String], ?<[String], ?<[runtime.TransformerCfg])] = tpe match
-          case '[runtime.TransformerCfg.FieldRelabelled[fromName, toName, c]] =>
-            Some((Type[fromName].as_?<[String], Type[toName].as_?<[String], Type[c].as_?<[runtime.TransformerCfg]))
-          case _ => scala.None
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerCfg])] =
+          tpe match
+            case '[runtime.TransformerCfg.FieldRelabelled[fromName, toName, c]] =>
+              Some(
+                (
+                  Type[fromName].as_?<[runtime.Path],
+                  Type[toName].as_?<[runtime.Path],
+                  Type[c].as_?<[runtime.TransformerCfg]
+                )
+              )
+            case _ => scala.None
       }
       object CoproductInstance extends CoproductInstanceModule {
         def apply[InstType: Type, TargetType: Type, Cfg <: runtime.TransformerCfg: Type]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.PartialTransformer
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 import io.scalaland.chimney.partial
 
@@ -29,7 +30,7 @@ object PartialTransformerDefinitionMacros {
         '{
           WithRuntimeDataStore
             .update($td, $value)
-            .asInstanceOf[PartialTransformerDefinition[From, To, FieldConst[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerDefinition[From, To, FieldConst[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -52,7 +53,12 @@ object PartialTransformerDefinitionMacros {
         '{
           WithRuntimeDataStore
             .update($td, $value)
-            .asInstanceOf[PartialTransformerDefinition[From, To, FieldConstPartial[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerDefinition[
+              From,
+              To,
+              FieldConstPartial[Select[fieldNameT, Root], Cfg],
+              Flags
+            ]]
         }
     }
   }
@@ -75,7 +81,7 @@ object PartialTransformerDefinitionMacros {
         '{
           WithRuntimeDataStore
             .update($td, $f)
-            .asInstanceOf[PartialTransformerDefinition[From, To, FieldComputed[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerDefinition[From, To, FieldComputed[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -98,7 +104,12 @@ object PartialTransformerDefinitionMacros {
         '{
           WithRuntimeDataStore
             .update($td, $f)
-            .asInstanceOf[PartialTransformerDefinition[From, To, FieldComputedPartial[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerDefinition[
+              From,
+              To,
+              FieldComputedPartial[Select[fieldNameT, Root], Cfg],
+              Flags
+            ]]
         }
     }
   }
@@ -120,7 +131,12 @@ object PartialTransformerDefinitionMacros {
       case ('[FieldNameUtils.StringBounded[fieldNameFromT]], '[FieldNameUtils.StringBounded[fieldNameToT]]) =>
         '{
           $td.asInstanceOf[
-            PartialTransformerDefinition[From, To, FieldRelabelled[fieldNameFromT, fieldNameToT, Cfg], Flags]
+            PartialTransformerDefinition[
+              From,
+              To,
+              FieldRelabelled[Select[fieldNameFromT, Root], Select[fieldNameToT, Root], Cfg],
+              Flags
+            ]
           ]
         }
     }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.PartialTransformer
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 import io.scalaland.chimney.partial
 
@@ -29,7 +30,7 @@ object PartialTransformerIntoMacros {
         '{
           WithRuntimeDataStore
             .update($ti, $value)
-            .asInstanceOf[PartialTransformerInto[From, To, FieldConst[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerInto[From, To, FieldConst[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -52,7 +53,7 @@ object PartialTransformerIntoMacros {
         '{
           WithRuntimeDataStore
             .update($ti, $value)
-            .asInstanceOf[PartialTransformerInto[From, To, FieldConstPartial[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerInto[From, To, FieldConstPartial[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -75,7 +76,7 @@ object PartialTransformerIntoMacros {
         '{
           WithRuntimeDataStore
             .update($ti, $f)
-            .asInstanceOf[PartialTransformerInto[From, To, FieldComputed[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerInto[From, To, FieldComputed[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -98,7 +99,7 @@ object PartialTransformerIntoMacros {
         '{
           WithRuntimeDataStore
             .update($ti, $f)
-            .asInstanceOf[PartialTransformerInto[From, To, FieldComputedPartial[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[PartialTransformerInto[From, To, FieldComputedPartial[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -119,7 +120,12 @@ object PartialTransformerIntoMacros {
     (FieldNameUtils.strLiteralType(fieldNameFrom).asType, FieldNameUtils.strLiteralType(fieldNameTo).asType) match {
       case ('[FieldNameUtils.StringBounded[fieldNameFromT]], '[FieldNameUtils.StringBounded[fieldNameToT]]) =>
         '{
-          $ti.asInstanceOf[PartialTransformerInto[From, To, FieldRelabelled[fieldNameFromT, fieldNameToT, Cfg], Flags]]
+          $ti.asInstanceOf[PartialTransformerInto[
+            From,
+            To,
+            FieldRelabelled[Select[fieldNameFromT, Root], Select[fieldNameToT, Root], Cfg],
+            Flags
+          ]]
         }
     }
   }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.quoted.*
@@ -28,7 +29,7 @@ object TransformerDefinitionMacros {
         '{
           WithRuntimeDataStore
             .update($td, $value)
-            .asInstanceOf[TransformerDefinition[From, To, FieldConst[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[TransformerDefinition[From, To, FieldConst[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -51,7 +52,7 @@ object TransformerDefinitionMacros {
         '{
           WithRuntimeDataStore
             .update($td, $f)
-            .asInstanceOf[TransformerDefinition[From, To, FieldComputed[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[TransformerDefinition[From, To, FieldComputed[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -72,7 +73,12 @@ object TransformerDefinitionMacros {
     (FieldNameUtils.strLiteralType(fieldNameFrom).asType, FieldNameUtils.strLiteralType(fieldNameTo).asType) match {
       case ('[FieldNameUtils.StringBounded[fieldNameFromT]], '[FieldNameUtils.StringBounded[fieldNameToT]]) =>
         '{
-          $td.asInstanceOf[TransformerDefinition[From, To, FieldRelabelled[fieldNameFromT, fieldNameToT, Cfg], Flags]]
+          $td.asInstanceOf[TransformerDefinition[
+            From,
+            To,
+            FieldRelabelled[Select[fieldNameFromT, Root], Select[fieldNameToT, Root], Cfg],
+            Flags
+          ]]
         }
     }
   }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -5,6 +5,7 @@ import io.scalaland.chimney.internal.*
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.Path.*
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.quoted.*
@@ -29,7 +30,7 @@ object TransformerIntoMacros {
         '{
           WithRuntimeDataStore
             .update($ti, $value)
-            .asInstanceOf[TransformerInto[From, To, FieldConst[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[TransformerInto[From, To, FieldConst[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -52,7 +53,7 @@ object TransformerIntoMacros {
         '{
           WithRuntimeDataStore
             .update($ti, $f)
-            .asInstanceOf[TransformerInto[From, To, FieldComputed[fieldNameT, Cfg], Flags]]
+            .asInstanceOf[TransformerInto[From, To, FieldComputed[Select[fieldNameT, Root], Cfg], Flags]]
         }
     }
   }
@@ -73,7 +74,12 @@ object TransformerIntoMacros {
     (FieldNameUtils.strLiteralType(fieldNameFrom).asType, FieldNameUtils.strLiteralType(fieldNameTo).asType) match {
       case ('[FieldNameUtils.StringBounded[fieldNameFromT]], '[FieldNameUtils.StringBounded[fieldNameToT]]) =>
         '{
-          $ti.asInstanceOf[TransformerInto[From, To, FieldRelabelled[fieldNameFromT, fieldNameToT, Cfg], Flags]]
+          $ti.asInstanceOf[TransformerInto[
+            From,
+            To,
+            FieldRelabelled[Select[fieldNameFromT, Root], Select[fieldNameToT, Root], Cfg],
+            Flags
+          ]]
         }
     }
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -171,6 +171,18 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       }
     }
 
+    val Path: PathModule
+    trait PathModule { this: Path.type =>
+      val Root: Type[runtime.Path.Root]
+      val Select: SelectModule
+      trait SelectModule
+          extends Type.Ctor2UpperBounded[
+            String,
+            runtime.Path,
+            runtime.Path.Select
+          ] { this: Select.type => }
+    }
+
     // You can `import ChimneyType.Implicits.*` in your shared code to avoid providing types manually, while avoiding conflicts
     // with implicit types seen in platform-specific scopes (which would happen if those implicits were always used).
     object Implicits {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -43,7 +43,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       val FieldConst: FieldConstModule
       trait FieldConstModule
           extends Type.Ctor2UpperBounded[
-            String,
+            runtime.Path,
             runtime.TransformerCfg,
             runtime.TransformerCfg.FieldConst
           ] { this: FieldConst.type => }
@@ -51,7 +51,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       val FieldConstPartial: FieldConstPartialModule
       trait FieldConstPartialModule
           extends Type.Ctor2UpperBounded[
-            String,
+            runtime.Path,
             runtime.TransformerCfg,
             runtime.TransformerCfg.FieldConstPartial
           ] { this: FieldConstPartial.type => }
@@ -59,7 +59,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       val FieldComputed: FieldComputedModule
       trait FieldComputedModule
           extends Type.Ctor2UpperBounded[
-            String,
+            runtime.Path,
             runtime.TransformerCfg,
             runtime.TransformerCfg.FieldComputed
           ] { this: FieldComputed.type => }
@@ -67,7 +67,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       val FieldComputedPartial: FieldComputedPartialModule
       trait FieldComputedPartialModule
           extends Type.Ctor2UpperBounded[
-            String,
+            runtime.Path,
             runtime.TransformerCfg,
             runtime.TransformerCfg.FieldComputedPartial
           ] { this: FieldComputedPartial.type => }
@@ -75,8 +75,8 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       val FieldRelabelled: FieldRelabelledModule
       trait FieldRelabelledModule
           extends Type.Ctor3UpperBounded[
-            String,
-            String,
+            runtime.Path,
+            runtime.Path,
             runtime.TransformerCfg,
             runtime.TransformerCfg.FieldRelabelled
           ] { this: FieldRelabelled.type => }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -248,10 +248,17 @@ private[compiletime] trait Configurations { this: Derivation =>
     @scala.annotation.nowarn("msg=Unreachable case")
     private def extractPath[Field <: runtime.Path: Type]: String = Type[Field] match {
       case ChimneyType.Path.Select(fieldName, path) if path.value =:= ChimneyType.Path.Root =>
-        fieldName.value.extractStringSingleton
+        import fieldName.Underlying as FieldName, path.Underlying as Path
+        Type[Path] match {
+          case root if root =:= ChimneyType.Path.Root => Type[FieldName].extractStringSingleton
+          case _                                      =>
+            // $COVERAGE-OFF$
+            reportError(s"Nested paths ${Type.prettyPrint[Field]} are not supported!!")
+          // $COVERAGE-ON$
+        }
       case _ =>
         // $COVERAGE-OFF$
-        reportError(s"Nested paths ${Type.prettyPrint[Field]} are not supported!!")
+        reportError(s"Bad paths shape ${Type.prettyPrint[Field]}!!")
       // $COVERAGE-ON$
     }
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.internal.runtime
+
+sealed abstract class Path
+object Path {
+  final class Root extends Path
+  final class Select[Name <: String, Instance <: Path] extends Path
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerCfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerCfg.scala
@@ -3,11 +3,11 @@ package io.scalaland.chimney.internal.runtime
 sealed abstract class TransformerCfg
 object TransformerCfg {
   final class Empty extends TransformerCfg
-  final class FieldConst[Name <: String, Cfg <: TransformerCfg] extends TransformerCfg
-  final class FieldConstPartial[Name <: String, Cfg <: TransformerCfg] extends TransformerCfg
-  final class FieldComputed[Name <: String, Cfg <: TransformerCfg] extends TransformerCfg
-  final class FieldComputedPartial[Name <: String, Cfg <: TransformerCfg] extends TransformerCfg
-  final class FieldRelabelled[FromName <: String, ToName <: String, Cfg <: TransformerCfg] extends TransformerCfg
+  final class FieldConst[Field <: Path, Cfg <: TransformerCfg] extends TransformerCfg
+  final class FieldConstPartial[Field <: Path, Cfg <: TransformerCfg] extends TransformerCfg
+  final class FieldComputed[Field <: Path, Cfg <: TransformerCfg] extends TransformerCfg
+  final class FieldComputedPartial[Field <: Path, Cfg <: TransformerCfg] extends TransformerCfg
+  final class FieldRelabelled[FromField <: Path, ToField <: Path, Cfg <: TransformerCfg] extends TransformerCfg
   final class CoproductInstance[InstType, TargetType, Cfg <: TransformerCfg] extends TransformerCfg
   final class CoproductInstancePartial[InstType, TargetType, Cfg <: TransformerCfg] extends TransformerCfg
 }


### PR DESCRIPTION
This task intends to change the type level representation of paths used for fields overrides. It is necessary to enable future work on #358 without breaking binary compatibility (source compatibility would be preserved but someone linking to code compiled with older version might have issues, so it would force version bump to 0.9.0).

This task does NOT intend to implement #358 as 0.8.0 is intended to avoid additional features.

TODO:

 - [x] create `internal.runtime.Path` type
 - [x] create its representation in `ChimneyTypes`
 - [x] change `TransformerCfg` to use `Path` instead of `String`
 - [x] change DSL macros to return `Select["fieldName", Root]` instead of `String`
   - at this point nested path will still be rejected by DSL  
 - [x] change config parser to parse `Select["fieldName", Root]` to "fieldName"
   - at this point config parsing would also reject nested paths if anyone attempted them 