### PR TITLE
Update quickstart example to show bigger difference between code by hand and Chimney DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 Battle tested Scala library for boilerplate-free data transformations.
 
+What does it mean?
+
 Imagine you have strict domain definition of a `User` and much less strict
 API definition of a `UserAPI`:
 
@@ -34,7 +36,7 @@ Converting the strict representation to less strict is obvious and boring:
 val user = User(User.Name("John"), User.Surname("Smith"))
 
 // encoding domain to API by hand
-val userApi = UserAPI(Some(user.name.value), Some(user.surname.value))
+UserAPI(Some(user.name.value), Some(user.surname.value))
 ```
 
 Converting the less strict representation to strict is also obvious and boring,
@@ -44,11 +46,15 @@ and additionally long:
 val userApi = UserAPI(Some(user.name.value), Some(user.surname.value))
 
 // decoding API to domain by hand
-val userOpt = for {
+for {
   name <- user.name.map(User.Name)
   surname <- user.surname.map(User.Surname)
 } yield User(name, surname)
 ```
+
+You know how this code would look like to the letter. There is nothing new you
+would learn from reading it if someone else wrote it. And you need to write it
+and update any time your case classes change.
 
 The good news is that this obvious and boring code could be generated for you:
 
@@ -62,8 +68,12 @@ userApi.transformIntoPartial[User].asOption
 // Some(User(Name(John, Surname(Smith))))
 ```
 
-it can also be generated for you when you works with sealed hierarchies
-(including Scala 3's enum):
+Short, simple, easy! When you update the classes, it would update the generated
+code for you. Additionally, you need not worry that you forgot to change something
+as you copy-pasted pieces of the transformation ad nauseam!
+
+It can also be generated for you when you works with sealed hierarchies
+(including Scala 3's `enum`!):
 
 ```scala
 sealed trait UserStatusAPI

--- a/README.md
+++ b/README.md
@@ -15,73 +15,114 @@
 
 Battle tested Scala library for boilerplate-free data transformations.
 
-In the daily life of a strongly-typed language's programmer sometimes it
-happens we need to transform an object of one type to another object which
-contains a number of the same or similar fields in their definitions.
+Imagine you have strict domain definition of a `User` and much less strict
+API definition of a `UserAPI`:
 
 ```scala
-case class MakeCoffee(id: Int, kind: String, addict: String)
-case class CoffeeMade(id: Int, kind: String, forAddict: String, at: ZonedDateTime)
+case class User(name: User.Name, surname: User.Surname)
+object User {
+  case class Name(value: String) extends AnyVal
+  case class Surname(value: String) extends AnyVal
+}
+
+case class UserAPI(name: Option[String], surname: Option[String])
 ```
-Usual approach is to just rewrite fields one by one
+
+Converting the strict representation to less strict is obvious and boring:
+
 ```scala
-val command = MakeCoffee(id = Random.nextInt,
-                         kind = "Espresso",
-                         addict = "Piotr")
-val event = CoffeeMade(id = command.id,
-                       kind = command.kind,
-                       forAddict = command.addict,
-                       at = ZonedDateTime.now)
+val user = User(User.Name("John"), User.Surname("Smith"))
+
+// encoding domain to API by hand
+val userApi = UserAPI(Some(user.name.value), Some(user.surname.value))
 ```
 
-While the example stays lean, in real-life code we usually end up with tons
-of such boilerplate, especially when:
+Converting the less strict representation to strict is also obvious and boring,
+and additionally long:
 
