### PR TITLE
java.util.Enum support

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -14,23 +14,33 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
       sym.isClass && sym.asClass.isSealed
     }
 
-    def parse[A: Type]: Option[Enum[A]] = if (isSealed(Type[A])) {
-      // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
-      val elements = extractSubclasses(Type[A].tpe.typeSymbol.asType).distinct
-        .map { (subtype: TypeSymbol) =>
-          val subtypeA = subtypeTypeOf[A](subtype)
-          subtypeA.mapK[Enum.Element[A, *]] { implicit Subtype: Type[subtypeA.Underlying] => _ =>
-            Enum.Element(name = subtypeName(subtype), upcast = _.upcastExpr[A])
-          }
-        }
-        // with GADT we can have subtypes that shouldn't appear in pattern matching
-        .filter(_.Underlying <:< Type[A])
-      Some(Enum(elements))
-    } else None
+    def isJavaEnum[A](A: Type[A]): Boolean = A.tpe.typeSymbol.isJavaEnum
+
+    def parse[A: Type]: Option[Enum[A]] =
+      if (isSealed(Type[A])) Some(symbolsToEnum(extractSubclasses(Type[A].tpe.typeSymbol.asType)))
+      else if (isJavaEnum(Type[A])) Some(symbolsToEnum(extractJavaEnumInstances(Type[A].tpe)))
+      else None
 
     private def extractSubclasses(t: TypeSymbol): List[TypeSymbol] =
       if (t.asClass.isSealed) t.asClass.knownDirectSubclasses.toList.map(_.asType).flatMap(extractSubclasses)
       else List(t)
