### PR TITLE
Refactor rules

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
@@ -31,7 +31,7 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
         ctx.src.upcastExpr[Left[FromL, FromR]].value
       ).flatMap { (derivedToL: TransformationExpr[ToL]) =>
         // We're constructing:
-        // '{ Left( ${ derivedToL } ) // from ${ src }.value }
+        // '{ Left( ${ derivedToL } ) /* from ${ src }.value */ }
         DerivationResult.expanded(derivedToL.map(Expr.Either.Left[ToL, ToR](_).upcastExpr[To]))
       }
 
@@ -42,7 +42,7 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
         ctx.src.upcastExpr[Right[FromL, FromR]].value
       ).flatMap { (derivedToR: TransformationExpr[ToR]) =>
         // We're constructing:
-        // '{ Right( ${ derivedToR } ) // from ${ src }.value }
+        // '{ Right( ${ derivedToR } ) /* from ${ src }.value */ }
         DerivationResult.expanded(derivedToR.map(Expr.Either.Right[ToL, ToR](_).upcastExpr[To]))
       }
 
@@ -73,9 +73,9 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
               case (Left(totalToLeft), Left(totalToRight)) =>
                 // We're constructing:
                 // '{ ${ src }.fold {
-                //    left: $fromL => Left(${ derivedToL })
+                //    left: $FromL => Left(${ derivedToL })
                 // } {
