### PR TITLE
Prepare auto-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: CI build
 on:
   push:
     branches: [ master ]
+    tags: [ '*' ]
   pull_request:
     branches: [ master ]
-    types: ['opened', 'reopened', 'labeled', 'synchronize']
+    types: [ opened, reopened, labeled, synchronize ]
 
 jobs:
   check-formatting:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,8 +1,10 @@
 name: Update Dependency Graph
+
 on:
   push:
     branches:
       - master
+
 jobs:
   dependency-graph:
     name: Update Dependency Graph

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -2,8 +2,7 @@ name: Update Dependency Graph
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
 
 jobs:
   dependency-graph:

--- a/.github/workflows/publish-benchmark-results.yml
+++ b/.github/workflows/publish-benchmark-results.yml
@@ -2,9 +2,8 @@ name: Publish benchmark results
 
 on:
   workflow_run:
-    workflows: ["CI build"]
-    types:
-      - completed
+    workflows: [ 'CI build' ]
+    types: [ completed ]
 
 jobs:
   push-to-data-repo:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Sonatype Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: coursier/cache-action@v6
+      - name: Import GPG key for signing the release
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: 'adopt:1.8.0-292'
+          apps: sbt
+      - name: Stage all artifacts and then release them in batch
+        run:  sbt publishSigned sonatypeBundleRelease
+        env:
+          RELEASE: true
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Sonatype Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: [ 'CI build' ]
+    branches: [ master ]
+    types: [ completed ]
 
 jobs:
   release-tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Sonatype Release
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - master
 
 jobs:
   release-tag:

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,2 @@
+# add try-chimney to defaults from https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+updates.fileExtensions = [".mill-version",".sbt",".sbt.shared",".sc",".scala",".scalafmt.conf",".yml","build.properties","mill-version","pom.xml","try-chimney.sh"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,16 +103,13 @@ would follow to publish a new version of the library:
   - [ ] verify that docs from the latest build are rendering correctly (on RTD or `cd docs && just serve`)
   - [ ] close the milestone (if it exists)
 2. Release
