### PR TITLE
Improve docs a little bit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,11 +54,16 @@ val settings = Seq(
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, _)) =>
         Seq(
-          // "-explain",
-          "-rewrite",
           // format: off
+          "-encoding", "UTF-8",
+          "-rewrite",
           "-source", "3.3-migration",
           // format: on
+          "-unchecked",
+          "-deprecation",
+          "-explain",
+          "-explain-types",
+          "-feature",
           "-Wconf:msg=Unreachable case:s", // suppress fake (?) errors in internal.compiletime
           "-Wnonunit-statement",
           // "-Wunused:imports", // import x.Underlying as X is marked as unused even though it is!

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -17,7 +17,7 @@ If we do not want to enable the same flag(s) in several places, we can define sh
     
     implicit val transformerCfg = TransformerConfiguration.default.enableMethodAccessors.enableMacrosLogging
     
-    implicit val patcherCfg = PatcherConfiguration.ignoreNoneInPatch.enableMacrosLogging
+    implicit val patcherCfg = PatcherConfiguration.default.ignoreNoneInPatch.enableMacrosLogging
     ```  
 
     Scala 3


### PR DESCRIPTION
TODO:

 - [x] typos that slipped through Grammarly check before 0.8.0 release
 - [x] describe implicit for transforming sealed/enum subtypes
 - [x] type parameters/generics transformations
 - [ ] ~mention how implicit TransformerConfiguration can be cross compiled without compiler warnings~