-- we keep separate models of different layers in the system
-- we apply practices like DDD (Domain-Driven-Design) where suggested
-  approach is to separate models of different bounded contexts
-- we use code-generation tools like Protocol Buffers that generate primitive
-  types like `Int` or `String`, while you'd prefer to use value objects in your
-  domain-level code to improve type-safety and readability
-- we maintain typed, versioned schemas and want to migrate between multiple schema versions
+```scala
+val userApi = UserAPI(Some(user.name.value), Some(user.surname.value))
 
-Chimney provides a compact DSL with which you can define transformation
-rules and transform your objects with as little boilerplate as possible.
+// decoding API to domain by hand
+val userOpt = for {
+  name <- user.name.map(User.Name)
+  surname <- user.surname.map(User.Surname)
+} yield User(name, surname)
+```
+
+The good news is that this obvious and boring code could be generated for you:
 
 ```scala
 import io.scalaland.chimney.dsl._
 
-val event = command.into[CoffeeMade]
-  .withFieldComputed(_.at, _ => ZonedDateTime.now)
-  .withFieldRenamed(_.addict, _.forAddict)
-  .transform
-  // CoffeeMade(24, "Espresso", "Piotr", "2020-02-03T20:26:59.659647+07:00[Europe/Warsaw]")
+user.transformInto[UserAPI]
+// UserAPI(John, Smith)
+
+userApi.transformIntoPartial[User].asOption
+// Some(User(Name(John, Surname(Smith))))
 ```
 