-                //    right: $fromR => Right(${ derivedToR })
+                //    right: $FromR => Right(${ derivedToR })
                 // }
                 TransformationExpr.fromTotal(
                   ctx.src
@@ -89,9 +89,9 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
               case _ =>
                 // We're constructing:
                 // '{ ${ src }.fold {
-                //    left: $fromL => ${ derivedToL }.map(Left(_))
+                //    left: $FromL => ${ derivedToL }.map(Left(_))
                 // } {
-                //    right: $fromR => ${ derivedToR }.map(Right(_))
+                //    right: $FromR => ${ derivedToR }.map(Right(_))
                 // }
                 TransformationExpr.fromPartial(
                   ctx.src

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
@@ -9,43 +9,46 @@ private[compiletime] trait TransformImplicitRuleModule { this: Derivation =>
   protected object TransformImplicitRule extends Rule("Implicit") {
 
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
-      ctx match {
-        case _ if !ctx.config.areOverridesEmpty =>
-          DerivationResult.log(
-            "Configuration has defined overrides - implicit summoning is skipped"
-          ) >> DerivationResult.attemptNextRule
-        case TransformationContext.ForTotal(src) =>
-          summonTransformerSafe[From, To].fold(DerivationResult.attemptNextRule[To]) { totalTransformer =>
+      if (ctx.config.areOverridesEmpty) transformWithImplicitIfAvailable[From, To]
+      else
+        DerivationResult.log("Configuration has defined overrides - attempt to summon implicits is skipped") >>
+          DerivationResult.attemptNextRule
+
+    private def transformWithImplicitIfAvailable[From, To](implicit
+        ctx: TransformationContext[From, To]
+    ): DerivationResult[Rule.ExpansionResult[To]] = ctx match {
+      case TransformationContext.ForTotal(src) =>
+        summonTransformerSafe[From, To].fold(DerivationResult.attemptNextRule[To]) { totalTransformer =>
+          // We're constructing:
+          // '{ ${ totalTransformer }.transform(${ src }) } }
+          DerivationResult.expandedTotal(totalTransformer.transform(src))
+        }
+      case TransformationContext.ForPartial(src, failFast) =>
+        import ctx.config.flags.implicitConflictResolution
+        (summonTransformerSafe[From, To], summonPartialTransformerSafe[From, To]) match {
+          case (Some(total), Some(partial)) if implicitConflictResolution.isEmpty =>
+            // TODO: change from immediately terminating error to DerivationResult.fail
+            reportError(
+              s"""Ambiguous implicits while resolving Chimney recursive transformation:
+                 |
+                 |PartialTransformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(partial)}
+                 |Transformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(total)}
+                 |
+                 |Please eliminate ambiguity from implicit scope or use enableImplicitConflictResolution/withFieldComputed/withFieldComputedPartial to decide which one should be used
+                 |""".stripMargin
+            )
+          case (Some(totalTransformer), partialTransformerOpt)
+              if partialTransformerOpt.isEmpty || implicitConflictResolution.contains(PreferTotalTransformer) =>
             // We're constructing:
             // '{ ${ totalTransformer }.transform(${ src }) } }
             DerivationResult.expandedTotal(totalTransformer.transform(src))
-          }
-        case TransformationContext.ForPartial(src, failFast) =>
-          import ctx.config.flags.implicitConflictResolution
-          (summonTransformerSafe[From, To], summonPartialTransformerSafe[From, To]) match {
-            case (Some(total), Some(partial)) if implicitConflictResolution.isEmpty =>
-              // TODO: change from immediately terminating error to DerivationResult.fail
-              reportError(
-                s"""Ambiguous implicits while resolving Chimney recursive transformation:
-                   |
-                   |PartialTransformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(partial)}
-                   |Transformer[${Type.prettyPrint[From]}, ${Type.prettyPrint[To]}]: ${Expr.prettyPrint(total)}
-                   |
-                   |Please eliminate ambiguity from implicit scope or use enableImplicitConflictResolution/withFieldComputed/withFieldComputedPartial to decide which one should be used
-                   |""".stripMargin
-              )
-            case (Some(totalTransformer), partialTransformerOpt)
-                if partialTransformerOpt.isEmpty || implicitConflictResolution.contains(PreferTotalTransformer) =>
-              // We're constructing:
-              // '{ ${ totalTransformer }.transform(${ src }) } }
-              DerivationResult.expandedTotal(totalTransformer.transform(src))
-            case (totalTransformerOpt, Some(partialTransformer))
-                if totalTransformerOpt.isEmpty || implicitConflictResolution.contains(PreferPartialTransformer) =>
-              // We're constructing:
-              // '{ ${ partialTransformer }.transform(${ src }, ${ failFast }) } }
-              DerivationResult.expandedPartial(partialTransformer.transform(src, failFast))
-            case _ => DerivationResult.attemptNextRule
-          }
-      }
+          case (totalTransformerOpt, Some(partialTransformer))
+              if totalTransformerOpt.isEmpty || implicitConflictResolution.contains(PreferPartialTransformer) =>
+            // We're constructing:
+            // '{ ${ partialTransformer }.transform(${ src }, ${ failFast }) } }
+            DerivationResult.expandedPartial(partialTransformer.transform(src, failFast))
+          case _ => DerivationResult.attemptNextRule
+        }
+    }
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -16,118 +16,144 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
     @scala.annotation.nowarn
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       (Type[From], Type[To], ctx) match {
-        case (Type.Map(fromK, fromV), IterableOrArray(to2), TransformationContext.ForPartial(src, failFast))
+        case (Type.Map(fromK, fromV), IterableOrArray(to2), TransformationContext.ForPartial(_, failFast))
             if to2.Underlying.isTuple =>
           // val Type.Tuple2(toK, toV) = to2: @unchecked
           val (toK, toV) = Type.Tuple2.unapply(to2.Underlying).get
-          import fromK.Underlying as FromK, fromV.Underlying as FromV, toV.Underlying as ToV, toK.Underlying as ToK,
-            to2.Underlying as To2
-          val toKeyResult = ExprPromise
-            .promise[fromK.Underlying](ExprPromise.NameGenerationStrategy.FromPrefix("key"))
-            .traverse { key =>
-              deriveRecursiveTransformationExpr[fromK.Underlying, toK.Underlying](key).map(_.ensurePartial -> key)
-            }
-          val toValueResult = ExprPromise
-            .promise[fromV.Underlying](ExprPromise.NameGenerationStrategy.FromPrefix("value"))
-            .traverse { value =>
-              deriveRecursiveTransformationExpr[fromV.Underlying, toV.Underlying](value).map(_.ensurePartial)
-            }
-
-          toKeyResult.parTuple(toValueResult).parTuple(to2.value.factory).flatMap {
-            case ((toKeyP, toValueP), factory) =>
-              DerivationResult.expandedPartial(
-                ChimneyExpr.PartialResult
-                  .traverse[To, (fromK.Underlying, fromV.Underlying), (toK.Underlying, toV.Underlying)](
-                    src.widenExpr[Map[fromK.Underlying, fromV.Underlying]].iterator,
-                    toKeyP
-                      .fulfilAsLambda2(toValueP) { case ((keyResult, key), valueResult) =>
-                        ChimneyExpr.PartialResult.product(
-                          keyResult.prependErrorPath(
-                            ChimneyExpr.PathElement.MapKey(key.upcastExpr[Any]).upcastExpr[partial.PathElement]
-                          ),
-                          valueResult.prependErrorPath(
-                            ChimneyExpr.PathElement.MapValue(key.upcastExpr[Any]).upcastExpr[partial.PathElement]
-                          ),
-                          failFast
-                        )
-                      }
-                      .tupled,
-                    failFast,
-                    factory.widenExpr[Factory[(toK.Underlying, toV.Underlying), To]]
-                  )
-              )
-          }
+          import to2.Underlying as InnerTo, fromK.Underlying as FromK, fromV.Underlying as FromV, toV.Underlying as ToV,
+            toK.Underlying as ToK
+          mapPartialMaps[From, To, InnerTo, FromK, FromV, ToK, ToV](to2.value, failFast)
         case (IterableOrArray(from2), IterableOrArray(to2), _) =>
-          import from2.{Underlying as From2, value as fromIorA}, to2.{Underlying as To2, value as toIorA}
-          ExprPromise
-            .promise[from2.Underlying](ExprPromise.NameGenerationStrategy.FromExpr(ctx.src))
-            .traverse { (newFromSrc: Expr[from2.Underlying]) =>
-              deriveRecursiveTransformationExpr[from2.Underlying, to2.Underlying](newFromSrc)
-            }
-            .flatMap { (to2P: ExprPromise[from2.Underlying, TransformationExpr[to2.Underlying]]) =>
-              to2P.foldTransformationExpr { (totalP: ExprPromise[from2.Underlying, Expr[to2.Underlying]]) =>
-                // After mapping we don't know the exact static type here, but we might check the values
-                // to see if we could skip .to(factory) part
-                lazy val mappedFrom = fromIorA.map(ctx.src)(totalP.fulfilAsLambda[to2.Underlying])
-                if (Type[from2.Underlying] =:= Type[to2.Underlying]) {
-                  toIorA.factory.flatMap { (factory: Expr[Factory[to2.Underlying, To]]) =>
-                    // We're constructing:
-                    // '{ ${ src }.to(Factory[$To, $to2]) }
-                    DerivationResult.expandedTotal(
-                      fromIorA.to[To](ctx.src)(factory.upcastExpr[Factory[from2.Underlying, To]])
-                    )
-                  }
-                } else if (mappedFrom.Underlying =:= Type[To]) {
-                  // We're constructing:
-                  // '{ ${ src }.map(from2 => ${ derivedTo2 }) }
-                  import mappedFrom.{Underlying, value as expr}
-                  DerivationResult.expandedTotal(expr.upcastExpr[To])
-                } else {
-                  // We're constructing
-                  // '{ ${ src }.iterator.map(from2 => ${ derivedTo2 }).to(Factory[$To, $to2]) }
-                  toIorA.factory.flatMap { (factory: Expr[Factory[to2.Underlying, To]]) =>
-                    DerivationResult.expandedTotal(
-                      fromIorA.iterator(ctx.src).map(totalP.fulfilAsLambda[to2.Underlying]).to[To](factory)
-                    )
-                  }
-                }
-              } { (partialP: ExprPromise[from2.Underlying, Expr[partial.Result[to2.Underlying]]]) =>
-                ctx match {
-                  case TransformationContext.ForPartial(src, failFast) =>
-                    // We're constructing:
-                    // '{ partial.Result.traverse[To, ($from2, Int), $to2](
-                    //   ${ src }.iterator.zipWithIndex,
-                    //   { case (value, index) =>
-                    //     ${ resultTo }.prependErrorPath(partial.PathElement.Index(index))
-                    //   },
-                    //   ${ failFast }
-                    // )(${ factory })
-                    toIorA.factory.flatMap { (factory: Expr[Factory[to2.Underlying, To]]) =>
-                      DerivationResult.expandedPartial(
-                        ChimneyExpr.PartialResult.traverse[To, (from2.Underlying, Int), to2.Underlying](
-                          fromIorA.iterator(src).zipWithIndex,
-                          partialP
-                            .fulfilAsLambda2(
-                              ExprPromise.promise[Int](ExprPromise.NameGenerationStrategy.FromPrefix("idx"))
-                            ) { (result: Expr[partial.Result[to2.Underlying]], idx: Expr[Int]) =>
-                              result.prependErrorPath(
-                                ChimneyExpr.PathElement.Index(idx).upcastExpr[partial.PathElement]
-                              )
-                            }
-                            .tupled,
-                          failFast,
-                          factory
-                        )
-                      )
-                    }
-                  case TransformationContext.ForTotal(_) =>
-                    DerivationResult.assertionError("Derived Partial Expr for Total Context")
-                }
-              }
-            }
+          import from2.{Underlying as InnerFrom, value as fromIorA}, to2.{Underlying as InnerTo, value as toIorA}
+          mapIterables[From, To, InnerFrom, InnerTo](fromIorA, toIorA)
         case _ =>
           DerivationResult.attemptNextRule
       }
+
+    private def mapPartialMaps[From, To, InnerTo: Type, FromK: Type, FromV: Type, ToK: Type, ToV: Type](
+        toIorA: IterableOrArray[To, InnerTo],
+        failFast: Expr[Boolean]
+    )(implicit
+        ctx: TransformationContext[From, To]
+    ): DerivationResult[Rule.ExpansionResult[To]] = {
+      val toKeyResult = ExprPromise
+        .promise[FromK](ExprPromise.NameGenerationStrategy.FromPrefix("key"))
+        .traverse { key =>
+          deriveRecursiveTransformationExpr[FromK, ToK](key).map(_.ensurePartial -> key)
+        }
+      val toValueResult = ExprPromise
+        .promise[FromV](ExprPromise.NameGenerationStrategy.FromPrefix("value"))
+        .traverse { value =>
+          deriveRecursiveTransformationExpr[FromV, ToV](value).map(_.ensurePartial)
+        }
+
+      toKeyResult.parTuple(toValueResult).parTuple(toIorA.factory).flatMap { case ((toKeyP, toValueP), factory) =>
+        // We're constructing:
+        // '{ partial.Result.traverse(
+        //   ${ src }.iterator,
+        //   { case (fromKey, fromValue) =>
+        //     partial.Result.product(
+        //       ${ derivedToKey }.prependErrorPath(partial.PathElement.MapKey(fromKey)))
+        //       ${ derivedToValue }.prependErrorPath(partial.PathElement.MapValue(fromKey))),
+        //   },
+        //   ${ failFast }
+        // )(${ factory }) }
+        DerivationResult.expandedPartial(
+          ChimneyExpr.PartialResult
+            .traverse[To, (FromK, FromV), (ToK, ToV)](
+              ctx.src.widenExpr[Map[FromK, FromV]].iterator,
+              toKeyP
+                .fulfilAsLambda2(toValueP) { case ((keyResult, key), valueResult) =>
+                  ChimneyExpr.PartialResult.product(
+                    keyResult.prependErrorPath(
+                      ChimneyExpr.PathElement.MapKey(key.upcastExpr[Any]).upcastExpr[partial.PathElement]
+                    ),
+                    valueResult.prependErrorPath(
+                      ChimneyExpr.PathElement.MapValue(key.upcastExpr[Any]).upcastExpr[partial.PathElement]
+                    ),
+                    failFast
+                  )
+                }
+                .tupled,
+              failFast,
+              factory.widenExpr[Factory[(ToK, ToV), To]]
+            )
+        )
+      }
+    }
+
+    private def mapIterables[From, To, InnerFrom: Type, InnerTo: Type](
+        fromIorA: IterableOrArray[From, InnerFrom],
+        toIorA: IterableOrArray[To, InnerTo]
+    )(implicit
+        ctx: TransformationContext[From, To]
+    ): DerivationResult[Rule.ExpansionResult[To]] =
+      ExprPromise
+        .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromExpr(ctx.src))
+        .traverse { (newFromSrc: Expr[InnerFrom]) =>
+          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromSrc)
+        }
+        .flatMap { (to2P: ExprPromise[InnerFrom, TransformationExpr[InnerTo]]) =>
+          to2P.foldTransformationExpr { (totalP: ExprPromise[InnerFrom, Expr[InnerTo]]) =>
+            // After mapping we don't know the exact static type here, but we might check the values
+            // to see if we could skip .to(factory) part
+            lazy val mappedFrom = fromIorA.map(ctx.src)(totalP.fulfilAsLambda[InnerTo])
+            if (Type[InnerFrom] =:= Type[InnerTo]) {
+              toIorA.factory.flatMap { (factory: Expr[Factory[InnerTo, To]]) =>
+                // We're constructing:
+                // '{ ${ src }.to(Factory[$To, $InnerTo]) }
+                DerivationResult.expandedTotal(
+                  fromIorA.to[To](ctx.src)(factory.upcastExpr[Factory[InnerFrom, To]])
+                )
+              }
+            } else if (mappedFrom.Underlying =:= Type[To]) {
+              // We're constructing:
+              // '{ ${ src }.map(from2 => ${ derivedInnerTo }) }
+              import mappedFrom.{Underlying, value as expr}
+              DerivationResult.expandedTotal(expr.upcastExpr[To])
+            } else {
+              // We're constructing
+              // '{ ${ src }.iterator.map(from2 => ${ derivedInnerTo }).to(Factory[$To, $InnerTo]) }
+              toIorA.factory.flatMap { (factory: Expr[Factory[InnerTo, To]]) =>
+                DerivationResult.expandedTotal(
+                  fromIorA.iterator(ctx.src).map(totalP.fulfilAsLambda[InnerTo]).to[To](factory)
+                )
+              }
+            }
+          } { (partialP: ExprPromise[InnerFrom, Expr[partial.Result[InnerTo]]]) =>
+            ctx match {
+              case TransformationContext.ForPartial(src, failFast) =>
+                // We're constructing:
+                // '{ partial.Result.traverse[To, ($InnerFrom, Int), $InnerTo](
+                //   ${ src }.iterator.zipWithIndex,
+                //   { case (value, index) =>
+                //     ${ resultTo }.prependErrorPath(partial.PathElement.Index(index))
+                //   },
+                //   ${ failFast }
+                // )(${ factory }) }
+                toIorA.factory.flatMap { (factory: Expr[Factory[InnerTo, To]]) =>
+                  DerivationResult.expandedPartial(
+                    ChimneyExpr.PartialResult.traverse[To, (InnerFrom, Int), InnerTo](
+                      fromIorA.iterator(src).zipWithIndex,
+                      partialP
+                        .fulfilAsLambda2(
+                          ExprPromise.promise[Int](ExprPromise.NameGenerationStrategy.FromPrefix("idx"))
+                        ) { (result: Expr[partial.Result[InnerTo]], idx: Expr[Int]) =>
+                          result.prependErrorPath(
+                            ChimneyExpr.PathElement.Index(idx).upcastExpr[partial.PathElement]
+                          )
+                        }
+                        .tupled,
+                      failFast,
+                      factory
+                    )
+                  )
+                }
+              case TransformationContext.ForTotal(_) =>
+                DerivationResult.assertionError("Derived Partial Expr for Total Context")
+            }
+          }
+        }
 
     implicit private class IorAOps[M: Type, A: Type](@unused private val iora: IterableOrArray[M, A]) {
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -8,7 +8,7 @@ import io.scalaland.chimney.partial
 
 private[compiletime] trait TransformProductToProductRuleModule { this: Derivation =>
 
-  import Type.Implicits.*, ChimneyType.Implicits.*
+  import Type.Implicits.*, ChimneyType.Implicits.*, ProductType.areNamesMatching
 
   protected object TransformProductToProductRule extends Rule("ProductToProduct") {
 
@@ -17,506 +17,515 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       (Type[From], Type[To]) match {
         case (Product.Extraction(fromExtractors), Product.Constructor(parameters, constructor)) =>
-          import ctx.config.*
-          import ProductType.areNamesMatching
-
-          lazy val fromEnabledExtractors = fromExtractors
-            .filter { getter =>
-              getter._2.value.sourceType match {
-                case Product.Getter.SourceType.ConstructorVal => true
-                case Product.Getter.SourceType.AccessorMethod => flags.methodAccessors
-                case Product.Getter.SourceType.JavaBeanGetter => flags.beanGetters
-              }
-            }
-            .filter { getter =>
-              getter._2.value.isLocal || flags.inheritedAccessors
-            }
-
-          val usePositionBasedMatching = Type[From].isTuple || Type[To].isTuple
-          lazy val ctorParamToGetter = parameters
-            .zip(fromEnabledExtractors)
-            .map { case ((toName, ctorParam), (fromName, getter)) =>
-              val t3 = (fromName, toName, getter)
-              ctorParam -> t3
-            }
-            .toMap
-
-          val verifyNoOverrideUnused = Traverse[List]
-            .parTraverse(
-              fieldOverrides.keys
-                .filterNot(fromName => parameters.keys.exists(toName => areNamesMatching(fromName, toName)))
-                .toList
-            ) { fromName =>
-              val tpeStr = Type.prettyPrint[To]
-              val params = parameters.keys.map(n => s"`$n`").mkString(", ")
-              DerivationResult.assertionError(
-                s"""|Assumed that parameter/setter $fromName is a part of $tpeStr, but wasn't found
-                    |available methods: $params""".stripMargin
-              )
-            }
-
-          DerivationResult.log {
-            val gettersStr = fromExtractors
-              .map { case (k, v) =>
-                s"`$k`: ${Type.prettyPrint(v.Underlying)} (${v.value.sourceType}, ${if (v.value.isLocal) "declared"
-                  else "inherited"})"
-              }
-              .mkString(", ")
-            val constructorStr = parameters
-              .map { case (k, v) =>
-                s"`$k`: ${Type.prettyPrint(v.Underlying)} (${v.value.targetType}, default = ${v.value.defaultValue
-                    .map(a => Expr.prettyPrint(a))})"
-              }
-              .mkString(", ")
-            s"Resolved ${Type.prettyPrint[From]} getters: ($gettersStr) and ${Type.prettyPrint[To]} constructor ($constructorStr)"
-          } >> verifyNoOverrideUnused >>
-            Traverse[List]
-              .parTraverse[
-                DerivationResult,
-                (String, Existential[Product.Parameter]),
-                (String, Existential[TransformationExpr])
-              ](
-                parameters.toList
-              ) { case (toName: String, ctorParam: Existential[Product.Parameter]) =>
-                import ctorParam.Underlying as CtorParam, ctorParam.value.defaultValue
-                fieldOverrides
-                  // user might have used _.getName in modifier, to define target we know as _.setName
-                  // so simple .get(toName) might not be enough
-                  .collectFirst { case (fromName, value) if areNamesMatching(fromName, toName) => fromName -> value }
-                  .map {
-                    case (_, RuntimeFieldOverride.Const(runtimeDataIdx)) =>
-                      // We're constructing:
-                      // '{ ${ runtimeDataStore }(idx).asInstanceOf[$ctorParam] }
-                      DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                        TransformationExpr.fromTotal(
-                          ctx.runtimeDataStore(runtimeDataIdx).asInstanceOfExpr[ctorParam.Underlying]
-                        )
-                      )
-                    case (fromName, RuntimeFieldOverride.ConstPartial(runtimeDataIdx)) =>
-                      // We're constructing:
-                      // '{
-                      //   ${ runtimeDataStore }(idx)
-                      //     .asInstanceOf[partial.Result[$ctorParam]]
-                      //     .prependErrorPath(PathElement.Accessor("fromName"))
-                      //  }
-                      DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                        TransformationExpr.fromPartial(
-                          ctx
-                            .runtimeDataStore(runtimeDataIdx)
-                            .asInstanceOfExpr[partial.Result[ctorParam.Underlying]]
-                            .prependErrorPath(
-                              ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastExpr[partial.PathElement]
-                            )
-                        )
-                      )
-                    case (fromName, RuntimeFieldOverride.Computed(runtimeDataIdx)) =>
-                      ctx match {
-                        case TransformationContext.ForTotal(src) =>
-                          // We're constructing:
-                          // '{ ${ runtimeDataStore }(idx).asInstanceOf[$From => $ctorParam](${ src }) }
-                          DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                            TransformationExpr.fromTotal(
-                              ctx
-                                .runtimeDataStore(runtimeDataIdx)
-                                .asInstanceOfExpr[From => ctorParam.Underlying]
-                                .apply(src)
-                            )
-                          )
-                        case TransformationContext.ForPartial(src, _) =>
-                          // We're constructing:
-                          // '{
-                          //   partial.Result.fromFunction(
-                          //     ${ runtimeDataStore }(idx).asInstanceOf[$From => $ctorParam]
-                          //   )
-                          //   .apply(${ src })
-                          //   .prependErrorPath(PathElement.Accessor("fromName"))
-                          // }
-                          DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                            TransformationExpr.fromPartial(
-                              ChimneyExpr.PartialResult
-                                .fromFunction(
-                                  ctx
-                                    .runtimeDataStore(runtimeDataIdx)
-                                    .asInstanceOfExpr[From => ctorParam.Underlying]
-                                )
-                                .apply(src)
-                                .prependErrorPath(
-                                  ChimneyExpr.PathElement
-                                    .Accessor(Expr.String(fromName))
-                                    .upcastExpr[partial.PathElement]
-                                )
-                            )
-                          )
-                      }
-                    case (fromName, RuntimeFieldOverride.ComputedPartial(runtimeDataIdx)) =>
-                      // We're constructing:
-                      // '{
-                      //   ${ runtimeDataStore }(idx)
-                      //     .asInstanceOf[$From => partial.Result[$ctorParam]](${ src })
-                      //     .prependErrorPath(PathElement.Accessor("fromName"))
-                      // }
-                      DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                        TransformationExpr.fromPartial(
-                          ctx
-                            .runtimeDataStore(runtimeDataIdx)
-                            .asInstanceOfExpr[From => partial.Result[ctorParam.Underlying]]
-                            .apply(ctx.src)
-                            .prependErrorPath(
-                              ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastExpr[partial.PathElement]
-                            )
-                        )
-                      )
-                    case (_, RuntimeFieldOverride.RenamedFrom(sourceName)) =>
-                      fromExtractors
-                        .collectFirst { case (`sourceName`, getter) =>
-                          import getter.Underlying as Getter, getter.value.get
-                          DerivationResult.namedScope(
-                            s"Recursive derivation for field `$sourceName`: ${Type
-                                .prettyPrint[getter.Underlying]} renamed into `$toName`: ${Type
-                                .prettyPrint[ctorParam.Underlying]}"
-                          ) {
-                            // We're constructing:
-                            // '{ ${ derivedToElement } } // using ${ src.$name }
-                            deriveRecursiveTransformationExpr[getter.Underlying, ctorParam.Underlying](
-                              get(ctx.src)
-                            ).transformWith { expr =>
-                              // If we derived partial.Result[$ctorParam] we are appending
-                              //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
-                              DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                                appendPath(expr, sourceName)
-                              )
-                            } { errors =>
-                              appendMissingTransformer[From, To, getter.Underlying, ctorParam.Underlying](
-                                errors,
-                                toName
-                              )
-                            }
-                          }
-                        }
-                        .getOrElse {
-                          val tpeStr = Type.prettyPrint[From]
-                          val methods = fromExtractors.keys.map(n => s"`$n`").mkString(", ")
-                          DerivationResult.assertionError(
-                            s"""|Assumed that field $sourceName is a part of $tpeStr, but wasn't found
-                                |available methods: $methods""".stripMargin
-                          )
-                        }
-                  }
-                  .orElse(
-                    (if (usePositionBasedMatching) ctorParamToGetter.get(ctorParam)
-                     else
-                       fromEnabledExtractors.collectFirst {
-                         case (fromName, getter) if areNamesMatching(fromName, toName) =>
-                           (fromName, toName, getter)
-                       })
-                      .map { case (fromName, toName, getter) =>
-                        if (
-                          ctorParam.value.targetType == Product.Parameter.TargetType.SetterParameter && !flags.beanSetters
-                        )
-                          DerivationResult
-                            .notSupportedTransformerDerivation(ctx)
-                            .log(s"Matched $fromName to $toName but $toName is setter and they are disabled")
-                        else {
-                          import getter.Underlying, getter.value.get
-                          DerivationResult.namedScope(
-                            s"Recursive derivation for field `$fromName`: ${Type
-                                .prettyPrint[getter.Underlying]} into matched `$toName`: ${Type.prettyPrint[ctorParam.Underlying]}"
-                          ) {
-                            // We're constructing:
-                            // '{ ${ derivedToElement } } // using ${ src.$name }
-                            deriveRecursiveTransformationExpr[getter.Underlying, ctorParam.Underlying](
-                              get(ctx.src)
-                            ).transformWith { expr =>
-                              // If we derived partial.Result[$ctorParam] we are appending
-                              //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
-                              DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                                appendPath(expr, fromName)
-                              )
-                            } { errors =>
-                              appendMissingTransformer[From, To, getter.Underlying, ctorParam.Underlying](
-                                errors,
-                                toName
-                              )
-                            }
-                          }
-                        }
-                      }
-                      .orElse(
-                        if (usePositionBasedMatching)
-                          Option(
-                            DerivationResult.incompatibleSourceTuple(
-                              sourceArity = fromEnabledExtractors.size,
-                              targetArity = parameters.size
-                            )
-                          )
-                        else None
-                      )
-                  )
-                  .orElse(defaultValue.filter(_ => ctx.config.flags.processDefaultValues).map {
-                    (value: Expr[ctorParam.Underlying]) =>
-                      // We're constructing:
-                      // '{ ${ defaultValue } }
-                      DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                        TransformationExpr.fromTotal(value)
-                      )
-                  })
-                  .orElse {
-                    Option(Expr.Option.None)
-                      .filter(_ => Type[ctorParam.Underlying].isOption && ctx.config.flags.optionDefaultsToNone)
-                      .map(value =>
-                        // We're constructing:
-                        // '{ None }
-                        DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                          TransformationExpr.fromTotal(value.upcastExpr[ctorParam.Underlying])
-                        )
-                      )
-
-                  }
-                  .orElse {
-                    Option(Expr.Unit).filter(_ => Type[ctorParam.Underlying] =:= Type[Unit]).map { value =>
-                      // We're constructing:
-                      // '{ () }
-                      DerivationResult.existential[TransformationExpr, ctorParam.Underlying](
-                        TransformationExpr.fromTotal(value.upcastExpr[ctorParam.Underlying])
-                      )
-                    }
-                  }
-                  .getOrElse {
-                    ctorParam.value.targetType match {
-                      case Product.Parameter.TargetType.ConstructorParameter =>
-                        // TODO: update this for isLocal
-                        DerivationResult
-                          .missingAccessor[From, To, ctorParam.Underlying, Existential[TransformationExpr]](
-                            toName,
-                            fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
-                          )
-                      case Product.Parameter.TargetType.SetterParameter =>
-                        // TODO: update this for isLocal
-                        DerivationResult
-                          .missingJavaBeanSetterParam[From, To, ctorParam.Underlying, Existential[
-                            TransformationExpr
-                          ]](
-                            ProductType.dropSet(toName),
-                            fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
-                          )
-                    }
-                  }
-                  .logSuccess(expr => s"Resolved `$toName` field value to ${expr.value.prettyPrint}")
-                  .map(toName -> _)
-              }
-              .logSuccess { args =>
-                val totals = args.count(_._2.value.isTotal)
-                val partials = args.count(_._2.value.isPartial)
-                s"Resolved ${args.size} arguments, $totals as total and $partials as partial Expr"
-              }
-              .map[TransformationExpr[To]] { (resolvedArguments: List[(String, Existential[TransformationExpr])]) =>
-                val totalConstructorArguments: Map[String, ExistentialExpr] = resolvedArguments.collect {
-                  case (name, exprE) if exprE.value.isTotal => name -> exprE.mapK[Expr](_ => _.ensureTotal)
-                }.toMap
-
-                resolvedArguments.collect {
-                  case (name, exprE) if exprE.value.isPartial =>
-                    name -> exprE.mapK[PartialExpr] { implicit ExprE: Type[exprE.Underlying] => _.ensurePartial }
-                } match {
-                  case Nil =>
-                    // We're constructing:
-                    // '{ ${ constructor } }
-                    TransformationExpr.fromTotal(constructor(totalConstructorArguments))
-                  case (name, res) :: Nil =>
-                    // We're constructing:
-                    // '{ ${ res }.map($name => ${ constructor }) }
-                    import res.{Underlying, value as resultExpr}
-                    TransformationExpr.fromPartial(
-                      resultExpr.map(Expr.Function1.instance { (innerExpr: Expr[res.Underlying]) =>
-                        constructor(totalConstructorArguments + (name -> ExistentialExpr(innerExpr)))
-                      })
-                    )
-                  case (name1, res1) :: (name2, res2) :: Nil =>
-                    // We're constructing:
-                    // '{ partial.Result.map2(${ res1 }, ${ res2 }, { ($name1, $name2) =>
-                    //   ${ constructor }
-                    // }, ${ failFast }) }
-                    import res1.{Underlying as Res1, value as result1Expr},
-                      res2.{Underlying as Res2, value as result2Expr}
-                    ctx match {
-                      case TransformationContext.ForTotal(_) =>
-                        assertionFailed("Expected partial while got total")
-                      case TransformationContext.ForPartial(_, failFast) =>
-                        TransformationExpr.fromPartial(
-                          ChimneyExpr.PartialResult.map2(
-                            result1Expr,
-                            result2Expr,
-                            Expr.Function2.instance {
-                              (inner1Expr: Expr[res1.Underlying], inner2Expr: Expr[res2.Underlying]) =>
-                                constructor(
-                                  totalConstructorArguments +
-                                    (name1 -> ExistentialExpr(inner1Expr)) +
-                                    (name2 -> ExistentialExpr(inner2Expr))
-                                )
-                            },
-                            failFast
-                          )
-                        )
-                    }
-                  case partialConstructorArguments =>
-                    // We're constructing:
-                    // '{
-                    //   lazy val res1 = ...
-                    //   lazy val res2 = ...
-                    //   lazy val res3 = ...
-                    //   ...
-                    //
-                    //   if (${ failFast }) {
-                    //     res1.flatMap { $name1 =>
-                    //       res2.flatMap { $name2 =>
-                    //         res3.flatMap { $name3 =>
-                    //           ...
-                    //            resN.map { $nameN => ${ constructor } }
-                    //         }
-                    //       }
-                    //     }
-                    //   } else {
-                    //     var allerrors: Errors = null
-                    //     allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res1 })
-                    //     allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res2 })
-                    //     allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res3 })
-                    //     ...
-                    //     if (allerrors == null) {
-                    //       ${ constructor } // using res1.asInstanceOf[partial.Result.Value[Tpe]].value, ...
-                    //     } else {
-                    //       allerrors
-                    //     }
-                    //   }
-                    // }
-                    TransformationExpr.fromPartial(
-                      partialConstructorArguments
-                        .traverse[PrependDefinitionsTo, (String, Existential[PartialExpr])] {
-                          case (name: String, expr: Existential[PartialExpr]) =>
-                            // We start by building this initial block of '{ def resN = ${ derivedResultTo } }
-                            import expr.{Underlying, value as partialExpr}
-                            PrependDefinitionsTo
-                              .prependLazyVal(
-                                partialExpr,
-                                ExprPromise.NameGenerationStrategy.FromPrefix("res")
-                              )
-                              .map { (inner: Expr[partial.Result[expr.Underlying]]) =>
-                                name -> Existential[PartialExpr, expr.Underlying](inner)
-                              }
-                        }
-                        .use { (partialsAsLazy: List[(String, Existential[PartialExpr])]) =>
-                          val failFastBranch: Expr[partial.Result[To]] = {
-                            // Here, we're building:
-                            // '{
-                            //   res1.flatMap { $name1 =>
-                            //     res2.flatMap { $name2 =>
-                            //       res3.flatMap { $name3 =>
-                            //         ...
-                            //          resN.map { $nameN => ${ constructor } }
-                            //       }
-                            //     }
-                            // } }
-                            def nestFlatMaps(
-                                unusedPartials: List[(String, Existential[PartialExpr])],
-                                constructorArguments: Product.Arguments
-                            ): Expr[partial.Result[To]] = unusedPartials match {
-                              // Should never happen
-                              case Nil => ???
-                              // last result to compose in - use .map instead of .flatMap
-                              case (name, res) :: Nil =>
-                                import res.{Underlying, value as resultToMap}
-                                resultToMap.map(Expr.Function1.instance[res.Underlying, To] {
-                                  (innerExpr: Expr[res.Underlying]) =>
-                                    constructor(constructorArguments + (name -> ExistentialExpr(innerExpr)))
-                                })
-                              // use .flatMap
-                              case (name, res) :: tail =>
-                                import res.{Underlying, value as resultToFlatMap}
-                                resultToFlatMap.flatMap(
-                                  Expr.Function1.instance[res.Underlying, partial.Result[To]] {
-                                    (innerExpr: Expr[res.Underlying]) =>
-                                      nestFlatMaps(
-                                        tail,
-                                        constructorArguments + (name -> ExistentialExpr(innerExpr))
-                                      )
-                                  }
-                                )
-                            }
-
-                            nestFlatMaps(partialsAsLazy.toList, totalConstructorArguments)
-                          }
-
-                          val fullErrorBranch: Expr[partial.Result[To]] =
-                            // Here, we're building:
-                            // '{
-                            //   var allerrors: Errors = null
-                            //   allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res1 })
-                            //   allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res2 })
-                            //   allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res3 })
-                            //   ...
-                            //   if (allerrors == null) {
-                            //     partial.Result.Value(${ constructor }) // using res1.asInstanceOf[partial.Result.Value[Tpe]].value, ...
-                            //   } else {
-                            //     allerrors
-                            //   }
-                            // }
-                            PrependDefinitionsTo
-                              .prependVar[partial.Result.Errors](
-                                Expr.Null.asInstanceOfExpr[partial.Result.Errors],
-                                ExprPromise.NameGenerationStrategy.FromPrefix("allerrors")
-                              )
-                              .use { case (allerrors, setAllErrors) =>
-                                Expr.block(
-                                  partialsAsLazy.map { case (_, result) =>
-                                    import result.{Underlying, value as expr}
-                                    // Here, we're building:
-                                    // '{ allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ resN }) }
-                                    setAllErrors(ChimneyExpr.PartialResult.Errors.mergeResultNullable(allerrors, expr))
-                                  },
-                                  // Here, we're building:
-                                  // '{ if (allerrors == null) $ifBlock else $elseBock }
-                                  Expr.ifElse[partial.Result[To]](allerrors eqExpr Expr.Null) {
-                                    // Here, we're building:
-                                    // '{ partial.Result.Value(${ constructor }) } // using res1.asInstanceOf[partial.Result.Value[Tpe]].value, ...
-                                    ChimneyExpr.PartialResult
-                                      .Value[To](
-                                        constructor(
-                                          totalConstructorArguments ++ partialsAsLazy.map { case (name, result) =>
-                                            name -> result.mapK[Expr] {
-                                              implicit PartialExpr: Type[result.Underlying] =>
-                                                (expr: Expr[partial.Result[result.Underlying]]) =>
-                                                  expr
-                                                    .asInstanceOfExpr[partial.Result.Value[result.Underlying]]
-                                                    .value
-                                            }
-                                          }
-                                        )
-                                      )
-                                      .upcastExpr[partial.Result[To]]
-                                  } {
-                                    allerrors.upcastExpr[partial.Result[To]]
-                                  }
-                                )
-                              }
-
-                          ctx match {
-                            case TransformationContext.ForTotal(_) =>
-                              assertionFailed("Expected partial, got total")
-                            case TransformationContext.ForPartial(_, failFast) =>
-                              // Finally, we are combining:
-                              // if (${ failFast }) {
-                              //   ${ failFastBranch }
-                              // } else {
-                              //   ${ fullErrorBranch }
-                              // }
-                              Expr.ifElse[partial.Result[To]](failFast)(failFastBranch)(fullErrorBranch)
-                          }
-                        }
-                    )
-                }
-              }
-              .flatMap(DerivationResult.expanded)
+          mapOverridesAndExtractorsToConstructorArguments[From, To](fromExtractors, parameters, constructor)
         case _ => DerivationResult.attemptNextRule
       }
