### PR TITLE
TransformerConfig's overrides refactoring

### DIFF
--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -159,6 +159,8 @@ private[compiletime] trait Exprs { this: Definitions =>
 
     /** Upcasts `Expr[A]` to `Expr[B]` in the emitted code: '{ (${ expr }) : B } */
     def upcastExpr[B: Type]: Expr[B] = Expr.upcast[A, B](expr)
+
+    def as_?? : ExistentialExpr = ExistentialExpr(expr)
   }
 
   implicit final protected class Function1[A: Type, B: Type](private val function1Expr: Expr[A => B]) {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/PatcherDerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/PatcherDerivationError.scala
@@ -11,13 +11,14 @@ final case class PatchFieldNotFoundInTargetObj(patchFieldName: String, objTypeNa
 
 object PatcherDerivationError {
 
-  def printError(patcherDerivationError: PatcherDerivationError): String = patcherDerivationError match {
-    case NotSupportedPatcherDerivation(objTypeName, patchTypeName) =>
-      s"Patcher derivation not supported for $objTypeName with patch type $patchTypeName"
-    case PatchFieldNotFoundInTargetObj(patchFieldName, objTypeName) =>
-      s"Field named '$patchFieldName' not found in target patching type $objTypeName!"
-  }
-
   def printErrors(errors: Seq[PatcherDerivationError]): String =
-    errors.map(printError).mkString("\n")
+    errors
+      .map {
+        case NotSupportedPatcherDerivation(objTypeName, patchTypeName) =>
+          s"Patcher derivation not supported for $objTypeName with patch type $patchTypeName"
+        case PatchFieldNotFoundInTargetObj(patchFieldName, objTypeName) =>
+          s"Field named '$patchFieldName' not found in target patching type $objTypeName!"
+      }
+      .map(_ + "\n")
+      .mkString("\n")
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
@@ -31,8 +31,8 @@ private[compiletime] trait Configurations { this: Derivation =>
 
     def allowAPatchImplicitSearch: PatcherConfig = copy(preventResolutionForTypes = None)
 
-    def withDefinitionScope(defScope: (??, ??)): PatcherConfig =
-      copy(preventResolutionForTypes = Some(defScope))
+    def preventResolutionFor[A: Type, Patch: Type]: PatcherConfig =
+      copy(preventResolutionForTypes = Some(Type[A].as_?? -> Type[Patch].as_??))
   }
 
   protected object PatcherConfigurations {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Contexts.scala
@@ -21,6 +21,10 @@ private[compiletime] trait Contexts { this: Derivation =>
         derivationStartedAt = derivationStartedAt
       )
         .asInstanceOf[this.type]
+
+    override def toString: String =
+      s"PatcherContext[A = ${Type.prettyPrint(A)}, Patch = ${Type
+          .prettyPrint(Patch)}](obj = ${Expr.prettyPrint(obj)}, patch = ${Expr.prettyPrint(patch)})($config)"
   }
   object PatcherContext {
 
@@ -32,7 +36,7 @@ private[compiletime] trait Contexts { this: Derivation =>
       PatcherContext(obj = obj, patch = patch)(
         A = Type[A],
         Patch = Type[Patch],
-        config = config.preventResolutionFor[A, Patch],
+        config = config.preventImplicitSummoningFor[A, Patch],
         derivationStartedAt = java.time.Instant.now()
       )
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Contexts.scala
@@ -32,7 +32,7 @@ private[compiletime] trait Contexts { this: Derivation =>
       PatcherContext(obj = obj, patch = patch)(
         A = Type[A],
         Patch = Type[Patch],
-        config = config.withDefinitionScope(Type[A].as_?? -> Type[Patch].as_??),
+        config = config.preventResolutionFor[A, Patch],
         derivationStartedAt = java.time.Instant.now()
       )
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Gateway.scala
@@ -72,6 +72,6 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
   private def extractExprAndLog[A: Type, Patch: Type, Out: Type](result: DerivationResult[Expr[Out]]): Expr[Out] =
     extractExprAndLog[Out](
       result,
-      s"""Chimney can't derive patcher for ${Type.prettyPrint[A]} with patch type ${Type.prettyPrint[Patch]}"""
+      s"""Chimney can't derive patching for ${Type.prettyPrint[A]} with patch type ${Type.prettyPrint[Patch]}"""
     )
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/ImplicitSummoning.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/ImplicitSummoning.scala
@@ -7,17 +7,10 @@ private[compiletime] trait ImplicitSummoning { this: Derivation =>
   final protected def summonPatcherSafe[A: Type, Patch: Type](implicit
       ctx: PatcherContext[A, Patch]
   ): Option[Expr[io.scalaland.chimney.Patcher[A, Patch]]] =
-    if (isForwardReferenceToItself[A, Patch](ctx.config.preventResolutionForTypes)) None
+    if (ctx.config.isImplicitSummoningPreventedFor[A, Patch]) None
     else summonPatcherUnchecked[A, Patch]
 
   final protected def summonPatcherUnchecked[A: Type, Patch: Type]
       : Option[Expr[io.scalaland.chimney.Patcher[A, Patch]]] =
     Expr.summonImplicit[io.scalaland.chimney.Patcher[A, Patch]]
-
-  // prevents: val t: Patcher[A, B] = (a, b) => t.patch(a, b)
-  private def isForwardReferenceToItself[A: Type, Patch: Type](
-      preventResolutionForTypes: Option[(??, ??)]
-  ): Boolean = preventResolutionForTypes.exists { case (from, to) =>
-    from.Underlying =:= Type[A] && to.Underlying =:= Type[Patch]
-  }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
@@ -107,7 +107,7 @@ private[compiletime] trait Contexts { this: Derivation =>
           From = Type[From],
           To = Type[To],
           runtimeDataStore = runtimeDataStore,
-          config = config.preventResolutionFor[From, To],
+          config = config.preventImplicitSummoningFor[From, To],
           derivationStartedAt = java.time.Instant.now()
         )
     }
@@ -145,7 +145,7 @@ private[compiletime] trait Contexts { this: Derivation =>
         From = Type[From],
         To = Type[To],
         runtimeDataStore = runtimeDataStore,
-        config = config.preventResolutionFor[From, To],
+        config = config.preventImplicitSummoningFor[From, To],
         derivationStartedAt = java.time.Instant.now()
       )
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
@@ -107,7 +107,7 @@ private[compiletime] trait Contexts { this: Derivation =>
           From = Type[From],
           To = Type[To],
           runtimeDataStore = runtimeDataStore,
-          config = config.withDefinitionScope(Type[From].as_?? -> Type[To].as_??),
+          config = config.preventResolutionFor[From, To],
           derivationStartedAt = java.time.Instant.now()
         )
     }
@@ -145,7 +145,7 @@ private[compiletime] trait Contexts { this: Derivation =>
         From = Type[From],
         To = Type[To],
         runtimeDataStore = runtimeDataStore,
-        config = config.withDefinitionScope(Type[From].as_?? -> Type[To].as_??),
+        config = config.preventResolutionFor[From, To],
         derivationStartedAt = java.time.Instant.now()
       )
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -37,19 +37,19 @@ private[compiletime] trait Derivation
   /** Intended use case: recursive derivation within rules */
   final protected def deriveRecursiveTransformationExpr[NewFrom: Type, NewTo: Type](
       newSrc: Expr[NewFrom],
-      recursiveDerivationType: RecursiveDerivationType = RecursiveDerivationType()
+      onRecur: OnRecur = OnRecur.cleanAll
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] =
-    deriveRecursiveTransformationExprUpdatingRules[NewFrom, NewTo](newSrc, recursiveDerivationType)(identity)
+    deriveRecursiveTransformationExprUpdatingRules[NewFrom, NewTo](newSrc, onRecur)(identity)
 
   /** Intended use case: recursive derivation within rules which should remove some rules from consideration */
   final protected def deriveRecursiveTransformationExprUpdatingRules[NewFrom: Type, NewTo: Type](
       newSrc: Expr[NewFrom],
-      recursiveDerivationType: RecursiveDerivationType = RecursiveDerivationType()
+      onRecur: OnRecur = OnRecur.cleanAll
   )(
       updateRules: List[Rule] => List[Rule]
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] = {
     val newCtx: TransformationContext[NewFrom, NewTo] = ctx.updateFromTo[NewFrom, NewTo](newSrc).updateConfig {
-      _.prepareForRecursiveCall(recursiveDerivationType)
+      _.prepareForRecursiveCall(onRecur)
     }
     deriveTransformationResultExprUpdatingRules(updateRules)(newCtx)
       .logSuccess {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -36,18 +36,20 @@ private[compiletime] trait Derivation
 
   /** Intended use case: recursive derivation within rules */
   final protected def deriveRecursiveTransformationExpr[NewFrom: Type, NewTo: Type](
-      newSrc: Expr[NewFrom]
+      newSrc: Expr[NewFrom],
+      recursiveDerivationType: RecursiveDerivationType = RecursiveDerivationType()
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] =
-    deriveRecursiveTransformationExprUpdatingRules[NewFrom, NewTo](newSrc)(identity)
+    deriveRecursiveTransformationExprUpdatingRules[NewFrom, NewTo](newSrc, recursiveDerivationType)(identity)
 
   /** Intended use case: recursive derivation within rules which should remove some rules from consideration */
   final protected def deriveRecursiveTransformationExprUpdatingRules[NewFrom: Type, NewTo: Type](
-      newSrc: Expr[NewFrom]
+      newSrc: Expr[NewFrom],
+      recursiveDerivationType: RecursiveDerivationType = RecursiveDerivationType()
   )(
       updateRules: List[Rule] => List[Rule]
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] = {
     val newCtx: TransformationContext[NewFrom, NewTo] = ctx.updateFromTo[NewFrom, NewTo](newSrc).updateConfig {
-      _.prepareForRecursiveCall
+      _.prepareForRecursiveCall(recursiveDerivationType)
     }
     deriveTransformationResultExprUpdatingRules(updateRules)(newCtx)
       .logSuccess {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Gateway.scala
@@ -27,7 +27,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
       val context = TransformationContext.ForTotal
         .create[From, To](
           src,
-          TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags],
+          TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags](src.as_??),
           runtimeDataStore
         )
         .updateConfig(_.allowFromToImplicitSearch)
@@ -55,7 +55,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
         val context = TransformationContext.ForTotal
           .create[From, To](
             src,
-            TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags],
+            TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags](src.as_??),
             runtimeDataStore
           )
 
@@ -85,7 +85,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
         .create[From, To](
           src,
           failFast,
-          TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags],
+          TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags](src.as_??),
           runtimeDataStore
         )
         .updateConfig(_.allowFromToImplicitSearch)
@@ -114,7 +114,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
           .create[From, To](
             src,
             failFast,
-            TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags],
+            TransformerConfigurations.readTransformerConfig[Cfg, InstanceFlags, ImplicitScopeFlags](src.as_??),
             runtimeDataStore
           )
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
@@ -8,14 +8,14 @@ private[compiletime] trait ImplicitSummoning { this: Derivation =>
       ctx: TransformationContext[From, To]
   ): Option[Expr[io.scalaland.chimney.Transformer[From, To]]] =
     // prevents: val t: Transformer[A, B] = a => t.transform(a)