-For computations that may potentially fail, Chimney provides partial transformers.
+it can also be generated for you when you works with sealed hierarchies
+(including Scala 3's enum):
 
 ```scala
-import io.scalaland.chimney.dsl._
-import io.scalaland.chimney.partial._
+sealed trait UserStatusAPI
+object UserStatusAPI {
+  case object Active extends UserStatusAPI
+  case class Inactive(cause: String) extends UserStatusAPI
+}
 
-case class UserForm(name: String, ageInput: String, email: Option[String])
-case class User(name: String, age: Int, email: String)
+enum UserStatus:
+  case Active
+  case Inactive(cause: String)
 
-UserForm("John", "21", Some("john@example.com"))
-  .intoPartial[User]
-  .withFieldComputedPartial(_.age, form => Result.fromCatching(form.ageInput.toInt))
-  .transform
-  .asOption  // Some(User("name", 21, "john@example.com"))
-
-val result = UserForm("Ted", "eighteen", None)
-  .intoPartial[User]
-  .withFieldComputedPartial(_.age, form => Result.fromCatching(form.ageInput.toInt))
-  .transform
+val userStatusAPI: UserStatusAPI = UserStatusAPI.Active
+val userStatus: UserStatus = UserStatus.Inactive("banned")
+```
   
-result.asOption // None
-result.asErrorMessageStrings 
-// Iterable("age" -> "For input string: \"eighteen\"", "email" -> "empty value")
+```scala
+import io.scalaland.chimney.dsl._
+
+userStatusApi.transformInto[UserStatus]
+// UserStatus.Active
+
+userStatus.transformInto[UserStatusAPI]
+// UserStatusAPI.Inactive(banned)
 ```
+
+and Java Beans:
+
+```scala
+class UserBean {
+private var name: String = _
+private var surname: String = _
+
+  def getName: String = name
+  def setName(name: String): Unit = this.name = name
+
+  def getSurname: String = surname
+  def setSurname(surname: String): Unit = this.surname = surname
+
+  override def toString(): String = s"UserBean($name, $surname)"
+}
+
+val userBean = new UserBean()
+userBean.setName("John")
+userBean.setSurname("Smith")
+```
+
+```scala
+import io.scalaland.chimney.dsl._
+
+user.into[UserBean].enableBeanSetters.transform
+// UserBean(John, Smith)
+
+userBean.into[User].enableBeanGetters.transform
+// User(John, Smith)
+```
+
+With Chimney, this and much more can be safely generated for you by the compiler -
+the more repetitive transformation you have the more boilerplate you shrug off!
 
 The library uses Scala macros underneath, to give you:
 - type-safety at compile-time

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,8 @@ Welcome to Chimney's documentation!
 
 **Chimney** is a Scala library for boilerplate-free data transformations.
 
+What does it mean?
+
 Imagine you have strict domain definition of a ``User`` and much less strict
 API definition of a ``UserAPI``:
 
@@ -23,7 +25,7 @@ Converting the strict representation to less strict is obvious and boring:
   val user = User(User.Name("John"), User.Surname("Smith"))
 
   // encoding domain to API by hand
-  val userApi = UserAPI(Some(user.name.value), Some(user.surname.value))
+  UserAPI(Some(user.name.value), Some(user.surname.value))
 
 Converting the less strict representation to strict is also obvious and boring,
 and additionally long:
@@ -33,10 +35,14 @@ and additionally long:
   val userApi = UserAPI(Some(user.name.value), Some(user.surname.value))
 
   // decoding API to domain by hand
-  val userOpt = for {
+  for {
     name <- user.name.map(User.Name)
     surname <- user.surname.map(User.Surname)
   } yield User(name, surname)
+
+You know how this code would look like to the letter. There is nothing new you
+would learn from reading it if someone else wrote it. And you need to write it
+and update any time your case classes change.
 
 The good news is that this obvious and boring code could be generated for you:
 
@@ -50,11 +56,12 @@ The good news is that this obvious and boring code could be generated for you:
   userApi.transformIntoPartial[User].asOption
   // Some(User(Name(John, Surname(Smith))))
 
-Simple and easy! And no need to worry that you forgot to change something
+Short, simple, easy! When you update the classes, it would update the generated
+code for you. Additionally, you need not worry that you forgot to change something
 as you copy-pasted pieces of the transformation ad nauseam!
 
 It can also be generated for you when you works with sealed hierarchies
-(including Scala 3's enum):
+(including Scala 3's ``enum``!):
 
 .. code-block:: scala
 

--- a/docs/source/transformers/standard-transformers.rst
+++ b/docs/source/transformers/standard-transformers.rst
@@ -36,6 +36,33 @@ transformer: ``Transformer[T, U]``.
   (new Car(180, 5)).transformInto[Vehicle]
   // Vehicle(180.0)
 
+
+Case classes
+------------
+
+Given types ``T`` and ``U`` such that both are case classes,
+and that each field in ``U`` type has a corresponding field in ``T``,
+Chimney is able to use fields in ``T`` as sources for values in ``U`` fields
+to generate transformer: ``Transformer[T, U]``.
+
+.. code-block:: scala
+
+  case class User(name: String, surname: String, age: Int)
+  case class AgelessUser(name: String, surname: String)
+
+  User("John", "Smith", 21).transformInto[AgelessUser]
+  // AgelessUser(John, Smith)
+
+.. note::
+
+  Actually, Chimney doesn't restrict itself only to case classes -
+  what it actually requires is that ``T`` type has public ``val`` s
+  (so they can be read) and ``U`` type has a public primary constructor
+  (so it can be called). If you want to customize transformation, then
+  the constructor's arguments matching names and types of its ``val`` s
+  (so that you could refer to them in DSL).
+
+
 Value classes
 -------------
 
@@ -58,6 +85,31 @@ them in a special way, supporting automatic value class field extraction and wra
   // plain.Person(10, "Bill", 30)
   val richPerson2 = plainPerson.transformInto[rich.Person]
   // rich.Person(PersonId(10), PersonName("Bill"), 30)
+
+
+Sealed hierarchies and enums
+----------------------------
+
+Given types ``T`` and ``U`` such that both are sealed traits/abstract classes,
+where each ``T`` subtype has a corresponding ``U`` subtype, and for each such
+pair transformation can be generated, Chimney is able to pattern-match each value
+from ``T`` and transform it to a corresponding ``U`` 's subtype value, while
+creating ``transformer: Transformer[T, U]``.
+
+.. code-block:: scala
+
+  sealed trait UserStatusAPI
+  object UserStatusAPI {
+    case object Active extends UserStatusAPI
+    case class Inactive(cause: String) extends UserStatusAPI
+    case object Unknown extends UserStatusAPI
+  }
+
+  enum UserStatus:
+    case Active
+    case Inactive(cause: String)
+
+  (UserStatus.Inactive("banned"): UserStatus).transformInto[UserStatusAPI]
 
 
 Options


### PR DESCRIPTION
Additionally, add case classes and sealed hierarchies to standard transformers docs page (which would address https://github.com/scalalandio/chimney/issues/97).

[Preview of a readme](https://github.com/scalalandio/chimney/blob/change-quickstart-examples/README.md)

[Preview of docs](https://chimney--382.org.readthedocs.build/en/382/)