+
+    private def extractJavaEnumInstances(t: c.Type): List[TypeSymbol] =
+      t.companion.decls.filter(_.isJavaEnum).map(_.asType).toList
+
+    private def symbolsToEnum[A: Type](subtypes: List[TypeSymbol]): Enum[A] =
+      Enum(
+        // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
+        subtypes.distinct
+          .map { (subtype: TypeSymbol) =>
+            val subtypeA = subtypeTypeOf[A](subtype)
+            subtypeA.mapK[Enum.Element[A, *]] { implicit Subtype: Type[subtypeA.Underlying] => _ =>
+              Enum.Element(name = subtypeName(subtype), upcast = _.upcastExpr[A])
+            }
+          }
+          // with GADT we can have subtypes that shouldn't appear in pattern matching
+          .filter(_.Underlying <:< Type[A])
+      )
 
     private def subtypeName(subtype: TypeSymbol): String = subtype.name.toString
   }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -9,38 +9,38 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
 
   protected object SealedHierarchy extends SealedHierarchyModule {
 
-    def isSealed[A](A: Type[A]): Boolean = {
-      val flags = TypeRepr.of(using A).typeSymbol.flags
+    def isJavaEnum[A: Type]: Boolean =
+      TypeRepr.of[A] <:< TypeRepr.typeConstructorOf(classOf[java.lang.Enum[?]])
+
+    def isSealed[A: Type]: Boolean = {
+      val flags = TypeRepr.of[A].typeSymbol.flags
       flags.is(Flags.Enum) || flags.is(Flags.Sealed)
     }
 
-    def isJavaEnum[A](A: Type[A]): Boolean =
-      TypeRepr.of(using A) <:< TypeRepr.typeConstructorOf(classOf[java.lang.Enum[?]])
-
     def parse[A: Type]: Option[Enum[A]] =
-      if isSealed(Type[A]) then Some(symbolsToEnum(extractSubclasses(TypeRepr.of[A].typeSymbol)))
-      else if isJavaEnum(Type[A]) then Some(symbolsToEnum(extractJavaEnumInstances(TypeRepr.of[A].typeSymbol)))
+      // no need for separate java.lang.Enum handling contrary to Scala 2
+      if isSealed[A] then Some(symbolsToEnum(extractSealedSubtypes[A]))
       else None
 
-    private def extractSubclasses(sym: Symbol): List[Symbol] =
-      if sym.flags.is(Flags.Sealed) then sym.children.flatMap(extractSubclasses)
-      else if sym.flags.is(Flags.Enum) then List(sym.typeRef.typeSymbol)
-      else if sym.flags.is(Flags.Module) then List(sym.typeRef.typeSymbol.moduleClass)
-      else List(sym)
+    private def extractSealedSubtypes[A: Type]: List[(String, ?<[A])] = {
+      def extractRecursively(sym: Symbol): List[Symbol] =
+        if sym.flags.is(Flags.Sealed) then sym.children.flatMap(extractRecursively)
+        else if sym.flags.is(Flags.Enum) then List(sym.typeRef.typeSymbol)
+        else if sym.flags.is(Flags.Module) then List(sym.typeRef.typeSymbol.moduleClass)
+        else List(sym)
 
-    private def extractJavaEnumInstances(sym: Symbol): List[Symbol] =
-      sym.fieldMembers.filter { m =>
-        m.typeRef <:< TypeRepr.typeConstructorOf(classOf[java.lang.Enum[?]])
-      }
+      // calling .distinct here as `children` returns duplicates for multiply-inherited types
+      extractRecursively(TypeRepr.of[A].typeSymbol).distinct.map(typeSymbol =>
+        subtypeName(typeSymbol) -> subtypeTypeOf[A](typeSymbol)
+      )
+    }
 
-    private def symbolsToEnum[A: Type](subtypes: List[Symbol]): Enum[A] =
+    private def symbolsToEnum[A: Type](subtypes: List[(String, ?<[A])]): Enum[A] =
       Enum(
-        // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
-        subtypes.distinct
-          .map { (subtype: Symbol) =>
-            val subtypeA = subtypeTypeOf[A](subtype)
+        subtypes
+          .map { case (name, subtypeA: ?<[A]) =>
             subtypeA.mapK[Enum.Element[A, *]] { implicit Subtype: Type[subtypeA.Underlying] => _ =>
-              Enum.Element[A, subtypeA.Underlying](name = subtypeName(subtype), upcast = _.upcastExpr[A])
+              Enum.Element[A, subtypeA.Underlying](name = name, upcast = _.upcastExpr[A])
             }
           }
           // with GADT we can have subtypes that shouldn't appear in pattern matching

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -14,24 +14,38 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
       flags.is(Flags.Enum) || flags.is(Flags.Sealed)
     }
 
-    def parse[A: Type]: Option[Enum[A]] = if isSealed(Type[A]) then {
-      val elements = extractSubclasses(TypeRepr.of[A].typeSymbol).distinct
-        .map { (subtype: Symbol) =>
-          val subtypeA = subtypeTypeOf[A](subtype)
-          subtypeA.mapK[Enum.Element[A, *]] { implicit Subtype: Type[subtypeA.Underlying] => _ =>
-            Enum.Element[A, subtypeA.Underlying](name = subtypeName(subtype), upcast = _.upcastExpr[A])
-          }
-        }
-        // with GADT we can have subtypes that shouldn't appear in pattern matching
-        .filter(_.Underlying <:< Type[A])
-      Some(Enum(elements))
-    } else None
+    def isJavaEnum[A](A: Type[A]): Boolean =
+      TypeRepr.of(using A) <:< TypeRepr.typeConstructorOf(classOf[java.lang.Enum[?]])
+
+    def parse[A: Type]: Option[Enum[A]] =
+      if isSealed(Type[A]) then Some(symbolsToEnum(extractSubclasses(TypeRepr.of[A].typeSymbol)))
+      else if isJavaEnum(Type[A]) then Some(symbolsToEnum(extractJavaEnumInstances(TypeRepr.of[A].typeSymbol)))
+      else None
 
     private def extractSubclasses(sym: Symbol): List[Symbol] =
       if sym.flags.is(Flags.Sealed) then sym.children.flatMap(extractSubclasses)
       else if sym.flags.is(Flags.Enum) then List(sym.typeRef.typeSymbol)
       else if sym.flags.is(Flags.Module) then List(sym.typeRef.typeSymbol.moduleClass)
       else List(sym)
+
+    private def extractJavaEnumInstances(sym: Symbol): List[Symbol] =
+      sym.fieldMembers.filter { m =>
+        m.typeRef <:< TypeRepr.typeConstructorOf(classOf[java.lang.Enum[?]])
+      }
+
+    private def symbolsToEnum[A: Type](subtypes: List[Symbol]): Enum[A] =
+      Enum(
+        // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
+        subtypes.distinct
+          .map { (subtype: Symbol) =>
+            val subtypeA = subtypeTypeOf[A](subtype)
+            subtypeA.mapK[Enum.Element[A, *]] { implicit Subtype: Type[subtypeA.Underlying] => _ =>
+              Enum.Element[A, subtypeA.Underlying](name = subtypeName(subtype), upcast = _.upcastExpr[A])
+            }
+          }
+          // with GADT we can have subtypes that shouldn't appear in pattern matching
+          .filter(_.Underlying <:< Type[A])
+      )
 
     private def subtypeName(subtype: Symbol): String = {
       val n = subtype.name

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
@@ -21,7 +21,9 @@ trait SealedHierarchies { this: Definitions =>
     def parse[A: Type]: Option[Enum[A]]
     final def unapply[A](tpe: Type[A]): Option[Enum[A]] = parse(tpe)
 
-    def isSealed[A](A: Type[A]): Boolean
+    def isJavaEnum[A: Type]: Boolean
+
+    def isSealed[A: Type]: Boolean
   }
 
   implicit class SealedHierarchyOps[A](private val tpe: Type[A]) {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -91,13 +91,11 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
-    new ApplyFixedCoproductType {
-      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
-        .addOverride(f)
-        .asInstanceOfExpr[PartialTransformerDefinition[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
-    }
-  }
+  ](f: Tree): Tree = new ApplyFixedCoproductType {
+    def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerDefinition[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+  }.applyJavaEnumFixFromClosureSignature[Inst](f)
 
   def withCoproductInstancePartialImpl[
       From: WeakTypeTag,
@@ -105,7 +103,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
+  ](f: Tree): Tree =
     new ApplyFixedCoproductType {
       def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
         .addOverride(f)
@@ -115,6 +113,5 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
           CoproductInstancePartial[FixedInstance, To, Cfg],
           Flags
         ]]
-    }
-  }
+    }.applyJavaEnumFixFromClosureSignature[Inst](f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -103,15 +103,14 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree =
-    new ApplyFixedCoproductType {
-      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
-        .addOverride(f)
-        .asInstanceOfExpr[PartialTransformerDefinition[
-          From,
-          To,
-          CoproductInstancePartial[FixedInstance, To, Cfg],
-          Flags
-        ]]
-    }.applyJavaEnumFixFromClosureSignature[Inst](f)
+  ](f: Tree): Tree = new ApplyFixedCoproductType {
+    def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerDefinition[
+        From,
+        To,
+        CoproductInstancePartial[FixedInstance, To, Cfg],
+        Flags
+      ]]
+  }.applyJavaEnumFixFromClosureSignature[Inst](f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -91,9 +91,13 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = c.prefix.tree
-    .addOverride(f)
-    .asInstanceOfExpr[PartialTransformerDefinition[From, To, CoproductInstance[Inst, To, Cfg], Flags]]
+  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
+    new ApplyFixedCoproductType {
+      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(f)
+        .asInstanceOfExpr[PartialTransformerDefinition[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+    }
+  }
 
   def withCoproductInstancePartialImpl[
       From: WeakTypeTag,
@@ -101,7 +105,16 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = c.prefix.tree
-    .addOverride(f)
-    .asInstanceOfExpr[PartialTransformerDefinition[From, To, CoproductInstancePartial[Inst, To, Cfg], Flags]]
+  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
+    new ApplyFixedCoproductType {
+      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(f)
+        .asInstanceOfExpr[PartialTransformerDefinition[
+          From,
+          To,
+          CoproductInstancePartial[FixedInstance, To, Cfg],
+          Flags
+        ]]
+    }
+  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -92,13 +92,11 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
-    new ApplyFixedCoproductType {
-      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
-        .addOverride(f)
-        .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
-    }
-  }
+  ](f: Tree): Tree = new ApplyFixedCoproductType {
+    def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+  }.applyJavaEnumFixFromClosureSignature[Inst](f)
 
   def withCoproductInstancePartialImpl[
       From: WeakTypeTag,
@@ -106,11 +104,9 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
-    new ApplyFixedCoproductType {
-      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
-        .addOverride(f)
-        .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstancePartial[FixedInstance, To, Cfg], Flags]]
-    }
-  }
+  ](f: Tree): Tree = new ApplyFixedCoproductType {
+    def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstancePartial[FixedInstance, To, Cfg], Flags]]
+  }.applyJavaEnumFixFromClosureSignature[Inst](f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -92,9 +92,13 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = c.prefix.tree
-    .addOverride(f)
-    .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstance[Inst, To, Cfg], Flags]]
+  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
+    new ApplyFixedCoproductType {
+      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(f)
+        .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+    }
+  }
 
   def withCoproductInstancePartialImpl[
       From: WeakTypeTag,
@@ -102,7 +106,11 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = c.prefix.tree
-    .addOverride(f)
-    .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstancePartial[Inst, To, Cfg], Flags]]
+  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
+    new ApplyFixedCoproductType {
+      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(f)
+        .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstancePartial[FixedInstance, To, Cfg], Flags]]
+    }
+  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -61,11 +61,9 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
-    new ApplyFixedCoproductType {
-      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
-        .addOverride(f)
-        .asInstanceOfExpr[TransformerDefinition[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
-    }
-  }
+  ](f: Tree): Tree = new ApplyFixedCoproductType {
+    def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[TransformerDefinition[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+  }.applyJavaEnumFixFromClosureSignature[Inst](f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -61,7 +61,11 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = c.prefix.tree
-    .addOverride(f)
-    .asInstanceOfExpr[TransformerDefinition[From, To, CoproductInstance[Inst, To, Cfg], Flags]]
+  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
+    new ApplyFixedCoproductType {
+      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(f)
+        .asInstanceOfExpr[TransformerDefinition[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+    }
+  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -61,11 +61,9 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
-    new ApplyFixedCoproductType {
-      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
-        .addOverride(f)
-        .asInstanceOfExpr[TransformerInto[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
-    }
-  }
+  ](f: Tree): Tree = new ApplyFixedCoproductType {
+    def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[TransformerInto[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+  }.applyJavaEnumFixFromClosureSignature[Inst](f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -61,7 +61,11 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       Cfg <: TransformerCfg: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag,
       Inst: WeakTypeTag
-  ](f: Tree): Tree = c.prefix.tree
-    .addOverride(f)
-    .asInstanceOfExpr[TransformerInto[From, To, CoproductInstance[Inst, To, Cfg], Flags]]
+  ](f: Tree): Tree = fixJavaEnumType[Inst](f) {
+    new ApplyFixedCoproductType {
+      def apply[FixedInstance: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(f)
+        .asInstanceOfExpr[TransformerInto[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
+    }
+  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/runtime/RefinedJavaEnum.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/runtime/RefinedJavaEnum.scala
@@ -1,0 +1,12 @@
+package io.scalaland.chimney.internal.runtime
+
+/** Apparently, `com.mypackage.JavaEnum.Value.type` is not a thing on Scala 2. At least when it comes to macros and
+  * `c.WeakTypeTag`.
+  *
+  * While there is `symbol.asTerm.typeSignature` for `JavaEnum.Value` (being aware that it "Value"), it will be upcasted
+  * to `JavaEnum`. We are only able to read it by reading a whole function tree, and we are only able to store it
+  * for DSL by encoding the name read from the tree in a dedicate type.
+  *
+  * In Scala 3 no such shenanigan are needed.
+  */
+sealed class RefinedJavaEnum[E, Value <: String]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/runtime/RefinedJavaEnum.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/runtime/RefinedJavaEnum.scala
@@ -1,11 +1,22 @@
 package io.scalaland.chimney.internal.runtime
 
-/** Apparently, `com.mypackage.JavaEnum.Value.type` is not a thing on Scala 2. At least when it comes to macros and
-  * `c.WeakTypeTag`.
+/** Apparently, `com.mypackage.JavaEnum.Value.type` is not a thing on Scala 2. This means that:
   *
-  * While there is `symbol.asTerm.typeSignature` for `JavaEnum.Value` (being aware that it "Value"), it will be upcasted
-  * to `JavaEnum`. We are only able to read it by reading a whole function tree, and we are only able to store it
-  * for DSL by encoding the name read from the tree in a dedicate type.
+  *   withCoproductInstance[com.mypackage.JavaEnum.Value.type] { value => ... }
+  *
+  * is ALWAYS treated as:
+  *
+  *   withCoproductInstance[com.mypackage.JavaEnum] { value => ... }
+  *
+  * matching on ALL values of `com.mypackage.JavaEnum`. Probably not what you want.
+  *
+  * While there is `symbol.asTerm.typeSignature` for `JavaEnum.Value` (being aware that it is "Value" and recognizing it
+  * in pattern-matching), it will be upcasted to `JavaEnum`. We are only able to read it by reading a whole function's
+  * tree:
+  *
+  *    withCoproductInstance { (value: com.mypackage.JavaEnum.Value.type) => ... }
+  *
+  * and we are only able to store it for DSL by encoding the name read from the tree with a dedicated type from below.
   *
   * In Scala 3 no such shenanigan are needed.
   */

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
@@ -14,7 +14,8 @@ object DerivationError {
       .collectFirst {
         case MacroException(exception) =>
           val stackTrace =
-            exception.getStackTrace.view.take(10).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
+            // exception.getStackTrace.view.take(10).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
+            exception.getStackTrace.view.map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
           s"  macro expansion thrown exception!: $exception:\n$stackTrace\n  \t${Console.RED}...${Console.RESET}"
         case NotYetImplemented(what) =>
           s"  derivation failed because functionality $what is not yet implemented!"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
@@ -14,8 +14,7 @@ object DerivationError {
       .collectFirst {
         case MacroException(exception) =>
           val stackTrace =
-            // exception.getStackTrace.view.take(10).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
-            exception.getStackTrace.view.map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
+            exception.getStackTrace.view.take(10).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
           s"  macro expansion thrown exception!: $exception:\n$stackTrace\n  \t${Console.RED}...${Console.RESET}"
         case NotYetImplemented(what) =>
           s"  derivation failed because functionality $what is not yet implemented!"

--- a/chimney/src/test/java/io/scalaland/chimney/javafixtures/jcolors1/Color.java
+++ b/chimney/src/test/java/io/scalaland/chimney/javafixtures/jcolors1/Color.java
@@ -1,0 +1,5 @@
+package io.scalaland.chimney.javafixtures.jcolors1;
+
+public enum Color {
+    Red, Green, Blue;
+}

--- a/chimney/src/test/java/io/scalaland/chimney/javafixtures/jcolors2/Color.java
+++ b/chimney/src/test/java/io/scalaland/chimney/javafixtures/jcolors2/Color.java
@@ -1,0 +1,5 @@
+package io.scalaland.chimney.javafixtures.jcolors2;
+
+public enum Color {
+    Red, Green, Blue, Black;
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
@@ -125,7 +125,33 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
       Some(shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0)))
   }
 
-  group("setting .withCoproductInstance(mapping)") {
+  test(
+    "not allow transformation of of sealed hierarchies when the transformation would be ambiguous".withTags(
+      if (isScala3) Set(munit.Ignore)
+      else Set.empty // ignore only on Scala 3 until https://github.com/lampepfl/dotty/issues/18484 is fixed
+    )
+  ) {
+    val error = compileErrorsScala2(
+      """
+           (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
+             .transformIntoPartial[shapes5.Shape]
+        """
+    )
+
+    error.check(
+      "Chimney can't derive transformation from io.scalaland.chimney.fixtures.shapes1.Shape to io.scalaland.chimney.fixtures.shapes5.Shape",
+      "io.scalaland.chimney.fixtures.shapes5.Shape",
+      "coproduct instance Triangle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous",
+      "coproduct instance Rectangle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous",
+      "Consult https://chimney.readthedocs.io for usage examples."
+    )
+
+    error.checkNot(
+      "coproduct instance Circle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous"
+    )
+  }
+
+  group("setting .withCoproductInstance[Subtype](mapping)") {
 
     test(
       """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Colors.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Colors.scala
@@ -24,3 +24,15 @@ package colors3 {
   case object Blue extends SimpleColor
   case object Black extends ComplexedColor
 }
+
+package colors4 {
+  sealed trait Color
+  case object Red extends Color
+  case object Green extends Color
+  case object Blue extends Color
+  case object Black extends Color
+  object Color {
+    case object Green extends Color
+    case object Black extends Color
+  }
+}

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
@@ -1,0 +1,354 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+import io.scalaland.chimney.javafixtures.*
+//import io.scalaland.chimney.utils.OptionUtils.*
+
+//import scala.annotation.unused
+
+class PartialTransformerJavaEnumSpec extends ChimneySpec {
+
+  test(
+    """transform from Java Enum "subset" instances to sealed hierarchy "superset" of case objects without modifiers"""
+  ) {
+    (jcolors1.Color.Red: jcolors1.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Red)
+    (jcolors1.Color.Green: jcolors1.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Green)
+    (jcolors1.Color.Blue: jcolors1.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Blue)
+  }
+
+  test(
+    """transform from sealed hierarchies "subset" of case objects to "superset" of Java Enums instances without modifiers"""
+  ) {
+    (colors1.Red: colors1.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Red)
+    (colors1.Green: colors1.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Green)
+    (colors1.Blue: colors1.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Blue)
+  }
+
+  test(
+    """transform Java Enums from "subset" of instances to "superset" of instances without modifiers"""
+  ) {
+    (jcolors1.Color.Red: jcolors1.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Red)
+    (jcolors1.Color.Green: jcolors1.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Green)
+    (jcolors1.Color.Blue: jcolors1.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Blue)
+  }
+
+//  test(
+//    """transform nested sealed hierarchies between flat and nested hierarchies of case objects without modifiers"""
+//  ) {
+//    (colors2.Red: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Red)
+//    (colors2.Green: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Green)
+//    (colors2.Blue: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Blue)
+//    (colors2.Black: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Black)
+//
+//    (colors3.Red: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Red)
+//    (colors3.Green: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Green)
+//    (colors3.Blue: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Blue)
+//    (colors3.Black: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Black)
+//  }
+//
+//  test(
+//    """transforming flat hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable with Total Transformer"""
+//  ) {
+//    implicit val intToDoubleTransformer: Transformer[Int, Double] = (_: Int).toDouble
+//
+//    (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
+//      .transformIntoPartial[shapes3.Shape]
+//      .asOption ==>
+//      Some(shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)))
+//    (shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4)): shapes1.Shape)
+//      .transformIntoPartial[shapes3.Shape]
+//      .asOption ==>
+//      Some(shapes3.Rectangle(shapes3.Point(0.0, 0.0), shapes3.Point(6.0, 4.0)))
+//
+//    implicit val intToStringTransformer: Transformer[Int, String] = (_: Int).toString
+//    import numbers.*, ScalesPartialTransformer.shortToLongTotalInner
+//
+//    (short.Zero: short.NumScale[Int, Nothing])
+//      .transformIntoPartial[long.NumScale[String]]
+//      .asOption ==> Some(long.Zero)
+//    (short.Million(4): short.NumScale[Int, Nothing])
+//      .transformIntoPartial[long.NumScale[String]]
+//      .asOption ==> Some(long.Million("4"))
+//    (short.Billion(2): short.NumScale[Int, Nothing])
+//      .transformIntoPartial[long.NumScale[String]]
+//      .asOption ==> Some(long.Milliard("2"))
+//    (short.Trillion(100): short.NumScale[Int, Nothing])
+//      .transformIntoPartial[long.NumScale[String]]
+//      .asOption ==> Some(long.Billion("100"))
+//  }
+//
+//  test(
+//    """transforming flat hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable with Partial Transformer"""
+//  ) {
+//    implicit val intToDoubleTransformer: PartialTransformer[Int, Double] =
+//      (a: Int, _) => partial.Result.fromValue(a.toDouble)
+//
+//    (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
+//      .transformIntoPartial[shapes3.Shape]
+//      .asOption ==>
+//      Some(shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)))
+//    (shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4)): shapes1.Shape)
+//      .transformIntoPartial[shapes3.Shape]
+//      .asOption ==>
+//      Some(shapes3.Rectangle(shapes3.Point(0.0, 0.0), shapes3.Point(6.0, 4.0)))
+//
+//    implicit val intParserOpt: PartialTransformer[String, Int] =
+//      PartialTransformer(_.parseInt.toPartialResult)
+//    import numbers.*, ScalesPartialTransformer.shortToLongPartialInner
+//
+//    (short.Zero: short.NumScale[String, Nothing])
+//      .transformIntoPartial[long.NumScale[Int]]
+//      .asOption ==> Some(long.Zero)
+//    (short.Million("4"): short.NumScale[String, Nothing])
+//      .transformIntoPartial[long.NumScale[Int]]
+//      .asOption ==> Some(long.Million(4))
+//    (short.Billion("2"): short.NumScale[String, Nothing])
+//      .transformIntoPartial[long.NumScale[Int]]
+//      .asOption ==> Some(long.Milliard(2))
+//    (short.Trillion("100"): short.NumScale[String, Nothing])
+//      .transformIntoPartial[long.NumScale[Int]]
+//      .asOption ==> Some(long.Billion(100))
+//
+//    (short.Million("x"): short.NumScale[String, Nothing])
+//      .transformIntoPartial[long.NumScale[Int]]
+//      .asOption ==> None
+//    (short.Billion("x"): short.NumScale[String, Nothing])
+//      .transformIntoPartial[long.NumScale[Int]]
+//      .asOption ==> None
+//    (short.Trillion("x"): short.NumScale[String, Nothing])
+//      .transformIntoPartial[long.NumScale[Int]]
+//      .asOption ==> None
+//  }
+//
+//  test(
+//    """transforming nested sealed hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable"""
+//  ) {
+//    (shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)): shapes3.Shape)
+//      .transformIntoPartial[shapes4.Shape]
+//      .asOption ==>
+//      Some(shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0)))
+//    (shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0)): shapes3.Shape)
+//      .transformIntoPartial[shapes4.Shape]
+//      .asOption ==>
+//      Some(shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0)))
+//    (shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0)): shapes4.Shape)
+//      .transformIntoPartial[shapes3.Shape]
+//      .asOption ==>
+//      Some(shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)))
+//    (shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0)): shapes4.Shape)
+//      .transformIntoPartial[shapes3.Shape]
+//      .asOption ==>
+//      Some(shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0)))
+//  }
+//
+//  group("setting .withCoproductInstance(mapping)") {
+//
+//    test(
+//      """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""
+//    ) {
+//      compileErrorsFixed("""(colors2.Black: colors2.Color).transformIntoPartial[colors1.Color]""").check(
+//        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.colors2.Color to io.scalaland.chimney.fixtures.colors1.Color",
+//        "io.scalaland.chimney.fixtures.colors1.Color",
+//        "can't transform coproduct instance io.scalaland.chimney.fixtures.colors2.Black to io.scalaland.chimney.fixtures.colors1.Color",
+//        "Consult https://chimney.readthedocs.io for usage examples."
+//      )
+//    }
+//
+//    test(
+//      """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
+//    ) {
+//      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
+//        colors1.Red
+//
+//      (colors2.Black: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform
+//        .asOption ==> Some(colors1.Red)
+//
+//      (colors2.Red: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform
+//        .asOption ==> Some(colors1.Red)
+//
+//      (colors2.Green: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform
+//        .asOption ==> Some(colors1.Green)
+//
+//      (colors2.Blue: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform
+//        .asOption ==> Some(colors1.Blue)
+//    }
+//
+//    test(
+//      """transform sealed hierarchies from "superset" of case classes to "subset" of case classes when user-provided mapping handled non-trivial cases"""
+//    ) {
+//      def triangleToPolygon(t: shapes1.Triangle): shapes2.Shape =
+//        shapes2.Polygon(
+//          List(
+//            t.p1.transformInto[shapes2.Point],
+//            t.p2.transformInto[shapes2.Point],
+//            t.p3.transformInto[shapes2.Point]
+//          )
+//        )
+//
+//      def rectangleToPolygon(r: shapes1.Rectangle): shapes2.Shape =
+//        shapes2.Polygon(
+//          List(
+//            r.p1.transformInto[shapes2.Point],
+//            shapes2.Point(r.p1.x, r.p2.y),
+//            r.p2.transformInto[shapes2.Point],
+//            shapes2.Point(r.p2.x, r.p1.y)
+//          )
+//        )
+//
+//      val triangle: shapes1.Shape =
+//        shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+//
+//      triangle
+//        .intoPartial[shapes2.Shape]
+//        .withCoproductInstance(triangleToPolygon)
+//        .withCoproductInstance(rectangleToPolygon)
+//        .transform
+//        .asOption ==> Some(shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0))))
+//
+//      val rectangle: shapes1.Shape =
+//        shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4))
+//
+//      rectangle
+//        .intoPartial[shapes2.Shape]
+//        .withCoproductInstance[shapes1.Shape] {
+//          case r: shapes1.Rectangle => rectangleToPolygon(r)
+//          case t: shapes1.Triangle => triangleToPolygon(t)
+//        }
+//        .transform
+//        .asOption ==> Some(
+//        shapes2.Polygon(
+//          List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
+//        )
+//      )
+//    }
+//  }
+//
+//  test(
+//    "transform sealed hierarchies of single value wrapping case classes to sealed hierarchy of flat case classes subtypes"
+//  ) {
+//    val triangle: shapes1.Shape = shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+//    triangle.transformIntoPartial[shapes6.Shape].asOption ==> Some(
+//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
+//    )
+//
+//    val rectangle: shapes1.Shape = shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
+//    rectangle.transformIntoPartial[shapes6.Shape].asOption ==> Some(
+//      shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
+//    )
+//  }
+//
+//  test(
+//    "transform sealed hierarchies of flat case classes subtypes to sealed hierarchy of single value wrapping case classes"
+//  ) {
+//    val triangle: shapes6.Shape =
+//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
+//    triangle.transformIntoPartial[shapes1.Shape].asOption ==> Some(
+//      shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+//    )
+//
+//    val rectangle: shapes6.Shape = shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
+//    rectangle.transformIntoPartial[shapes1.Shape].asOption ==> Some(
+//      shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
+//    )
+//  }
+//
+//  group("setting .withCoproductInstancePartial[Subtype](mapping)") {
+//
+//    test(
+//      """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
+//    ) {
+//      def blackIsRed(b: colors2.Black.type): partial.Result[colors1.Color] =
+//        partial.Result.fromEmpty
+//
+//      (colors2.Black: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstancePartial(blackIsRed)
+//        .transform
+//        .asOption ==> None
+//
+//      (colors2.Red: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstancePartial(blackIsRed)
+//        .transform
+//        .asOption ==> Some(colors1.Red)
+//
+//      (colors2.Green: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstancePartial(blackIsRed)
+//        .transform
+//        .asOption ==> Some(colors1.Green)
+//
+//      (colors2.Blue: colors2.Color)
+//        .intoPartial[colors1.Color]
+//        .withCoproductInstancePartial(blackIsRed)
+//        .transform
+//        .asOption ==> Some(colors1.Blue)
+//    }
+//
+//    test(
+//      """transform sealed hierarchies from "superset" of case classes to "subset" of case classes when user-provided mapping handled non-trivial cases"""
+//    ) {
+//      def triangleToPolygon(t: shapes1.Triangle): partial.Result[shapes2.Shape] =
+//        partial.Result.fromValue(
+//          shapes2.Polygon(
+//            List(
+//              t.p1.transformInto[shapes2.Point],
+//              t.p2.transformInto[shapes2.Point],
+//              t.p3.transformInto[shapes2.Point]
+//            )
+//          )
+//        )
+//
+//      def rectangleToPolygon(r: shapes1.Rectangle): partial.Result[shapes2.Shape] =
+//        partial.Result.fromValue(
+//          shapes2.Polygon(
+//            List(
+//              r.p1.transformInto[shapes2.Point],
+//              shapes2.Point(r.p1.x, r.p2.y),
+//              r.p2.transformInto[shapes2.Point],
+//              shapes2.Point(r.p2.x, r.p1.y)
+//            )
+//          )
+//        )
+//
+//      val triangle: shapes1.Shape =
+//        shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+//
+//      triangle
+//        .intoPartial[shapes2.Shape]
+//        .withCoproductInstancePartial(triangleToPolygon)
+//        .withCoproductInstancePartial(rectangleToPolygon)
+//        .transform
+//        .asOption ==> Some(shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0))))
+//
+//      val rectangle: shapes1.Shape =
+//        shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4))
+//
+//      rectangle
+//        .intoPartial[shapes2.Shape]
+//        .withCoproductInstancePartial[shapes1.Shape] {
+//          case r: shapes1.Rectangle => rectangleToPolygon(r)
+//          case t: shapes1.Triangle => triangleToPolygon(t)
+//        }
+//        .transform
+//        .asOption ==> Some(
+//        shapes2.Polygon(
+//          List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
+//        )
+//      )
+//    }
+//  }
+}

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
@@ -91,25 +91,25 @@ class PartialTransformerJavaEnumSpec extends ChimneySpec {
 
       (jcolors2.Color.Black: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> Some(colors1.Red)
 
       (jcolors2.Color.Red: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> Some(colors1.Red)
 
       (jcolors2.Color.Green: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> Some(colors1.Green)
 
       (jcolors2.Color.Blue: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> Some(colors1.Blue)
     }
@@ -125,25 +125,25 @@ class PartialTransformerJavaEnumSpec extends ChimneySpec {
 
       (jcolors2.Color.Black: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstancePartial(blackIsRed)
+        .withCoproductInstancePartial((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> None
 
       (jcolors2.Color.Red: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstancePartial(blackIsRed)
+        .withCoproductInstancePartial((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> Some(colors1.Red)
 
       (jcolors2.Color.Green: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstancePartial(blackIsRed)
+        .withCoproductInstancePartial((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> Some(colors1.Green)
 
       (jcolors2.Color.Blue: jcolors2.Color)
         .intoPartial[colors1.Color]
-        .withCoproductInstancePartial(blackIsRed)
+        .withCoproductInstancePartial((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform
         .asOption ==> Some(colors1.Blue)
     }

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
@@ -33,116 +33,45 @@ class PartialTransformerJavaEnumSpec extends ChimneySpec {
     (jcolors1.Color.Blue: jcolors1.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Blue)
   }
 
-//  test(
-//    """transform nested sealed hierarchies between flat and nested hierarchies of case objects without modifiers"""
-//  ) {
-//    (colors2.Red: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Red)
-//    (colors2.Green: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Green)
-//    (colors2.Blue: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Blue)
-//    (colors2.Black: colors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Black)
-//
-//    (colors3.Red: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Red)
-//    (colors3.Green: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Green)
-//    (colors3.Blue: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Blue)
-//    (colors3.Black: colors3.Color).transformIntoPartial[colors2.Color].asOption ==> Some(colors2.Black)
-//  }
-//
-//  test(
-//    """transforming flat hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable with Total Transformer"""
-//  ) {
-//    implicit val intToDoubleTransformer: Transformer[Int, Double] = (_: Int).toDouble
-//
-//    (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
-//      .transformIntoPartial[shapes3.Shape]
-//      .asOption ==>
-//      Some(shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)))
-//    (shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4)): shapes1.Shape)
-//      .transformIntoPartial[shapes3.Shape]
-//      .asOption ==>
-//      Some(shapes3.Rectangle(shapes3.Point(0.0, 0.0), shapes3.Point(6.0, 4.0)))
-//
-//    implicit val intToStringTransformer: Transformer[Int, String] = (_: Int).toString
-//    import numbers.*, ScalesPartialTransformer.shortToLongTotalInner
-//
-//    (short.Zero: short.NumScale[Int, Nothing])
-//      .transformIntoPartial[long.NumScale[String]]
-//      .asOption ==> Some(long.Zero)
-//    (short.Million(4): short.NumScale[Int, Nothing])
-//      .transformIntoPartial[long.NumScale[String]]
-//      .asOption ==> Some(long.Million("4"))
-//    (short.Billion(2): short.NumScale[Int, Nothing])
-//      .transformIntoPartial[long.NumScale[String]]
-//      .asOption ==> Some(long.Milliard("2"))
-//    (short.Trillion(100): short.NumScale[Int, Nothing])
-//      .transformIntoPartial[long.NumScale[String]]
-//      .asOption ==> Some(long.Billion("100"))
-//  }
-//
-//  test(
-//    """transforming flat hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable with Partial Transformer"""
-//  ) {
-//    implicit val intToDoubleTransformer: PartialTransformer[Int, Double] =
-//      (a: Int, _) => partial.Result.fromValue(a.toDouble)
-//
-//    (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
-//      .transformIntoPartial[shapes3.Shape]
-//      .asOption ==>
-//      Some(shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)))
-//    (shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4)): shapes1.Shape)
-//      .transformIntoPartial[shapes3.Shape]
-//      .asOption ==>
-//      Some(shapes3.Rectangle(shapes3.Point(0.0, 0.0), shapes3.Point(6.0, 4.0)))
-//
-//    implicit val intParserOpt: PartialTransformer[String, Int] =
-//      PartialTransformer(_.parseInt.toPartialResult)
-//    import numbers.*, ScalesPartialTransformer.shortToLongPartialInner
-//
-//    (short.Zero: short.NumScale[String, Nothing])
-//      .transformIntoPartial[long.NumScale[Int]]
-//      .asOption ==> Some(long.Zero)
-//    (short.Million("4"): short.NumScale[String, Nothing])
-//      .transformIntoPartial[long.NumScale[Int]]
-//      .asOption ==> Some(long.Million(4))
-//    (short.Billion("2"): short.NumScale[String, Nothing])
-//      .transformIntoPartial[long.NumScale[Int]]
-//      .asOption ==> Some(long.Milliard(2))
-//    (short.Trillion("100"): short.NumScale[String, Nothing])
-//      .transformIntoPartial[long.NumScale[Int]]
-//      .asOption ==> Some(long.Billion(100))
-//
-//    (short.Million("x"): short.NumScale[String, Nothing])
-//      .transformIntoPartial[long.NumScale[Int]]
-//      .asOption ==> None
-//    (short.Billion("x"): short.NumScale[String, Nothing])
-//      .transformIntoPartial[long.NumScale[Int]]
-//      .asOption ==> None
-//    (short.Trillion("x"): short.NumScale[String, Nothing])
-//      .transformIntoPartial[long.NumScale[Int]]
-//      .asOption ==> None
-//  }
-//
-//  test(
-//    """transforming nested sealed hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable"""
-//  ) {
-//    (shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)): shapes3.Shape)
-//      .transformIntoPartial[shapes4.Shape]
-//      .asOption ==>
-//      Some(shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0)))
-//    (shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0)): shapes3.Shape)
-//      .transformIntoPartial[shapes4.Shape]
-//      .asOption ==>
-//      Some(shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0)))
-//    (shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0)): shapes4.Shape)
-//      .transformIntoPartial[shapes3.Shape]
-//      .asOption ==>
-//      Some(shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)))
-//    (shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0)): shapes4.Shape)
-//      .transformIntoPartial[shapes3.Shape]
-//      .asOption ==>
-//      Some(shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0)))
-//  }
-//
-//  group("setting .withCoproductInstance(mapping)") {
+  test(
+    """transform between Java Enums flat and nested hierarchies of case objects without modifiers"""
+  ) {
+    (jcolors2.Color.Red: jcolors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Red)
+    (jcolors2.Color.Green: jcolors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Green)
+    (jcolors2.Color.Blue: jcolors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Blue)
+    (jcolors2.Color.Black: jcolors2.Color).transformIntoPartial[colors3.Color].asOption ==> Some(colors3.Black)
+
+    (colors3.Red: colors3.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Red)
+    (colors3.Green: colors3.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Green)
+    (colors3.Blue: colors3.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Blue)
+    (colors3.Black: colors3.Color).transformIntoPartial[jcolors2.Color].asOption ==> Some(jcolors2.Color.Black)
+  }
+
+  test(
+    "not allow transformation of of sealed hierarchies when the transformation would be ambiguous".withTags(
+      if (isScala3) Set(munit.Ignore)
+      else Set.empty // ignore only on Scala 3 until https://github.com/lampepfl/dotty/issues/18484 is fixed
+    )
+  ) {
+    val error = compileErrorsScala2(
+      """(jcolors2.Color.Black: jcolors2.Color).transformIntoPartial[colors4.Color]"""
+    )
+
+    error.check(
+      "Chimney can't derive transformation from io.scalaland.chimney.javafixtures.jcolors2.Color to io.scalaland.chimney.fixtures.colors4.Color",
+      "io.scalaland.chimney.fixtures.colors4.Color",
+      "coproduct instance Green of io.scalaland.chimney.fixtures.colors4.Color is ambiguous",
+      "coproduct instance Black of io.scalaland.chimney.fixtures.colors4.Color is ambiguous",
+      "Consult https://chimney.readthedocs.io for usage examples."
+    )
+
+    error.checkNot(
+      "coproduct instance Red of io.scalaland.chimney.fixtures.colors4.Color is ambiguous",
+      "coproduct instance Blue of io.scalaland.chimney.fixtures.colors4.Color is ambiguous"
+    )
+  }
+
+//  group("setting .withCoproductInstance[Subtype](mapping)") {
 //
 //    test(
 //      """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/PartialTransformerJavaEnumSpec.scala
@@ -3,9 +3,8 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 import io.scalaland.chimney.javafixtures.*
-//import io.scalaland.chimney.utils.OptionUtils.*
 
-//import scala.annotation.unused
+import scala.annotation.unused
 
 class PartialTransformerJavaEnumSpec extends ChimneySpec {
 
@@ -71,213 +70,82 @@ class PartialTransformerJavaEnumSpec extends ChimneySpec {
     )
   }
 
-//  group("setting .withCoproductInstance[Subtype](mapping)") {
-//
-//    test(
-//      """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""
-//    ) {
-//      compileErrorsFixed("""(colors2.Black: colors2.Color).transformIntoPartial[colors1.Color]""").check(
-//        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.colors2.Color to io.scalaland.chimney.fixtures.colors1.Color",
-//        "io.scalaland.chimney.fixtures.colors1.Color",
-//        "can't transform coproduct instance io.scalaland.chimney.fixtures.colors2.Black to io.scalaland.chimney.fixtures.colors1.Color",
-//        "Consult https://chimney.readthedocs.io for usage examples."
-//      )
-//    }
-//
-//    test(
-//      """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
-//    ) {
-//      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
-//        colors1.Red
-//
-//      (colors2.Black: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform
-//        .asOption ==> Some(colors1.Red)
-//
-//      (colors2.Red: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform
-//        .asOption ==> Some(colors1.Red)
-//
-//      (colors2.Green: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform
-//        .asOption ==> Some(colors1.Green)
-//
-//      (colors2.Blue: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform
-//        .asOption ==> Some(colors1.Blue)
-//    }
-//
-//    test(
-//      """transform sealed hierarchies from "superset" of case classes to "subset" of case classes when user-provided mapping handled non-trivial cases"""
-//    ) {
-//      def triangleToPolygon(t: shapes1.Triangle): shapes2.Shape =
-//        shapes2.Polygon(
-//          List(
-//            t.p1.transformInto[shapes2.Point],
-//            t.p2.transformInto[shapes2.Point],
-//            t.p3.transformInto[shapes2.Point]
-//          )
-//        )
-//
-//      def rectangleToPolygon(r: shapes1.Rectangle): shapes2.Shape =
-//        shapes2.Polygon(
-//          List(
-//            r.p1.transformInto[shapes2.Point],
-//            shapes2.Point(r.p1.x, r.p2.y),
-//            r.p2.transformInto[shapes2.Point],
-//            shapes2.Point(r.p2.x, r.p1.y)
-//          )
-//        )
-//
-//      val triangle: shapes1.Shape =
-//        shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
-//
-//      triangle
-//        .intoPartial[shapes2.Shape]
-//        .withCoproductInstance(triangleToPolygon)
-//        .withCoproductInstance(rectangleToPolygon)
-//        .transform
-//        .asOption ==> Some(shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0))))
-//
-//      val rectangle: shapes1.Shape =
-//        shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4))
-//
-//      rectangle
-//        .intoPartial[shapes2.Shape]
-//        .withCoproductInstance[shapes1.Shape] {
-//          case r: shapes1.Rectangle => rectangleToPolygon(r)
-//          case t: shapes1.Triangle => triangleToPolygon(t)
-//        }
-//        .transform
-//        .asOption ==> Some(
-//        shapes2.Polygon(
-//          List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
-//        )
-//      )
-//    }
-//  }
-//
-//  test(
-//    "transform sealed hierarchies of single value wrapping case classes to sealed hierarchy of flat case classes subtypes"
-//  ) {
-//    val triangle: shapes1.Shape = shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
-//    triangle.transformIntoPartial[shapes6.Shape].asOption ==> Some(
-//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
-//    )
-//
-//    val rectangle: shapes1.Shape = shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
-//    rectangle.transformIntoPartial[shapes6.Shape].asOption ==> Some(
-//      shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
-//    )
-//  }
-//
-//  test(
-//    "transform sealed hierarchies of flat case classes subtypes to sealed hierarchy of single value wrapping case classes"
-//  ) {
-//    val triangle: shapes6.Shape =
-//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
-//    triangle.transformIntoPartial[shapes1.Shape].asOption ==> Some(
-//      shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
-//    )
-//
-//    val rectangle: shapes6.Shape = shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
-//    rectangle.transformIntoPartial[shapes1.Shape].asOption ==> Some(
-//      shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
-//    )
-//  }
-//
-//  group("setting .withCoproductInstancePartial[Subtype](mapping)") {
-//
-//    test(
-//      """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
-//    ) {
-//      def blackIsRed(b: colors2.Black.type): partial.Result[colors1.Color] =
-//        partial.Result.fromEmpty
-//
-//      (colors2.Black: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstancePartial(blackIsRed)
-//        .transform
-//        .asOption ==> None
-//
-//      (colors2.Red: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstancePartial(blackIsRed)
-//        .transform
-//        .asOption ==> Some(colors1.Red)
-//
-//      (colors2.Green: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstancePartial(blackIsRed)
-//        .transform
-//        .asOption ==> Some(colors1.Green)
-//
-//      (colors2.Blue: colors2.Color)
-//        .intoPartial[colors1.Color]
-//        .withCoproductInstancePartial(blackIsRed)
-//        .transform
-//        .asOption ==> Some(colors1.Blue)
-//    }
-//
-//    test(
-//      """transform sealed hierarchies from "superset" of case classes to "subset" of case classes when user-provided mapping handled non-trivial cases"""
-//    ) {
-//      def triangleToPolygon(t: shapes1.Triangle): partial.Result[shapes2.Shape] =
-//        partial.Result.fromValue(
-//          shapes2.Polygon(
-//            List(
-//              t.p1.transformInto[shapes2.Point],
-//              t.p2.transformInto[shapes2.Point],
-//              t.p3.transformInto[shapes2.Point]
-//            )
-//          )
-//        )
-//
-//      def rectangleToPolygon(r: shapes1.Rectangle): partial.Result[shapes2.Shape] =
-//        partial.Result.fromValue(
-//          shapes2.Polygon(
-//            List(
-//              r.p1.transformInto[shapes2.Point],
-//              shapes2.Point(r.p1.x, r.p2.y),
-//              r.p2.transformInto[shapes2.Point],
-//              shapes2.Point(r.p2.x, r.p1.y)
-//            )
-//          )
-//        )
-//
-//      val triangle: shapes1.Shape =
-//        shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
-//
-//      triangle
-//        .intoPartial[shapes2.Shape]
-//        .withCoproductInstancePartial(triangleToPolygon)
-//        .withCoproductInstancePartial(rectangleToPolygon)
-//        .transform
-//        .asOption ==> Some(shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0))))
-//
-//      val rectangle: shapes1.Shape =
-//        shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4))
-//
-//      rectangle
-//        .intoPartial[shapes2.Shape]
-//        .withCoproductInstancePartial[shapes1.Shape] {
-//          case r: shapes1.Rectangle => rectangleToPolygon(r)
-//          case t: shapes1.Triangle => triangleToPolygon(t)
-//        }
-//        .transform
-//        .asOption ==> Some(
-//        shapes2.Polygon(
-//          List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
-//        )
-//      )
-//    }
-//  }
+  group("setting .withCoproductInstance[Subtype](mapping)") {
+
+    test(
+      """should be absent by default and not allow transforming Java Enum "superset" instances to sealed hierarchy "subset" of case objects"""
+    ) {
+      compileErrorsFixed("""(jcolors2.Color.Black: jcolors2.Color).transformIntoPartial[colors1.Color]""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.javafixtures.jcolors2.Color to io.scalaland.chimney.fixtures.colors1.Color",
+        "io.scalaland.chimney.fixtures.colors1.Color",
+        "can't transform coproduct instance io.scalaland.chimney.javafixtures.jcolors2.Color.Black to io.scalaland.chimney.fixtures.colors1.Color",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+
+    test(
+      """transform from Java Enum "superset" instances to sealed hierarchy "subset" of case objects when user-provided mapping handled additional cases"""
+    ) {
+      def blackIsRed(@unused b: jcolors2.Color.Black.type): colors1.Color =
+        colors1.Red
+
+      (jcolors2.Color.Black: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform
+        .asOption ==> Some(colors1.Red)
+
+      (jcolors2.Color.Red: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform
+        .asOption ==> Some(colors1.Red)
+
+      (jcolors2.Color.Green: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform
+        .asOption ==> Some(colors1.Green)
+
+      (jcolors2.Color.Blue: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform
+        .asOption ==> Some(colors1.Blue)
+    }
+  }
+
+  group("setting .withCoproductInstancePartial[Subtype](mapping)") {
+
+    test(
+      """transform from Java Enum "superset" instances to sealed hierarchy "subset" of case objects when user-provided mapping handled additional cases"""
+    ) {
+      def blackIsRed(b: jcolors2.Color.Black.type): partial.Result[colors1.Color] =
+        partial.Result.fromEmpty
+
+      (jcolors2.Color.Black: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstancePartial(blackIsRed)
+        .transform
+        .asOption ==> None
+
+      (jcolors2.Color.Red: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstancePartial(blackIsRed)
+        .transform
+        .asOption ==> Some(colors1.Red)
+
+      (jcolors2.Color.Green: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstancePartial(blackIsRed)
+        .transform
+        .asOption ==> Some(colors1.Green)
+
+      (jcolors2.Color.Blue: jcolors2.Color)
+        .intoPartial[colors1.Color]
+        .withCoproductInstancePartial(blackIsRed)
+        .transform
+        .asOption ==> Some(colors1.Blue)
+    }
+  }
 }

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
@@ -32,105 +32,44 @@ class TotalTransformerJavaEnumSpec extends ChimneySpec {
     (jcolors1.Color.Blue: jcolors1.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Blue
   }
 
-//  test(
-//    """transform nested sealed hierarchies between flat and nested hierarchies of case objects without modifiers"""
-//  ) {
-//    (colors2.Red: colors2.Color).transformInto[colors3.Color] ==> colors3.Red
-//    (colors2.Green: colors2.Color).transformInto[colors3.Color] ==> colors3.Green
-//    (colors2.Blue: colors2.Color).transformInto[colors3.Color] ==> colors3.Blue
-//    (colors2.Black: colors2.Color).transformInto[colors3.Color] ==> colors3.Black
-//
-//    (colors3.Red: colors3.Color).transformInto[colors2.Color] ==> colors2.Red
-//    (colors3.Green: colors3.Color).transformInto[colors2.Color] ==> colors2.Green
-//    (colors3.Blue: colors3.Color).transformInto[colors2.Color] ==> colors2.Blue
-//    (colors3.Black: colors3.Color).transformInto[colors2.Color] ==> colors2.Black
-//  }
-//
-//  test(
-//    """transforming flat hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable with Total Transformers"""
-//  ) {
-//    implicit val intToDoubleTransformer: Transformer[Int, Double] = (_: Int).toDouble
-//
-//    (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
-//      .transformInto[shapes3.Shape] ==>
-//      shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0))
-//
-//    (shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4)): shapes1.Shape)
-//      .transformInto[shapes3.Shape] ==>
-//      shapes3.Rectangle(shapes3.Point(0.0, 0.0), shapes3.Point(6.0, 4.0))
-//  }
-//
-//  test(
-//    """transforming nested sealed hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable"""
-//  ) {
-//    (shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)): shapes3.Shape)
-//      .transformInto[shapes4.Shape] ==>
-//      shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0))
-//
-//    (shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0)): shapes3.Shape)
-//      .transformInto[shapes4.Shape] ==>
-//      shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0))
-//
-//    (shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0)): shapes4.Shape)
-//      .transformInto[shapes3.Shape] ==>
-//      shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0))
-//
-//    (shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0)): shapes4.Shape)
-//      .transformInto[shapes3.Shape] ==>
-//      shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0))
-//  }
-//
-//  test(
-//    "transform sealed hierarchies of single value wrapping case classes to sealed hierarchy of flat case classes subtypes"
-//  ) {
-//    val triangle: shapes1.Shape = shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
-//    triangle.transformInto[shapes6.Shape] ==>
-//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
-//
-//    val rectangle: shapes1.Shape = shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
-//    rectangle.transformInto[shapes6.Shape] ==>
-//      shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
-//  }
-//
-//  test(
-//    "transform sealed hierarchies of flat case classes subtypes to sealed hierarchy of single value wrapping case classes"
-//  ) {
-//    val triangle: shapes6.Shape =
-//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
-//    triangle.transformInto[shapes1.Shape] ==>
-//      shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
-//
-//    val rectangle: shapes6.Shape = shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
-//    rectangle.transformInto[shapes1.Shape] ==>
-//      shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
-//  }
-//
-//  test(
-//    "not allow transformation of of sealed hierarchies when the transformation would be ambiguous".withTags(
-//      if (isScala3) Set(munit.Ignore)
-//      else Set.empty // ignore only on Scala 3 until https://github.com/lampepfl/dotty/issues/18484 is fixed
-//    )
-//  ) {
-//    val error = compileErrorsScala2(
-//      """
-//           (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
-//             .transformInto[shapes5.Shape]
-//        """
-//    )
-//
-//    error.check(
-//      "Chimney can't derive transformation from io.scalaland.chimney.fixtures.shapes1.Shape to io.scalaland.chimney.fixtures.shapes5.Shape",
-//      "io.scalaland.chimney.fixtures.shapes5.Shape",
-//      "coproduct instance Triangle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous",
-//      "coproduct instance Rectangle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous",
-//      "Consult https://chimney.readthedocs.io for usage examples."
-//    )
-//
-//    error.checkNot(
-//      "coproduct instance Circle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous"
-//    )
-//  }
-//
+  test(
+    """transform between Java Enums flat and nested hierarchies of case objects without modifiers"""
+  ) {
+    (jcolors2.Color.Red: jcolors2.Color).transformInto[colors3.Color] ==> colors3.Red
+    (jcolors2.Color.Green: jcolors2.Color).transformInto[colors3.Color] ==> colors3.Green
+    (jcolors2.Color.Blue: jcolors2.Color).transformInto[colors3.Color] ==> colors3.Blue
+    (jcolors2.Color.Black: jcolors2.Color).transformInto[colors3.Color] ==> colors3.Black
+
+    (colors3.Red: colors3.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Red
+    (colors3.Green: colors3.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Green
+    (colors3.Blue: colors3.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Blue
+    (colors3.Black: colors3.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Black
+  }
+
+  test(
+    "not allow transformation of of sealed hierarchies when the transformation would be ambiguous".withTags(
+      if (isScala3) Set(munit.Ignore)
+      else Set.empty // ignore only on Scala 3 until https://github.com/lampepfl/dotty/issues/18484 is fixed
+    )
+  ) {
+    val error = compileErrorsScala2(
+      """(jcolors2.Color.Black: jcolors2.Color).transformInto[colors4.Color]"""
+    )
+
+    error.check(
+      "Chimney can't derive transformation from io.scalaland.chimney.javafixtures.jcolors2.Color to io.scalaland.chimney.fixtures.colors4.Color",
+      "io.scalaland.chimney.fixtures.colors4.Color",
+      "coproduct instance Green of io.scalaland.chimney.fixtures.colors4.Color is ambiguous",
+      "coproduct instance Black of io.scalaland.chimney.fixtures.colors4.Color is ambiguous",
+      "Consult https://chimney.readthedocs.io for usage examples."
+    )
+
+    error.checkNot(
+      "coproduct instance Red of io.scalaland.chimney.fixtures.colors4.Color is ambiguous",
+      "coproduct instance Blue of io.scalaland.chimney.fixtures.colors4.Color is ambiguous"
+    )
+  }
+
 //  group("setting .withCoproductInstance[Subtype](mapping)") {
 //
 //    test(

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
@@ -91,22 +91,22 @@ class TotalTransformerJavaEnumSpec extends ChimneySpec {
 
       (jcolors2.Color.Black: jcolors2.Color)
         .into[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform ==> colors1.Red
 
       (jcolors2.Color.Red: jcolors2.Color)
         .into[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform ==> colors1.Red
 
       (jcolors2.Color.Green: jcolors2.Color)
         .into[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform ==> colors1.Green
 
       (jcolors2.Color.Blue: jcolors2.Color)
         .into[colors1.Color]
-        .withCoproductInstance(blackIsRed)
+        .withCoproductInstance((b: jcolors2.Color.Black.type) => blackIsRed(b))
         .transform ==> colors1.Blue
     }
   }

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
@@ -1,0 +1,219 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+import io.scalaland.chimney.javafixtures.*
+
+//import scala.annotation.unused
+
+class TotalTransformerJavaEnumSpec extends ChimneySpec {
+
+  test(
+    """transform flat sealed hierarchies from "subset" of case objects to "superset" of case objects without modifiers"""
+  ) {
+    (jcolors1.Color.Red: jcolors1.Color).transformInto[colors2.Color] ==> colors2.Red
+    (jcolors1.Color.Green: jcolors1.Color).transformInto[colors2.Color] ==> colors2.Green
+    (jcolors1.Color.Blue: jcolors1.Color).transformInto[colors2.Color] ==> colors2.Blue
+  }
+
+  test(
+    """transform from sealed hierarchies "subset" of case objects to "superset" of Java Enums instances without modifiers"""
+  ) {
+    (colors1.Red: colors1.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Red
+    (colors1.Green: colors1.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Green
+    (colors1.Blue: colors1.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Blue
+  }
+
+  test(
+    """transform Java Enums from "subset" of instances to "superset" of instances without modifiers"""
+  ) {
+    (jcolors1.Color.Red: jcolors1.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Red
+    (jcolors1.Color.Green: jcolors1.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Green
+    (jcolors1.Color.Blue: jcolors1.Color).transformInto[jcolors2.Color] ==> jcolors2.Color.Blue
+  }
+
+//  test(
+//    """transform nested sealed hierarchies between flat and nested hierarchies of case objects without modifiers"""
+//  ) {
+//    (colors2.Red: colors2.Color).transformInto[colors3.Color] ==> colors3.Red
+//    (colors2.Green: colors2.Color).transformInto[colors3.Color] ==> colors3.Green
+//    (colors2.Blue: colors2.Color).transformInto[colors3.Color] ==> colors3.Blue
+//    (colors2.Black: colors2.Color).transformInto[colors3.Color] ==> colors3.Black
+//
+//    (colors3.Red: colors3.Color).transformInto[colors2.Color] ==> colors2.Red
+//    (colors3.Green: colors3.Color).transformInto[colors2.Color] ==> colors2.Green
+//    (colors3.Blue: colors3.Color).transformInto[colors2.Color] ==> colors2.Blue
+//    (colors3.Black: colors3.Color).transformInto[colors2.Color] ==> colors2.Black
+//  }
+//
+//  test(
+//    """transforming flat hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable with Total Transformers"""
+//  ) {
+//    implicit val intToDoubleTransformer: Transformer[Int, Double] = (_: Int).toDouble
+//
+//    (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
+//      .transformInto[shapes3.Shape] ==>
+//      shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0))
+//
+//    (shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4)): shapes1.Shape)
+//      .transformInto[shapes3.Shape] ==>
+//      shapes3.Rectangle(shapes3.Point(0.0, 0.0), shapes3.Point(6.0, 4.0))
+//  }
+//
+//  test(
+//    """transforming nested sealed hierarchies from "subset" of case classes to "superset" of case classes without modifiers when common corresponding types are transformable"""
+//  ) {
+//    (shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0)): shapes3.Shape)
+//      .transformInto[shapes4.Shape] ==>
+//      shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0))
+//
+//    (shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0)): shapes3.Shape)
+//      .transformInto[shapes4.Shape] ==>
+//      shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0))
+//
+//    (shapes4.Triangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0), shapes4.Point(0.0, 0.0)): shapes4.Shape)
+//      .transformInto[shapes3.Shape] ==>
+//      shapes3.Triangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0), shapes3.Point(0.0, 0.0))
+//
+//    (shapes4.Rectangle(shapes4.Point(2.0, 0.0), shapes4.Point(2.0, 2.0)): shapes4.Shape)
+//      .transformInto[shapes3.Shape] ==>
+//      shapes3.Rectangle(shapes3.Point(2.0, 0.0), shapes3.Point(2.0, 2.0))
+//  }
+//
+//  test(
+//    "transform sealed hierarchies of single value wrapping case classes to sealed hierarchy of flat case classes subtypes"
+//  ) {
+//    val triangle: shapes1.Shape = shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+//    triangle.transformInto[shapes6.Shape] ==>
+//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
+//
+//    val rectangle: shapes1.Shape = shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
+//    rectangle.transformInto[shapes6.Shape] ==>
+//      shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
+//  }
+//
+//  test(
+//    "transform sealed hierarchies of flat case classes subtypes to sealed hierarchy of single value wrapping case classes"
+//  ) {
+//    val triangle: shapes6.Shape =
+//      shapes6.Triangle(shapes6.Shape.Triangle(shapes6.Point(0, 0), shapes6.Point(2, 2), shapes6.Point(2, 0)))
+//    triangle.transformInto[shapes1.Shape] ==>
+//      shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+//
+//    val rectangle: shapes6.Shape = shapes6.Rectangle(shapes6.Shape.Rectangle(shapes6.Point(0, 0), shapes6.Point(2, 2)))
+//    rectangle.transformInto[shapes1.Shape] ==>
+//      shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(2, 2))
+//  }
+//
+//  test(
+//    "not allow transformation of of sealed hierarchies when the transformation would be ambiguous".withTags(
+//      if (isScala3) Set(munit.Ignore)
+//      else Set.empty // ignore only on Scala 3 until https://github.com/lampepfl/dotty/issues/18484 is fixed
+//    )
+//  ) {
+//    val error = compileErrorsScala2(
+//      """
+//           (shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0)): shapes1.Shape)
+//             .transformInto[shapes5.Shape]
+//        """
+//    )
+//
+//    error.check(
+//      "Chimney can't derive transformation from io.scalaland.chimney.fixtures.shapes1.Shape to io.scalaland.chimney.fixtures.shapes5.Shape",
+//      "io.scalaland.chimney.fixtures.shapes5.Shape",
+//      "coproduct instance Triangle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous",
+//      "coproduct instance Rectangle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous",
+//      "Consult https://chimney.readthedocs.io for usage examples."
+//    )
+//
+//    error.checkNot(
+//      "coproduct instance Circle of io.scalaland.chimney.fixtures.shapes5.Shape is ambiguous"
+//    )
+//  }
+//
+//  group("setting .withCoproductInstance[Subtype](mapping)") {
+//
+//    test(
+//      """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""
+//    ) {
+//      compileErrorsFixed("""(colors2.Black: colors2.Color).transformInto[colors1.Color]""").check(
+//        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.colors2.Color to io.scalaland.chimney.fixtures.colors1.Color",
+//        "io.scalaland.chimney.fixtures.colors1.Color",
+//        "can't transform coproduct instance io.scalaland.chimney.fixtures.colors2.Black to io.scalaland.chimney.fixtures.colors1.Color",
+//        "Consult https://chimney.readthedocs.io for usage examples."
+//      )
+//    }
+//
+//    test(
+//      """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
+//    ) {
+//      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
+//        colors1.Red
+//
+//      (colors2.Black: colors2.Color)
+//        .into[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform ==> colors1.Red
+//
+//      (colors2.Red: colors2.Color)
+//        .into[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform ==> colors1.Red
+//
+//      (colors2.Green: colors2.Color)
+//        .into[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform ==> colors1.Green
+//
+//      (colors2.Blue: colors2.Color)
+//        .into[colors1.Color]
+//        .withCoproductInstance(blackIsRed)
+//        .transform ==> colors1.Blue
+//    }
+//
+//    test(
+//      """transform sealed hierarchies from "superset" of case classes to "subset" of case classes when user-provided mapping handled non-trivial cases"""
+//    ) {
+//      def triangleToPolygon(t: shapes1.Triangle): shapes2.Shape =
+//        shapes2.Polygon(
+//          List(
+//            t.p1.transformInto[shapes2.Point],
+//            t.p2.transformInto[shapes2.Point],
+//            t.p3.transformInto[shapes2.Point]
+//          )
+//        )
+//
+//      def rectangleToPolygon(r: shapes1.Rectangle): shapes2.Shape =
+//        shapes2.Polygon(
+//          List(
+//            r.p1.transformInto[shapes2.Point],
+//            shapes2.Point(r.p1.x, r.p2.y),
+//            r.p2.transformInto[shapes2.Point],
+//            shapes2.Point(r.p2.x, r.p1.y)
+//          )
+//        )
+//
+//      val triangle: shapes1.Shape =
+//        shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
+//
+//      triangle
+//        .into[shapes2.Shape]
+//        .withCoproductInstance(triangleToPolygon)
+//        .withCoproductInstance(rectangleToPolygon)
+//        .transform ==> shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0)))
+//
+//      val rectangle: shapes1.Shape =
+//        shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4))
+//
+//      rectangle
+//        .into[shapes2.Shape]
+//        .withCoproductInstance[shapes1.Shape] {
+//          case r: shapes1.Rectangle => rectangleToPolygon(r)
+//          case t: shapes1.Triangle => triangleToPolygon(t)
+//        }
+//        .transform ==> shapes2.Polygon(
+//        List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
+//      )
+//    }
+//  }
+}

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
@@ -4,12 +4,12 @@ import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 import io.scalaland.chimney.javafixtures.*
 
-//import scala.annotation.unused
+import scala.annotation.unused
 
 class TotalTransformerJavaEnumSpec extends ChimneySpec {
 
   test(
-    """transform flat sealed hierarchies from "subset" of case objects to "superset" of case objects without modifiers"""
+    """transform from Java Enum "subset" instances to sealed hierarchy "superset" of case objects without modifiers"""
   ) {
     (jcolors1.Color.Red: jcolors1.Color).transformInto[colors2.Color] ==> colors2.Red
     (jcolors1.Color.Green: jcolors1.Color).transformInto[colors2.Color] ==> colors2.Green
@@ -70,89 +70,44 @@ class TotalTransformerJavaEnumSpec extends ChimneySpec {
     )
   }
 
-//  group("setting .withCoproductInstance[Subtype](mapping)") {
-//
-//    test(
-//      """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""
-//    ) {
-//      compileErrorsFixed("""(colors2.Black: colors2.Color).transformInto[colors1.Color]""").check(
-//        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.colors2.Color to io.scalaland.chimney.fixtures.colors1.Color",
-//        "io.scalaland.chimney.fixtures.colors1.Color",
-//        "can't transform coproduct instance io.scalaland.chimney.fixtures.colors2.Black to io.scalaland.chimney.fixtures.colors1.Color",
-//        "Consult https://chimney.readthedocs.io for usage examples."
-//      )
-//    }
-//
-//    test(
-//      """transform sealed hierarchies from "superset" of case objects to "subset" of case objects when user-provided mapping handled additional cases"""
-//    ) {
-//      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
-//        colors1.Red
-//
-//      (colors2.Black: colors2.Color)
-//        .into[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform ==> colors1.Red
-//
-//      (colors2.Red: colors2.Color)
-//        .into[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform ==> colors1.Red
-//
-//      (colors2.Green: colors2.Color)
-//        .into[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform ==> colors1.Green
-//
-//      (colors2.Blue: colors2.Color)
-//        .into[colors1.Color]
-//        .withCoproductInstance(blackIsRed)
-//        .transform ==> colors1.Blue
-//    }
-//
-//    test(
-//      """transform sealed hierarchies from "superset" of case classes to "subset" of case classes when user-provided mapping handled non-trivial cases"""
-//    ) {
-//      def triangleToPolygon(t: shapes1.Triangle): shapes2.Shape =
-//        shapes2.Polygon(
-//          List(
-//            t.p1.transformInto[shapes2.Point],
-//            t.p2.transformInto[shapes2.Point],
-//            t.p3.transformInto[shapes2.Point]
-//          )
-//        )
-//
-//      def rectangleToPolygon(r: shapes1.Rectangle): shapes2.Shape =
-//        shapes2.Polygon(
-//          List(
-//            r.p1.transformInto[shapes2.Point],
-//            shapes2.Point(r.p1.x, r.p2.y),
-//            r.p2.transformInto[shapes2.Point],
-//            shapes2.Point(r.p2.x, r.p1.y)
-//          )
-//        )
-//
-//      val triangle: shapes1.Shape =
-//        shapes1.Triangle(shapes1.Point(0, 0), shapes1.Point(2, 2), shapes1.Point(2, 0))
-//
-//      triangle
-//        .into[shapes2.Shape]
-//        .withCoproductInstance(triangleToPolygon)
-//        .withCoproductInstance(rectangleToPolygon)
-//        .transform ==> shapes2.Polygon(List(shapes2.Point(0, 0), shapes2.Point(2, 2), shapes2.Point(2, 0)))
-//
-//      val rectangle: shapes1.Shape =
-//        shapes1.Rectangle(shapes1.Point(0, 0), shapes1.Point(6, 4))
-//
-//      rectangle
-//        .into[shapes2.Shape]
-//        .withCoproductInstance[shapes1.Shape] {
-//          case r: shapes1.Rectangle => rectangleToPolygon(r)
-//          case t: shapes1.Triangle => triangleToPolygon(t)
-//        }
-//        .transform ==> shapes2.Polygon(
-//        List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
-//      )
-//    }
-//  }
+  group("setting .withCoproductInstance[Subtype](mapping)") {
+
+    test(
+      """should be absent by default and not allow transforming Java Enum "superset" instances to sealed hierarchy "subset" of case objects"""
+    ) {
+      compileErrorsFixed("""(jcolors2.Color.Black: jcolors2.Color).transformInto[colors1.Color]""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.javafixtures.jcolors2.Color to io.scalaland.chimney.fixtures.colors1.Color",
+        "io.scalaland.chimney.fixtures.colors1.Color",
+        "can't transform coproduct instance io.scalaland.chimney.javafixtures.jcolors2.Color.Black to io.scalaland.chimney.fixtures.colors1.Color",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+
+    test(
+      """transform from Java Enum "superset" instances to sealed hierarchy "subset" of case objects when user-provided mapping handled additional cases"""
+    ) {
+      def blackIsRed(@unused b: jcolors2.Color.Black.type): colors1.Color =
+        colors1.Red
+
+      (jcolors2.Color.Black: jcolors2.Color)
+        .into[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform ==> colors1.Red
+
+      (jcolors2.Color.Red: jcolors2.Color)
+        .into[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform ==> colors1.Red
+
+      (jcolors2.Color.Green: jcolors2.Color)
+        .into[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform ==> colors1.Green
+
+      (jcolors2.Color.Blue: jcolors2.Color)
+        .into[colors1.Color]
+        .withCoproductInstance(blackIsRed)
+        .transform ==> colors1.Blue
+    }
+  }
 }


### PR DESCRIPTION
- [x] parse `java.util.Enum` into `SealedHierarchies` `Enum` ADT
  - [x] in Scala 2 macros 
  - [x] in Scala 3 macros
- [x] parse `java.util.Enum` in DSL
  - [x] `withCoproductInstance`
    - [x] in Scala 2 macros 
    - [x] in Scala 3 macros
  - [x] `withCoproductInstancePartial`
    - [x] in Scala 2 macros 
    - [x] in Scala 3 macros
- [x] create `TotalTransformerJavaEnumSpec`
  - [x] enable all tests as DSL parsing will proceed
- [x] creatr `PartialTransformerJavaEnumSpec`
  - [x] enable all tests as DSL parsing will proceed
- [ ] describe in documentation the limitation of `withCoproduct*` for Java Enums (on Scala 2 type inference will upcast and loose information of particular `enum` value, need to provide `{ name: JavaEnum.Value.type => ... }` explicitly so that macro could parse the whole tree)