### PR TITLE
Filter out no symbols and handle AnyVals with private constructors

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -16,7 +16,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
       def isParameterless(method: MethodSymbol): Boolean = method.paramLists.flatten.isEmpty
 
       def isDefaultConstructor(ctor: Symbol): Boolean =
-        ctor.isPublic && ctor.isConstructor && isParameterless(ctor.asMethod)
+        ctor != NoSymbol && ctor.isPublic && ctor.isConstructor && isParameterless(ctor.asMethod)
 
       def isAccessor(accessor: MethodSymbol): Boolean =
         accessor.isPublic && isParameterless(accessor)
@@ -38,7 +38,6 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
       def isJavaSetterOrVar(setter: Symbol): Boolean =
         (setter.isMethod && isJavaSetter(setter.asMethod)) || isVar(setter)
-
     }
 
     import platformSpecific.*
@@ -46,9 +45,8 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
     def isPOJO[A](implicit A: Type[A]): Boolean = {
       val sym = A.tpe.typeSymbol
-      !A.isPrimitive && !(A <:< Type[
-        String
-      ]) && !sym.isJavaEnum && sym.isClass && !sym.isAbstract && sym.asClass.primaryConstructor.isPublic
+      !A.isPrimitive && !(A <:< Type[String]) && !sym.isJavaEnum && sym.isClass && !sym.isAbstract &&
+      sym.asClass.primaryConstructor != NoSymbol && sym.asClass.primaryConstructor.isPublic
     }
     def isCaseClass[A](implicit A: Type[A]): Boolean =
       isPOJO[A] && A.tpe.typeSymbol.asClass.isCaseClass

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -15,8 +15,9 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
       val A = Type[A].tpe
 
       val getterOpt: Option[Symbol] = A.decls.to(List).find(m => m.isPublic && m.isMethod && m.asMethod.isGetter)
-      val primaryConstructorOpt: Option[Symbol] = A.decls
-        .to(List)
+      val primaryConstructorOpt: Option[Symbol] = Option(A.typeSymbol)
+        .filter(_.isClass)
+        .map(_.asClass.primaryConstructor)
         .find(m => m.isPublic && m.isConstructor && m.asMethod.paramLists.flatten.size == 1)
       val argumentOpt: Option[Symbol] = primaryConstructorOpt.flatMap(_.asMethod.paramLists.flatten.headOption)
 

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -14,7 +14,8 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
       val sym: Symbol = A.typeSymbol
 
       val getterOpt: Option[Symbol] = sym.declarations.filter(isPublic).headOption
-      val primaryConstructorOpt: Option[Symbol] = Option(sym.primaryConstructor).filter(_.isClassConstructor)
+      val primaryConstructorOpt: Option[Symbol] =
+        Option(sym.primaryConstructor).filterNot(_.isNoSymbol).filter(_.isClassConstructor).filter(isPublic)
       val argumentOpt: Option[Symbol] = primaryConstructorOpt.flatMap { primaryConstructor =>
         paramListsOf(A, primaryConstructor).flatten match {
           case argument :: Nil => Some(argument)
@@ -52,6 +53,7 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
     }
 
     private def isPublic(sym: Symbol): Boolean =
-      !(sym.flags.is(Flags.Private) || sym.flags.is(Flags.PrivateLocal) || sym.flags.is(Flags.Protected))
+      !sym.isNoSymbol &&
+        (!(sym.flags.is(Flags.Private) || sym.flags.is(Flags.PrivateLocal) || sym.flags.is(Flags.Protected)))
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerValueTypeSpec.scala
@@ -24,6 +24,23 @@ class PartialTransformerValueTypeSpec extends ChimneySpec {
     )
   }
 
+  test("AnyVals with private private constructor are not considered value classes") {
+    @unused val transformer: Transformer[String, Int] = (src: String) => src.length
+
+    compileErrorsFixed("AlsoNotAValueType.create(100).transformIntoPartial[UserName]").check(
+      "derivation from value: io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType to io.scalaland.chimney.fixtures.valuetypes.UserName is not supported in Chimney!"
+    )
+    compileErrorsFixed("AlsoNotAValueType.create(100).transformIntoPartial[UserId]").check(
+      "derivation from alsonotavaluetype: io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType to scala.Int is not supported in Chimney!"
+    )
+    compileErrorsFixed("""UserName("Batman").transformIntoPartial[AlsoNotAValueType]""").check(
+      "derivation from username: io.scalaland.chimney.fixtures.valuetypes.UserName to io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType is not supported in Chimney!"
+    )
+    compileErrorsFixed("UserId(100).transformIntoPartial[AlsoNotAValueType]").check(
+      "derivation from userid: io.scalaland.chimney.fixtures.valuetypes.UserId to io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType is not supported in Chimney!"
+    )
+  }
+
   test("transform from a value class(member type 'T') into a value(type 'T')") {
     UserName("Batman").transformIntoPartial[String].asOption ==> Some("Batman")
     User("100", UserName("abc")).transformIntoPartial[UserDTO].asOption ==> Some(UserDTO("100", "abc"))

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerValueTypeSpec.scala
@@ -24,6 +24,23 @@ class TotalTransformerValueTypeSpec extends ChimneySpec {
     )
   }
 
+  test("AnyVals with private private constructor are not considered value classes") {
+    @unused val transformer: Transformer[String, Int] = (src: String) => src.length
+
+    compileErrorsFixed("AlsoNotAValueType.create(100).transformInto[UserName]").check(
+      "derivation from value: io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType to io.scalaland.chimney.fixtures.valuetypes.UserName is not supported in Chimney!"
+    )
+    compileErrorsFixed("AlsoNotAValueType.create(100).transformInto[UserId]").check(
+      "derivation from alsonotavaluetype: io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType to scala.Int is not supported in Chimney!"
+    )
+    compileErrorsFixed("""UserName("Batman").transformInto[AlsoNotAValueType]""").check(
+      "derivation from username: io.scalaland.chimney.fixtures.valuetypes.UserName to io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType is not supported in Chimney!"
+    )
+    compileErrorsFixed("UserId(100).transformInto[AlsoNotAValueType]").check(
+      "derivation from userid: io.scalaland.chimney.fixtures.valuetypes.UserId to io.scalaland.chimney.fixtures.valuetypes.AlsoNotAValueType is not supported in Chimney!"
+    )
+  }
+
   test("transform from a value class(member type: 'T') into a value(type 'T')") {
     UserName("Batman").transformInto[String] ==> "Batman"
     User("100", UserName("abc")).transformInto[UserDTO] ==> UserDTO("100", "abc")

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/valuetypes/valuetypes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/valuetypes/valuetypes.scala
@@ -16,3 +16,9 @@ case class UserWithId(id: Int)
 class NotAValueType(private val integer: Int) extends AnyVal {
   def string: String = integer.toString
 }
+class AlsoNotAValueType private (val integer: Int) extends AnyVal {
+  def string: String = integer.toString
+}
+object AlsoNotAValueType {
+  def create(int: Int): AlsoNotAValueType = new AlsoNotAValueType(int)
+}


### PR DESCRIPTION
Handles some corner cases when:
 - macros would return `primaryConstructor` which is NoSymbol (S2)/Symbol.noSymbol (S3)
 - AnyVal would have a private constructor