+
+    private def mapOverridesAndExtractorsToConstructorArguments[From, To](
+        fromExtractors: Product.Getters[From],
+        parameters: Product.Parameters,
+        constructor: Product.Arguments => Expr[To]
+    )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] = {
+      import ctx.config.*
+
+      lazy val fromEnabledExtractors = fromExtractors
+        .filter { getter =>
+          getter._2.value.sourceType match {
+            case Product.Getter.SourceType.ConstructorVal => true
+            case Product.Getter.SourceType.AccessorMethod => flags.methodAccessors
+            case Product.Getter.SourceType.JavaBeanGetter => flags.beanGetters
+          }
+        }
+        .filter { getter =>
+          getter._2.value.isLocal || flags.inheritedAccessors
+        }
+
+      val usePositionBasedMatching = Type[From].isTuple || Type[To].isTuple
+      lazy val ctorParamToGetter = parameters
+        .zip(fromEnabledExtractors)
+        .map { case ((toName, ctorParam), (fromName, getter)) =>
+          val t3 = (fromName, toName, getter)
+          ctorParam -> t3
+        }
+        .toMap
+
+      val verifyNoOverrideUnused = Traverse[List]
+        .parTraverse(
+          fieldOverrides.keys
+            .filterNot(fromName => parameters.keys.exists(toName => areNamesMatching(fromName, toName)))
+            .toList
+        ) { fromName =>
+          val tpeStr = Type.prettyPrint[To]
+          val params = parameters.keys.map(n => s"`$n`").mkString(", ")
+          DerivationResult.assertionError(
+            s"""|Assumed that parameter/setter $fromName is a part of $tpeStr, but wasn't found
+                |available methods: $params""".stripMargin
+          )
+        }
+
+      DerivationResult.log {
+        val gettersStr = fromExtractors
+          .map { case (k, v) =>
+            s"`$k`: ${Type.prettyPrint(v.Underlying)} (${v.value.sourceType}, ${if (v.value.isLocal) "declared"
+              else "inherited"})"
+          }
+          .mkString(", ")
+        val constructorStr = parameters
+          .map { case (k, v) =>
+            s"`$k`: ${Type.prettyPrint(v.Underlying)} (${v.value.targetType}, default = ${v.value.defaultValue
+                .map(a => Expr.prettyPrint(a))})"
+          }
+          .mkString(", ")
+        s"Resolved ${Type.prettyPrint[From]} getters: ($gettersStr) and ${Type.prettyPrint[To]} constructor ($constructorStr)"
+      } >> verifyNoOverrideUnused >>
+        Traverse[List]
+          .parTraverse[
+            DerivationResult,
+            (String, Existential[Product.Parameter]),
+            (String, Existential[TransformationExpr])
+          ](
+            parameters.toList
+          ) { case (toName: String, ctorParam: Existential[Product.Parameter]) =>
+            import ctorParam.Underlying as CtorParam, ctorParam.value.defaultValue
+            fieldOverrides
+              // user might have used _.getName in modifier, to define target we know as _.setName
+              // so simple .get(toName) might not be enough
+              .collectFirst { case (fromName, value) if areNamesMatching(fromName, toName) => fromName -> value }
+              .map { case (fromName, value) =>
+                useOverride[From, To, CtorParam](fromExtractors, fromName, toName, value)
+              }
+              .orElse {
+                val resolvedExtractor =
+                  if (usePositionBasedMatching) ctorParamToGetter.get(ctorParam)
+                  else
+                    fromEnabledExtractors.collectFirst {
+                      case (fromName, getter) if areNamesMatching(fromName, toName) => (fromName, toName, getter)
+                    }
+                resolvedExtractor
+                  .map { case (fromName, toName, getter) =>
+                    useExtractor[From, To, CtorParam](ctorParam.value.targetType, fromName, toName, getter)
+                  }
+                  .orElse[DerivationResult[Existential[TransformationExpr]]](
+                    if (usePositionBasedMatching)
+                      Option(
+                        DerivationResult.incompatibleSourceTuple(
+                          sourceArity = fromEnabledExtractors.size,
+                          targetArity = parameters.size
+                        )
+                      )
+                    else None
+                  )
+              }
+              .orElse(useFallbackValues[From, To, CtorParam](defaultValue))
+              .getOrElse[DerivationResult[Existential[TransformationExpr]]] {
+                ctorParam.value.targetType match {
+                  case Product.Parameter.TargetType.ConstructorParameter =>
+                    // TODO: update this for isLocal
+                    DerivationResult
+                      .missingAccessor[From, To, CtorParam, Existential[TransformationExpr]](
+                        toName,
+                        fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
+                      )
+                  case Product.Parameter.TargetType.SetterParameter =>
+                    // TODO: update this for isLocal
+                    DerivationResult
+                      .missingJavaBeanSetterParam[From, To, CtorParam, Existential[TransformationExpr]](
+                        ProductType.dropSet(toName),
+                        fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
+                      )
+                }
+              }
+              .logSuccess(expr => s"Resolved `$toName` field value to ${expr.value.prettyPrint}")
+              .map(toName -> _)
+          }
+          .logSuccess { args =>
+            val totals = args.count(_._2.value.isTotal)
+            val partials = args.count(_._2.value.isPartial)
+            s"Resolved ${args.size} arguments, $totals as total and $partials as partial Expr"
+          }
+          .map[TransformationExpr[To]] { (resolvedArguments: List[(String, Existential[TransformationExpr])]) =>
+            wireArgumentsToConstructor[From, To](resolvedArguments, constructor)
+          }
+          .flatMap(DerivationResult.expanded)
+    }
+
+    private def useOverride[From, To, CtorParam: Type](
+        fromExtractors: Product.Getters[From],
+        fromName: String,
+        toName: String,
+        runtimeFieldOverride: RuntimeFieldOverride
+    )(implicit
+        ctx: TransformationContext[From, To]
+    ): DerivationResult[Existential[TransformationExpr]] = runtimeFieldOverride match {
+      case RuntimeFieldOverride.Const(runtimeDataIdx) =>
+        // We're constructing:
+        // '{ ${ runtimeDataStore }(idx).asInstanceOf[$ctorParam] }
+        DerivationResult.existential[TransformationExpr, CtorParam](
+          TransformationExpr.fromTotal(
+            ctx.runtimeDataStore(runtimeDataIdx).asInstanceOfExpr[CtorParam]
+          )
+        )
+      case RuntimeFieldOverride.ConstPartial(runtimeDataIdx) =>
+        // We're constructing:
+        // '{
+        //   ${ runtimeDataStore }(idx)
+        //     .asInstanceOf[partial.Result[$ctorParam]]
+        //     .prependErrorPath(PathElement.Accessor("fromName"))
+        //  }
+        DerivationResult.existential[TransformationExpr, CtorParam](
+          TransformationExpr.fromPartial(
+            ctx
+              .runtimeDataStore(runtimeDataIdx)
+              .asInstanceOfExpr[partial.Result[CtorParam]]
+              .prependErrorPath(
+                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastExpr[partial.PathElement]
+              )
+          )
+        )
+      case RuntimeFieldOverride.Computed(runtimeDataIdx) =>
+        ctx match {
+          case TransformationContext.ForTotal(src) =>
+            // We're constructing:
+            // '{ ${ runtimeDataStore }(idx).asInstanceOf[$From => $ctorParam](${ src }) }
+            DerivationResult.existential[TransformationExpr, CtorParam](
+              TransformationExpr.fromTotal(
+                ctx.runtimeDataStore(runtimeDataIdx).asInstanceOfExpr[From => CtorParam].apply(src)
+              )
+            )
+          case TransformationContext.ForPartial(src, _) =>
+            // We're constructing:
+            // '{
+            //   partial.Result.fromFunction(
+            //     ${ runtimeDataStore }(idx).asInstanceOf[$From => $ctorParam]
+            //   )
+            //   .apply(${ src })
+            //   .prependErrorPath(PathElement.Accessor("fromName"))
+            // }
+            DerivationResult.existential[TransformationExpr, CtorParam](
+              TransformationExpr.fromPartial(
+                ChimneyExpr.PartialResult
+                  .fromFunction(
+                    ctx.runtimeDataStore(runtimeDataIdx).asInstanceOfExpr[From => CtorParam]
+                  )
+                  .apply(src)
+                  .prependErrorPath(
+                    ChimneyExpr.PathElement
+                      .Accessor(Expr.String(fromName))
+                      .upcastExpr[partial.PathElement]
+                  )
+              )
+            )
+        }
+      case RuntimeFieldOverride.ComputedPartial(runtimeDataIdx) =>
+        // We're constructing:
+        // '{
+        //   ${ runtimeDataStore }(idx)
+        //     .asInstanceOf[$From => partial.Result[$ctorParam]](${ src })
+        //     .prependErrorPath(PathElement.Accessor("fromName"))
+        // }
+        DerivationResult.existential[TransformationExpr, CtorParam](
+          TransformationExpr.fromPartial(
+            ctx
+              .runtimeDataStore(runtimeDataIdx)
+              .asInstanceOfExpr[From => partial.Result[CtorParam]]
+              .apply(ctx.src)
+              .prependErrorPath(
+                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastExpr[partial.PathElement]
+              )
+          )
+        )
+      case RuntimeFieldOverride.RenamedFrom(sourceName) =>
+        fromExtractors
+          .collectFirst { case (`sourceName`, getter) =>
+            import getter.Underlying as Getter, getter.value.get
+            DerivationResult.namedScope(
+              s"Recursive derivation for field `$sourceName`: ${Type
+                  .prettyPrint[Getter]} renamed into `$toName`: ${Type
+                  .prettyPrint[CtorParam]}"
+            ) {
+              // We're constructing:
+              // '{ ${ derivedToElement } } // using ${ src.$name }
+              deriveRecursiveTransformationExpr[Getter, CtorParam](get(ctx.src)).transformWith { expr =>
+                // If we derived partial.Result[$ctorParam] we are appending
+                //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
+                DerivationResult.existential[TransformationExpr, CtorParam](appendPath(expr, sourceName))
+              } { errors =>
+                appendMissingTransformer[From, To, Getter, CtorParam](errors, toName)
+              }
+            }
+          }
+          .getOrElse {
+            val tpeStr = Type.prettyPrint[From]
+            val methods = fromExtractors.keys.map(n => s"`$n`").mkString(", ")
+            DerivationResult.assertionError(
+              s"""|Assumed that field $sourceName is a part of $tpeStr, but wasn't found
+                  |available methods: $methods""".stripMargin
+            )
+          }
+    }
+
+    private def useExtractor[From, To, CtorParam: Type](
+        ctorTargetType: Product.Parameter.TargetType,
+        fromName: String,
+        toName: String,
+        getter: Existential[Product.Getter[From, *]]
+    )(implicit
+        ctx: TransformationContext[From, To]
+    ): DerivationResult[Existential[TransformationExpr]] =
+      if (ctorTargetType == Product.Parameter.TargetType.SetterParameter && !ctx.config.flags.beanSetters)
+        DerivationResult
+          .notSupportedTransformerDerivation(ctx)
+          .log(s"Matched $fromName to $toName but $toName is setter and they are disabled")
+      else {
+        import getter.Underlying as Getter, getter.value.get
+        DerivationResult.namedScope(
+          s"Recursive derivation for field `$fromName`: ${Type
+              .prettyPrint[Getter]} into matched `$toName`: ${Type.prettyPrint[CtorParam]}"
+        ) {
+          // We're constructing:
+          // '{ ${ derivedToElement } } // using ${ src.$name }
+          deriveRecursiveTransformationExpr[Getter, CtorParam](get(ctx.src)).transformWith { expr =>
+            // If we derived partial.Result[$ctorParam] we are appending
+            //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
+            DerivationResult.existential[TransformationExpr, CtorParam](appendPath(expr, fromName))
+          } { errors =>
+            appendMissingTransformer[From, To, Getter, CtorParam](errors, toName)
+          }
+        }
+      }
+
+    private def useFallbackValues[From, To, CtorParam: Type](
+        defaultValue: Option[Expr[CtorParam]]
+    )(implicit ctx: TransformationContext[From, To]): Option[DerivationResult[Existential[TransformationExpr]]] =
+      defaultValue
+        .filter(_ => ctx.config.flags.processDefaultValues)
+        .map { (value: Expr[CtorParam]) =>
+          // We're constructing:
+          // '{ ${ defaultValue } }
+          DerivationResult.existential[TransformationExpr, CtorParam](
+            TransformationExpr.fromTotal(value)
+          )
+        }
+        .orElse {
+          Option(Expr.Option.None)
+            .filter(_ => Type[CtorParam].isOption && ctx.config.flags.optionDefaultsToNone)
+            .map(value =>
+              // We're constructing:
+              // '{ None }
+              DerivationResult.existential[TransformationExpr, CtorParam](
+                TransformationExpr.fromTotal(value.upcastExpr[CtorParam])
+              )
+            )
+
+        }
+        .orElse {
+          Option(Expr.Unit).filter(_ => Type[CtorParam] =:= Type[Unit]).map { value =>
+            // We're constructing:
+            // '{ () }
+            DerivationResult.existential[TransformationExpr, CtorParam](
+              TransformationExpr.fromTotal(value.upcastExpr[CtorParam])
+            )
+          }
+        }
+
+    private def wireArgumentsToConstructor[From, To](
+        resolvedArguments: List[(String, Existential[TransformationExpr])],
+        constructor: Product.Arguments => Expr[To]
+    )(implicit ctx: TransformationContext[From, To]): TransformationExpr[To] = {
+      val totalConstructorArguments: Map[String, ExistentialExpr] = resolvedArguments.collect {
+        case (name, exprE) if exprE.value.isTotal => name -> exprE.mapK[Expr](_ => _.ensureTotal)
+      }.toMap
+
+      resolvedArguments.collect {
+        case (name, exprE) if exprE.value.isPartial =>
+          name -> exprE.mapK[PartialExpr] { implicit ExprE: Type[exprE.Underlying] => _.ensurePartial }
+      } match {
+        case Nil =>
+          // We're constructing:
+          // '{ ${ constructor } }
+          TransformationExpr.fromTotal(constructor(totalConstructorArguments))
+        case (name, res) :: Nil =>
+          // We're constructing:
+          // '{ ${ res }.map($name => ${ constructor }) }
+          import res.{Underlying as Res, value as resultExpr}
+          TransformationExpr.fromPartial(
+            resultExpr.map(Expr.Function1.instance { (innerExpr: Expr[Res]) =>
+              constructor(totalConstructorArguments + (name -> ExistentialExpr(innerExpr)))
+            })
+          )
+        case (name1, res1) :: (name2, res2) :: Nil =>
+          // We're constructing:
+          // '{ partial.Result.map2(${ res1 }, ${ res2 }, { ($name1, $name2) =>
+          //   ${ constructor }
+          // }, ${ failFast }) }
+          import res1.{Underlying as Res1, value as result1Expr}, res2.{Underlying as Res2, value as result2Expr}
+          ctx match {
+            case TransformationContext.ForTotal(_) =>
+              assertionFailed("Expected partial while got total")
+            case TransformationContext.ForPartial(_, failFast) =>
+              TransformationExpr.fromPartial(
+                ChimneyExpr.PartialResult.map2(
+                  result1Expr,
+                  result2Expr,
+                  Expr.Function2.instance { (inner1Expr: Expr[Res1], inner2Expr: Expr[Res2]) =>
+                    constructor(
+                      totalConstructorArguments +
+                        (name1 -> ExistentialExpr(inner1Expr)) +
+                        (name2 -> ExistentialExpr(inner2Expr))
+                    )
+                  },
+                  failFast
+                )
+              )
+          }
+        case partialConstructorArguments =>
+          // We're constructing:
+          // '{
+          //   lazy val res1 = ...
+          //   lazy val res2 = ...
+          //   lazy val res3 = ...
+          //   ...
+          //
+          //   if (${ failFast }) {
+          //     res1.flatMap { $name1 =>
+          //       res2.flatMap { $name2 =>
+          //         res3.flatMap { $name3 =>
+          //           ...
+          //            resN.map { $nameN => ${ constructor } }
+          //         }
+          //       }
+          //     }
+          //   } else {
+          //     var allerrors: Errors = null
+          //     allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res1 })
+          //     allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res2 })
+          //     allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res3 })
+          //     ...
+          //     if (allerrors == null) {
+          //       ${ constructor } // using res1.asInstanceOf[partial.Result.Value[Tpe]].value, ...
+          //     } else {
+          //       allerrors
+          //     }
+          //   }
+          // }
+          TransformationExpr.fromPartial(
+            partialConstructorArguments
+              .traverse[PrependDefinitionsTo, (String, Existential[PartialExpr])] {
+                case (name: String, expr: Existential[PartialExpr]) =>
+                  // We start by building this initial block of '{ def resN = ${ derivedResultTo } }
+                  import expr.{Underlying as Res, value as partialExpr}
+                  PrependDefinitionsTo
+                    .prependLazyVal(
+                      partialExpr,
+                      ExprPromise.NameGenerationStrategy.FromPrefix("res")
+                    )
+                    .map { (inner: Expr[partial.Result[Res]]) =>
+                      name -> Existential[PartialExpr, Res](inner)
+                    }
+              }
+              .use { (partialsAsLazy: List[(String, Existential[PartialExpr])]) =>
+                val failFastBranch: Expr[partial.Result[To]] = {
+                  // Here, we're building:
+                  // '{
+                  //   res1.flatMap { $name1 =>
+                  //     res2.flatMap { $name2 =>
+                  //       res3.flatMap { $name3 =>
+                  //         ...
+                  //          resN.map { $nameN => ${ constructor } }
+                  //       }
+                  //     }
+                  // } }
+                  def nestFlatMaps(
+                      unusedPartials: List[(String, Existential[PartialExpr])],
+                      constructorArguments: Product.Arguments
+                  ): Expr[partial.Result[To]] = unusedPartials match {
+                    // Should never happen
+                    case Nil => ???
+                    // last result to compose in - use .map instead of .flatMap
+                    case (name, res) :: Nil =>
+                      import res.{Underlying as Res, value as resultToMap}
+                      resultToMap.map(Expr.Function1.instance[Res, To] { (innerExpr: Expr[Res]) =>
+                        constructor(constructorArguments + (name -> ExistentialExpr(innerExpr)))
+                      })
+                    // use .flatMap
+                    case (name, res) :: tail =>
+                      import res.{Underlying as Res, value as resultToFlatMap}
+                      resultToFlatMap.flatMap(
+                        Expr.Function1.instance[Res, partial.Result[To]] { (innerExpr: Expr[Res]) =>
+                          nestFlatMaps(tail, constructorArguments + (name -> ExistentialExpr(innerExpr)))
+                        }
+                      )
+                  }
+
+                  nestFlatMaps(partialsAsLazy.toList, totalConstructorArguments)
+                }
+
+                val fullErrorBranch: Expr[partial.Result[To]] =
+                  // Here, we're building:
+                  // '{
+                  //   var allerrors: Errors = null
+                  //   allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res1 })
+                  //   allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res2 })
+                  //   allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ res3 })
+                  //   ...
+                  //   if (allerrors == null) {
+                  //     partial.Result.Value(${ constructor }) // using res1.asInstanceOf[partial.Result.Value[Tpe]].value, ...
+                  //   } else {
+                  //     allerrors
+                  //   }
+                  // }
+                  PrependDefinitionsTo
+                    .prependVar[partial.Result.Errors](
+                      Expr.Null.asInstanceOfExpr[partial.Result.Errors],
+                      ExprPromise.NameGenerationStrategy.FromPrefix("allerrors")
+                    )
+                    .use { case (allerrors, setAllErrors) =>
+                      Expr.block(
+                        partialsAsLazy.map { case (_, result) =>
+                          import result.{Underlying, value as expr}
+                          // Here, we're building:
+                          // '{ allerrors = partial.Result.Errors.__mergeResultNullable(allerrors, ${ resN }) }
+                          setAllErrors(ChimneyExpr.PartialResult.Errors.mergeResultNullable(allerrors, expr))
+                        },
+                        // Here, we're building:
+                        // '{ if (allerrors == null) $ifBlock else $elseBock }
+                        Expr.ifElse[partial.Result[To]](allerrors eqExpr Expr.Null) {
+                          // Here, we're building:
+                          // '{ partial.Result.Value(${ constructor }) } // using res1.asInstanceOf[partial.Result.Value[Tpe]].value, ...
+                          ChimneyExpr.PartialResult
+                            .Value[To](
+                              constructor(
+                                totalConstructorArguments ++ partialsAsLazy.map { case (name, result) =>
+                                  import result.Underlying as Res
+                                  name -> result.mapK[Expr] { _ => (expr: Expr[partial.Result[Res]]) =>
+                                    expr.asInstanceOfExpr[partial.Result.Value[Res]].value
+                                  }
+                                }
+                              )
+                            )
+                            .upcastExpr[partial.Result[To]]
+                        } {
+                          allerrors.upcastExpr[partial.Result[To]]
+                        }
+                      )
+                    }
+
+                ctx match {
+                  case TransformationContext.ForTotal(_) =>
+                    assertionFailed("Expected partial, got total")
+                  case TransformationContext.ForPartial(_, failFast) =>
+                    // Finally, we are combining:
+                    // if (${ failFast }) {
+                    //   ${ failFastBranch }
+                    // } else {
+                    //   ${ fullErrorBranch }
+                    // }
+                    Expr.ifElse[partial.Result[To]](failFast)(failFastBranch)(fullErrorBranch)
+                }
+              }
+          )
+      }
+    }
 
     // If we derived partial.Result[$ctorParam] we are appending
     //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSubtypesRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSubtypesRuleModule.scala