-    if (ctx.config.isResolutionPreventedFor[From, To]) None
+    if (ctx.config.isImplicitSummoningPreventedFor[From, To]) None
     else summonTransformerUnchecked[From, To]
 
   final protected def summonPartialTransformerSafe[From, To](implicit
       ctx: TransformationContext[From, To]
   ): Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
     // prevents: val t: PartialTransformer[A, B] = a => t.transform(a)
-    if (ctx.config.isResolutionPreventedFor[From, To]) None
+    if (ctx.config.isImplicitSummoningPreventedFor[From, To]) None
     else summonPartialTransformerUnchecked[From, To]
 
   final protected def summonTransformerUnchecked[From: Type, To: Type]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
@@ -7,13 +7,15 @@ private[compiletime] trait ImplicitSummoning { this: Derivation =>
   final protected def summonTransformerSafe[From, To](implicit
       ctx: TransformationContext[From, To]
   ): Option[Expr[io.scalaland.chimney.Transformer[From, To]]] =
-    if (isForwardReferenceToItself[From, To](ctx.config.preventResolutionForTypes)) None
+    // prevents: val t: Transformer[A, B] = a => t.transform(a)
+    if (ctx.config.isResolutionPreventedFor[From, To]) None
     else summonTransformerUnchecked[From, To]
 
   final protected def summonPartialTransformerSafe[From, To](implicit
       ctx: TransformationContext[From, To]
   ): Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
-    if (isForwardReferenceToItself[From, To](ctx.config.preventResolutionForTypes)) None
+    // prevents: val t: PartialTransformer[A, B] = a => t.transform(a)
+    if (ctx.config.isResolutionPreventedFor[From, To]) None
     else summonPartialTransformerUnchecked[From, To]
 
   final protected def summonTransformerUnchecked[From: Type, To: Type]
@@ -23,11 +25,4 @@ private[compiletime] trait ImplicitSummoning { this: Derivation =>
   final protected def summonPartialTransformerUnchecked[From: Type, To: Type]
       : Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
     Expr.summonImplicit[io.scalaland.chimney.PartialTransformer[From, To]]
-
-  // prevents: val t: Transformer[A, B] = a => t.transform(a)
-  private def isForwardReferenceToItself[From: Type, To: Type](
-      preventResolutionForTypes: Option[(??, ??)]
-  ): Boolean = preventResolutionForTypes.exists { case (from, to) =>
-    from.Underlying =:= Type[From] && to.Underlying =:= Type[To]
-  }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
@@ -9,7 +9,7 @@ private[compiletime] trait TransformImplicitRuleModule { this: Derivation =>
   protected object TransformImplicitRule extends Rule("Implicit") {
 
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
-      if (ctx.config.areOverridesEmpty) transformWithImplicitIfAvailable[From, To]
+      if (ctx.config.areOverridesEmptyForCurrent[From, To]) transformWithImplicitIfAvailable[From, To]
       else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
 
     private def transformWithImplicitIfAvailable[From, To](implicit

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -283,7 +283,10 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
             ) {
               // We're constructing:
               // '{ ${ derivedToElement } } // using ${ src.$name }
-              deriveRecursiveTransformationExpr[ExtractedSrc, CtorParam](extractedSrcExpr).transformWith { expr =>
+              deriveRecursiveTransformationExpr[ExtractedSrc, CtorParam](
+                extractedSrcExpr,
+                OnRecur(fromField = KeepFieldOverrides, toField = DownField(toName))
+              ).transformWith { expr =>
                 // If we derived partial.Result[$ctorParam] we are appending
                 //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
                 DerivationResult.existential[TransformationExpr, CtorParam](appendPath(expr, sourcePath))
@@ -315,7 +318,10 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
         ) {
           // We're constructing:
           // '{ ${ derivedToElement } } // using ${ src.$name }
-          deriveRecursiveTransformationExpr[Getter, CtorParam](get(ctx.src)).transformWith { expr =>
+          deriveRecursiveTransformationExpr[Getter, CtorParam](
+            get(ctx.src),
+            OnRecur(fromField = DownField(fromName), toField = DownField(toName))
+          ).transformWith { expr =>
             // If we derived partial.Result[$ctorParam] we are appending
             //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
             DerivationResult.existential[TransformationExpr, CtorParam](appendPath(expr, fromName))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSubtypesRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSubtypesRuleModule.scala
@@ -9,7 +9,7 @@ private[compiletime] trait TransformSubtypesRuleModule { this: Derivation =>
 
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       if (Type[From] <:< Type[To]) {
-        if (ctx.config.areOverridesEmpty) transformByUpcasting[From, To]
+        if (ctx.config.areOverridesEmptyForCurrent[From, To]) transformByUpcasting[From, To]
         else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
       } else DerivationResult.attemptNextRule
 

--- a/docs/docs/supported-patching.md
+++ b/docs/docs/supported-patching.md
@@ -109,9 +109,10 @@ If the flag was enabled in the implicit config it can be disabled with `.failRed
       .using(UserUpdateForm("xyz@@domain.com", 123123123L, "some address"))
       .failRedundantPatcherFields
       .patch
-    // Chimney can't derive patcher for Playground.User with patch type Playground.UserUpdateForm
+    // Chimney can't derive patcher for User with patch type UserUpdateForm
     // 
-    // Field named 'address' not found in target patching type Playground.User!
+    // Field named 'address' not found in target patching type User!
+    //
     // Consult https://chimney.readthedocs.io for usage examples.
     ```
 

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -345,9 +345,9 @@ If the flag was enabled in the implicit config it can be disabled with `.disable
     (new Source("value", 512)).into[Target].disableMethodAccessors.transform
     // Chimney can't derive transformation from Source to Target
     //
-    // Playground.Target
-    //   a: java.lang.String - no accessor named a in source type Playground.Source
-    //   b: scala.Int - no accessor named b in source type Playground.Source
+    // Target
+    //   a: java.lang.String - no accessor named a in source type Source
+    //   b: scala.Int - no accessor named b in source type Source
     //
     // There are methods in Source that might be used as accessors for `a`, `b` fields in Target. Consider using `.enableMethodAccessors`.
     //

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -433,6 +433,10 @@ would generate:
 !!! example
 
     ```
+    + Start derivation with context: PatcherContext[A = User, Patch = UserUpdateForm](obj = user, patch = userupdateform)(PatcherConfig(
+    |   flags = PatcherFlags(displayMacrosLogging),
+    |   preventImplicitSummoningForTypes = None
+    | ))
     + Deriving Patcher expression for User with patch UserUpdateForm
       + Deriving Total Transformer expression from java.lang.String to Email
         + Attempting expansion of rule Implicit


### PR DESCRIPTION
TODO:

 - [x] hide config extraction and update logic behind TansformerConfig
 - [x] allow rules to tell recursive derivation what to do with field overrides
 - [x] update rules working with fields to use that logic

Goals:

 - unblock https://github.com/scalalandio/chimney/issues/358 - if config would take care of updating field paths to field overrides in the currently handled transformation, we could read nested paths and then make sure that rules see only those field overrides which are aligned with their nesting
 - unblock work on https://github.com/scalalandio/chimney/issues/115 - if config would take care of updating overrides it could update if for several source values at once

Probably the best way of testing if it works would be to branch off this PR and try to implement #358.