### PR TITLE
Don't look for implicits if `.into.transform` with flags overrides was used

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
@@ -9,8 +9,7 @@ private[compiletime] trait TransformImplicitRuleModule { this: Derivation =>
   protected object TransformImplicitRule extends Rule("Implicit") {
 
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
-      if (ctx.config.areOverridesEmptyForCurrent[From, To] || ctx.config.flags.wasInstanceOverridden)
-        transformWithImplicitIfAvailable[From, To]
+      if (ctx.config.areOverridesEmptyForCurrent[From, To]) transformWithImplicitIfAvailable[From, To]
       else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
 
     private def transformWithImplicitIfAvailable[From, To](implicit

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitRuleModule.scala
@@ -9,7 +9,8 @@ private[compiletime] trait TransformImplicitRuleModule { this: Derivation =>
   protected object TransformImplicitRule extends Rule("Implicit") {
 
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
-      if (ctx.config.areOverridesEmptyForCurrent[From, To]) transformWithImplicitIfAvailable[From, To]
+      if (ctx.config.areOverridesEmptyForCurrent[From, To] || ctx.config.flags.wasInstanceOverridden)
+        transformWithImplicitIfAvailable[From, To]
       else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
 
     private def transformWithImplicitIfAvailable[From, To](implicit

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerImplicitResolutionSpec.scala
@@ -83,4 +83,32 @@ class PartialTransformerImplicitResolutionSpec extends ChimneySpec {
     result.asEither ==> Right(expected)
     result.asErrorPathMessageStrings ==> Iterable.empty
   }
+
+  test("ignore implicit Partial Transformer if an local flag is present but not if only implicit flag is present") {
+    import trip.*
+
+    @unused implicit def instance: PartialTransformer[Person, UserWithDefault] =
+      PartialTransformer.fromFunction(person => UserWithDefault(person.name, person.age, 38))
+
+    @unused implicit val cfg = TransformerConfiguration.default.enableDefaultValues
+
+    val expectedInstance = UserWithDefault("John", 10, 38)
+
+    val result = Person("John", 10, 140).transformIntoPartial[UserWithDefault]
+    result.asOption ==> Some(expectedInstance)
+    result.asEither ==> Right(expectedInstance)
+    result.asErrorPathMessageStrings ==> Iterable.empty
+
+    val result2 = Person("John", 10, 140).intoPartial[UserWithDefault].transform
+    result2.asOption ==> Some(expectedInstance)
+    result2.asEither ==> Right(expectedInstance)
+    result2.asErrorPathMessageStrings ==> Iterable.empty
+
+    val expectedDefault = UserWithDefault("John", 10)
+
+    val result3 = Person("John", 10, 140).intoPartial[UserWithDefault].enableDefaultValues.transform
+    result3.asOption ==> Some(expectedDefault)
+    result3.asEither ==> Right(expectedDefault)
+    result3.asErrorPathMessageStrings ==> Iterable.empty
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerImplicitResolutionSpec.scala
@@ -39,4 +39,17 @@ class TotalTransformerImplicitResolutionSpec extends ChimneySpec {
 
     Person("John", 10, 140).into[User].withFieldConst(_.name, "Not John").transform ==> User("Not John", 10, 140)
   }
+
+  test("ignore implicit Total Transformer if an local flag is present but not if only implicit flag is present") {
+    import trip.*
+
+    @unused implicit def instance: Transformer[Person, UserWithDefault] =
+      person => UserWithDefault(person.name, person.age, 38)
+
+    @unused implicit val cfg = TransformerConfiguration.default.enableDefaultValues
+
+    Person("John", 10, 140).transformInto[UserWithDefault] ==> UserWithDefault("John", 10, 38)
+    Person("John", 10, 140).into[UserWithDefault].transform ==> UserWithDefault("John", 10, 38)
+    Person("John", 10, 140).into[UserWithDefault].enableDefaultValues.transform ==> UserWithDefault("John", 10)
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Trip.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Trip.scala
@@ -9,4 +9,6 @@ package trip {
   case class Trip(id: Int, people: Vector[Person])
 
   case class User(name: String, age: Int, height: Double)
+
+  case class UserWithDefault(name: String, age: Int, footSize: Int = 42)
 }

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -46,6 +46,21 @@ If we do not want to enable the same flag(s) in several places, we can define sh
     This includes automatic derivation as well, so summoning automatically derived Transformer would adhere to these
     flags.
 
+!!! warning
+
+    Since 0.8.0, Chimney assumes that you do NOT want to use the use implicit Transformer if you passed any `withField*`
+    or `withCoproduct*` customization - using an implicit would not make it possible to do so. However, setting any flag
+    with `enable*` or `disable*` would not prevent using implicit. So you could have situation like:
+    
+    ```scala
+    implicit val foo2bar: Transformer[Foo, Bar] = ...
+    foo.into[Bar].enableDefaultValues.transform // uses foo2bar ignoring flags
+    ```
+    
+    Since 0.8.1, Chimney would ignore an implicit if any flag was explicitly used in `.into.transform`. Flags defined in
+    an implicit `TransformerConfiguration` would be considerd new default settings in new derivations, but would not
+    cause `.into.transform` to ignore an implicit if one is present. 
+
 ## Automatic, Semiautomatic and Inlined derivation
 
 When you use the standard way of working with Chimney, but `import io.scalaland.chimney.dsl._`

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -254,6 +254,42 @@ and then
 
 The same is true for partial transformers.
 
+## Recursive calls on implicits
+
+Old versions of Chimney in situations like this:
+
+!!! example
+
+    ```scala
+    implicit val t: Transformer[Foo, Bar] = foo => foo.transformInto[Bar] // or
+    implicit val t: Transformer[Foo, Bar] = foo => foo.into[Bar].transform
+    ```
+    
+would result in errors like:
+
+!!! example
+
+    ```scala
+    forward reference extends over definition of value t
+    ```
+
+In newer, it can result in would result in errors like:
+
+!!! example
+
+    ```scala
+    java.lang.StackOverflowError
+    ```
+
+It's a sign of recursion which has to be handled with [semiautomatic derivation](cookbook.md#automatic-vs-semiautomatic).
+
+!!! example
+
+    ```scala
+    implicit val t: Transformer[Foo, Bar] = Transformer.derive[Foo, Bar] // or
+    implicit val t: Transformer[Foo, Bar] = Transformer.define[Foo, Bar].buildTransformer
+    ```
+
 ## `sealed trait`s fail to recompile
 
 In the case of incremental compilation, the Zinc compiler sometimes has issues with


### PR DESCRIPTION
TODO:
 - [x] create a ticket for it - some people has a problem with this behavior in the past but reported it only on Gitter
 - [x] create Transformer and Partial Transformer tests for it (`*ImplicitResolutionSpec`)
 - [x] add to the documentation
   - [x] information that _local_ flags would disable implicit searching (implicit `TransformerConfiguration` won't)
   - [x] information that implicit resolution and subtyping would NOT use implicits if we locally set up flags OR value overrides
 - [x] merge config refactor (#406) as this PR uses TC after changes 