@@ -7,12 +7,19 @@ private[compiletime] trait TransformSubtypesRuleModule { this: Derivation =>
 
   protected object TransformSubtypesRule extends Rule("Subtypes") {
 
-    override def expand[From, To](implicit
+    def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
+      if (Type[From] <:< Type[To]) {
+        if (ctx.config.areOverridesEmpty) transformByUpcasting[From, To]
+        else
+          DerivationResult.log("Configuration has defined overrides - attempt to upcast source is skipped") >>
+            DerivationResult.attemptNextRule
+      } else DerivationResult.attemptNextRule
+
+    private def transformByUpcasting[From, To](implicit
         ctx: TransformationContext[From, To]
     ): DerivationResult[Rule.ExpansionResult[To]] =
       // We're constructing:
       // '{ ${ src } : $To } }
-      if (Type[From] <:< Type[To]) DerivationResult.expandedTotal(ctx.src.upcastExpr[To])
-      else DerivationResult.attemptNextRule
+      DerivationResult.expandedTotal(ctx.src.upcastExpr[To])
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformToOptionRuleModule.scala
@@ -17,10 +17,15 @@ private[compiletime] trait TransformToOptionRuleModule { this: Derivation & Tran
       else if (Type[To].isOption)
         DerivationResult.namedScope(s"Lifting ${Type.prettyPrint[From]} -> ${Type
             .prettyPrint[To]} transformation into ${Type.prettyPrint[Option[From]]} -> ${Type.prettyPrint[To]}") {
-          // We're constructing:
-          // '{ Option(${ derivedTo2 }) } }
-          TransformOptionToOptionRule.expand(ctx.updateFromTo[Option[From], To](Expr.Option(ctx.src)))
+          wrapInOptionAndTransform[From, To]
         }
       else DerivationResult.attemptNextRule
   }
+
+  private def wrapInOptionAndTransform[From, To](implicit
+      ctx: TransformationContext[From, To]
+  ): DerivationResult[Rule.ExpansionResult[To]] =
+    // We're constructing:
+    // '{ Option(${ derivedTo2 }) } }
+    TransformOptionToOptionRule.expand(ctx.updateFromTo[Option[From], To](Expr.Option(ctx.src)))
 }


### PR DESCRIPTION
Refactor rules so that:

 * `def expand` logic would only deal with checking if rule apply and delegating derivation to a `private def`
 * if some existenial types are used import them as e.g. `import from2.Underlying as InnerFrom` and then use these names in `private def`s (e.g. `[InnerFrom: Type]`)
 * for longer methods decompose them into smaller methods describing which part of the logic is being handled (especially ProductToProduct is quite long)