-  - [ ] update Scala versions (if needed!) in `docs/docs/mkdocs.yml` and `try-chimney.sh`
-  - [ ] `git commit -m "Release [version]"` these 2 changes (if needed)
-  - [ ] locally run `git tag [version]` (no `v` in the tag, no `-a`)
-  - [ ] run `git push && git push --tags` to trigger the release action
-  - [ ] approve running benchmarks on the tag
+  - [ ] create tag (no `v` in the tag name, no `-a`)
+  - [ ] approve running benchmarks on the tagged commit
 3. Post-release actions
   - [ ] verify in https://oss.sonatype.org/ that the release was successful
   - [ ] open https://chimney.readthedocs.io/ and make sure that the version got published (-Mn, -RCn versions might require manual activation!)
   - [ ] draft a (pre)release on GitHub (don't publish it until Maven lists the new version!)
-  - [ ] await until the version is available on Maven Central
+  - [ ] wait until the version is available on Maven Central
   - [ ] verify that Scaladex sees it
   - [ ] force download of Scaladoc (open Scaladoc dor each Scala version, change "latest" to the new version to force download) 
   - [ ] run https://github.com/sbts/github-badge-cache-buster to flush GH badge cache (`./github-badge-cache-buster.sh https://github.com/scalalandio/chimney`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,10 @@ Information about Scala macros can be found on:
  * [Scala 3 macros documentation](https://docs.scala-lang.org/scala3/guides/macros/macros.html)
  * [EPFL papers](https://infoscience.epfl.ch/search?ln=en&as=1&m1=p&p1=macros&f1=keyword&op1=a&m2=p&p2=scala&f2=&op2=a&m3=a&p3=&f3=&dt=&d1d=&d1m=&d1y=&d2d=&d2m=&d2y=&rm=&action_search=Search&sf=title&so=a&rg=10&c=Infoscience&of=hb)
 
-Very basic introduction can be found in [design doc](DESIGN.md). From then on we suggest looking at tests, and using
-`.enableMacrosLogging` to see how some branches are triggered. If still at doubt, you can ask us on GH discussions.
+Very basic introduction can be found in [design doc](DESIGN.md) and in the
+[Under the hood](https://chimney.readthedocs.io/en/stable/under-the-hood/) section of the documentation.
+From then on we suggest looking at tests, and using`.enableMacrosLogging` to see how some branches are triggered.
+If still at doubt, you can ask us on GH discussions.
 
 ## Contributing to the documentation
 
@@ -87,3 +89,36 @@ To develop locally it is recommended to install [Just](https://github.com/casey/
  * open http://0.0.0.0:8000/
 
 Site will reload and update as you edit the markdown files in docs/docs directory.
+
+## Release checklist
+
+For now, the release is a manual process, so storing the checklist somewhere makes sense.
+
+1. Pre-release checks 
+  - [ ] verify that all task in the milestone are finished (if milestone for the release exists)
+  - [ ] verify that all Scala Steward PRs are merged or manually replaced
+  - [ ] wait for the `master` to build and pass all tests
+  - [ ] search `TODO`s in the code and verify that they are not problematic (no missing documentation links for instance)
+  - [ ] verify that docs from the latest build are rendering correctly (on RTD or `cd docs && just serve`)
+  - [ ] close the milestone (if it exists)
+2. Release
+  - [ ] update Scala versions (if needed) in `docs/docs/mkdocs.yml` and `try-chimney.sh`
+  - [ ] `git commit -m "Release [version]"` these 2 changes (no push!)
+  - [ ] locally run `git tag [version]` (no `v` in the tag, no `-a`) (no push!)
+  - [ ] start `RELEASE=true sbt` (disables `-Xfatal-warnings` for `doc` task)
+  - [ ] run `show version` and verify than version name is correct
+  - [ ] run `publishSigned`
+  - [ ] check if all versions are staged locally
+  - [ ] run `sonatypeBundleRelease`
+  - [ ] verify in oss.sonatype.org that release was successful
+  - [ ] run `git push && git push --tags`
+  - [ ] deploy benchmarks on the tag
+3. Post-release actions
+  - [ ] open https://chimney.readthedocs.io/ and make sure that the version got published (-Mn, -RCn versions might require manual activation!)
+  - [ ] draft a (pre)release on GitHub (don't publish it until Maven lists the new version!)
+  - [ ] await until the version is available on Maven Central
+  - [ ] verify that Scaladex sees it
+  - [ ] force download of Scaladoc (open Scaladoc dor each Scala version, change latest to the new version to force download) 
+  - [ ] run https://github.com/sbts/github-badge-cache-buster to flush GH badge cache (`./github-badge-cache-buster.sh https://github.com/scalalandio/chimney`)
+  - [ ] publish the (pre)release on GitHub
+  - [ ] publish information on Twitter/Mastodon/Reddit/etc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,33 +92,34 @@ Site will reload and update as you edit the markdown files in docs/docs director
 
 ## Release checklist
 
-For now, the release is a manual process, so storing the checklist somewhere makes sense.
+To ensure that there are no silly, easily avoidable issues found right after the release, there is a list of steps we
+would follow to publish a new version of the library:
 
 1. Pre-release checks 
-  - [ ] verify that all task in the milestone are finished (if milestone for the release exists)
+  - [ ] verify that all task in the milestone are finished (if a milestone for the release exists)
   - [ ] verify that all Scala Steward PRs are merged or manually replaced
-  - [ ] wait for the `master` to build and pass all tests
+  - [ ] wait for the `master` to build and pass all tests, ensure that they are all green
   - [ ] search `TODO`s in the code and verify that they are not problematic (no missing documentation links for instance)
   - [ ] verify that docs from the latest build are rendering correctly (on RTD or `cd docs && just serve`)
   - [ ] close the milestone (if it exists)
 2. Release
-  - [ ] update Scala versions (if needed) in `docs/docs/mkdocs.yml` and `try-chimney.sh`
-  - [ ] `git commit -m "Release [version]"` these 2 changes (no push!)
-  - [ ] locally run `git tag [version]` (no `v` in the tag, no `-a`) (no push!)
-  - [ ] start `RELEASE=true sbt` (disables `-Xfatal-warnings` for `doc` task)
-  - [ ] run `show version` and verify than version name is correct
-  - [ ] run `publishSigned`
-  - [ ] check if all versions are staged locally
-  - [ ] run `sonatypeBundleRelease`
-  - [ ] verify in oss.sonatype.org that release was successful
-  - [ ] run `git push && git push --tags`
-  - [ ] deploy benchmarks on the tag
+  - [ ] update Scala versions (if needed!) in `docs/docs/mkdocs.yml` and `try-chimney.sh`
+  - [ ] `git commit -m "Release [version]"` these 2 changes (if needed)
+  - [ ] locally run `git tag [version]` (no `v` in the tag, no `-a`)
+  - [ ] run `git push && git push --tags` to trigger the release action
+  - [ ] approve running benchmarks on the tag
 3. Post-release actions
+  - [ ] verify in https://oss.sonatype.org/ that the release was successful
   - [ ] open https://chimney.readthedocs.io/ and make sure that the version got published (-Mn, -RCn versions might require manual activation!)
   - [ ] draft a (pre)release on GitHub (don't publish it until Maven lists the new version!)
   - [ ] await until the version is available on Maven Central
   - [ ] verify that Scaladex sees it
-  - [ ] force download of Scaladoc (open Scaladoc dor each Scala version, change latest to the new version to force download) 
+  - [ ] force download of Scaladoc (open Scaladoc dor each Scala version, change "latest" to the new version to force download) 
   - [ ] run https://github.com/sbts/github-badge-cache-buster to flush GH badge cache (`./github-badge-cache-buster.sh https://github.com/scalalandio/chimney`)
   - [ ] publish the (pre)release on GitHub
-  - [ ] publish information on Twitter/Mastodon/Reddit/etc
+  - [ ] publish announcements on Twitter/Mastodon/Reddit/etc
+
+While building, testing and deployment are automated, some things have to be verified manually, because they are not
+immediate (library can become visible on Maven Central 15 minutes after publishing or a few hours later), or because
+human needs to tell if things are in good shape (documentation's content, whether all that should go into the release
+was done, etc).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Scaladoc 2.13](https://javadoc.io/badge2/io.scalaland/chimney_2.13/scaladoc%202.13.svg)](https://javadoc.io/doc/io.scalaland/chimney_2.13)
 [![Scaladoc 3](https://javadoc.io/badge2/io.scalaland/chimney_3/scaladoc%203.svg)](https://javadoc.io/doc/io.scalaland/chimney_3)
 
-The battle-tested Scala library for data transformations. Supported for (2.12, 2.13, 3.3+) x (JVM, Scala.js, Scala Native)
+The battle-tested Scala library for data transformations. Supported for (2.12, 2.13, 3.3+) x (JVM, Scala.js, Scala Native).
 
 Chimney documentation is available at https://chimney.readthedocs.io. Read the Docs keeps it versioned in case you need
 to access documentation for older versions.
@@ -21,11 +21,10 @@ to access documentation for older versions.
 ## Contribution
 
 A way to get started is described in [CONTRIBUTING.md](CONTRIBUTING.md) and the general overview of the architecture
-is given in [DESIGN.md](DESIGN.md).
+is given in [DESIGN.md](DESIGN.md) and in [Under the hood](https://chimney.readthedocs.io/en/stable/under-the-hood/)
+section of the documentation.
 
 ## Thanks
 
 Thanks to [JProfiler (Java profiler)](https://www.ej-technologies.com/products/jprofiler/overview.html)
 for helping us develop the library and allowing us to use it during development.
-
-Thanks to [SwissBorg](https://swissborg.com) for sponsoring the development time for this project.

--- a/build.sbt
+++ b/build.sbt
@@ -199,31 +199,29 @@ val versionSchemeSettings = Seq(versionScheme := Some("early-semver"))
 
 val publishSettings = Seq(
   organization := "io.scalaland",
-  homepage := Some(url("https://scalaland.io")),
-  licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+  homepage := Some(url("https://scalaland.io/chimney")),
+  organizationHomepage := Some(url("https://scalaland.io")),
+  licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
   scmInfo := Some(
-    ScmInfo(url("https://github.com/scalalandio/chimney"), "scm:git:git@github.com:scalalandio/chimney.git")
+    ScmInfo(url("https://github.com/scalalandio/chimney/"), "scm:git:git@github.com:scalalandio/chimney.git")
+  ),
+  startYear := Some(2017),
+  developers := List(
+    Developer("krzemin", "Piotr Krzemiński", "", url("https://github.com/krzemin")),
+    Developer("MateuszKubuszok", "Mateusz Kubuszok", "", url("https://github.com/MateuszKubuszok"))
+  ),
+  pomExtra := (
+    <issueManagement>
+      <system>GitHub issues</system>
+      <url>https://github.com/scalalandio/chimney/issues</url>
+    </issueManagement>
   ),
   publishTo := sonatypePublishToBundle.value,
   publishMavenStyle := true,
   Test / publishArtifact := false,
   pomIncludeRepository := { _ =>
     false
-  },
-  pomExtra := (
-    <developers>
-      <developer>
-        <id>krzemin</id>
-        <name>Piotr Krzemiński</name>
-        <url>http://github.com/krzemin</url>
-      </developer>
-      <developer>
-        <id>MateuszKubuszok</id>
-        <name>Mateusz Kubuszok</name>
-        <url>http://github.com/MateuszKubuszok</url>
-      </developer>
-    </developers>
-  )
+  }
 ) ++ (if (isRelease) Seq(scalacOptions -= "-Xfatal-warnings") else Seq.empty)
 
 val mimaSettings = Seq(

--- a/try-chimney.sh
+++ b/try-chimney.sh
@@ -3,9 +3,5 @@ COURSIER_URL=https://github.com/coursier/launchers/raw/master/coursier
 
 test -e ~/.coursier/coursier || (mkdir -p ~/.coursier && curl -fLo ~/.coursier/coursier $COURSIER_URL && chmod +x ~/.coursier/coursier)
 
-~/.coursier/coursier launch -q -P -M ammonite.Main \
-  com.lihaoyi:ammonite_2.13.3:2.5.9 \
-  org.typelevel:cats-core_2.13:2.9.0 \
-  io.scalaland:chimney_2.13:0.8.0 \
-  io.scalaland:chimney-cats_2.13:0.8.0 \
-  -- --predef-code 'import $plugin.$ivy.`org.typelevel:kind-projector_2.13.10:0.13.2`;import io.scalaland.chimney.dsl._;import io.scalaland.chimney.cats._' < /dev/tty
+~/.coursier/coursier launch --java-opt -Dfoo=bar --java-opt -Xmx2g --java-opt -Xss16m com.lihaoyi:ammonite_3.3.1:latest.release -M ammonite.Main \
+  -- --predef-code 'import $ivy.`io.scalaland::chimney-cats:latest.release`;import io.scalaland.chimney.dsl._;import io.scalaland.chimney.cats._' < /dev/tty


### PR DESCRIPTION
We got to the point where preparing a release is virtually fully automated, but still a human needs to trigger the script on their own computer. We could push it on so that we only need to verify that we want it released in current shape, create a tag, and go out for a dinner or a beer, or whatever. Then we can just make an announcement once things get synced everywhere.

* modify `try-chimney.sh` so that we won't have to update it periodically
* prepare a GH Action which would automatically release Chimney on tag
* create a checklist to verify things before-during-and-after release
* update README

TODO:

- [x] create a dedicated user on Sonatype for releases
- [x] give it a nice, long, random password
- [x] have it added to `io.scalaland` group
- [x] generate it a nice new GPG key and publish it
- [x] set up:
  - [x] `GPG_PRIVATE_KEY`
  - [x] `GPG_PASSPHRASE`
  - [x] `SONATYPE_USERNAME`
  - [x] `SONATYPE_PASSWORD`