### PR TITLE
Resolve #434 by trying fallback values prior to failing

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -107,35 +107,31 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                   .map { case (fromName, toName, getter) =>
                     useExtractor[From, To, CtorParam](ctorParam.value.targetType, fromName, toName, getter)
                   }
-                  .orElse[DerivationResult[Existential[TransformationExpr]]](
-                    if (usePositionBasedMatching)
-                      Option(
-                        DerivationResult.incompatibleSourceTuple(
-                          sourceArity = fromEnabledExtractors.size,
-                          targetArity = parameters.size
-                        )
-                      )
-                    else None
-                  )
               }
               .orElse(useFallbackValues[From, To, CtorParam](defaultValue))
               .getOrElse[DerivationResult[Existential[TransformationExpr]]] {
-                ctorParam.value.targetType match {
-                  case Product.Parameter.TargetType.ConstructorParameter =>
-                    // TODO: update this for isLocal
-                    DerivationResult
-                      .missingAccessor[From, To, CtorParam, Existential[TransformationExpr]](
-                        toName,
-                        fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
-                      )
-                  case Product.Parameter.TargetType.SetterParameter =>
-                    // TODO: update this for isLocal
-                    DerivationResult
-                      .missingJavaBeanSetterParam[From, To, CtorParam, Existential[TransformationExpr]](
-                        ProductType.dropSet(toName),
-                        fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
-                      )
-                }
+                if (usePositionBasedMatching)
+                  DerivationResult.incompatibleSourceTuple(
+                    sourceArity = fromEnabledExtractors.size,
+                    targetArity = parameters.size
+                  )
+                else
+                  ctorParam.value.targetType match {
+                    case Product.Parameter.TargetType.ConstructorParameter =>
+                      // TODO: update this for isLocal
+                      DerivationResult
+                        .missingAccessor[From, To, CtorParam, Existential[TransformationExpr]](
+                          toName,
+                          fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
+                        )
+                    case Product.Parameter.TargetType.SetterParameter =>
+                      // TODO: update this for isLocal
+                      DerivationResult
+                        .missingJavaBeanSetterParam[From, To, CtorParam, Existential[TransformationExpr]](
+                          ProductType.dropSet(toName),
+                          fromExtractors.exists { case (fromName, _) => areNamesMatching(fromName, toName) }
+                        )
+                  }
               }
               .logSuccess(expr => s"Resolved `$toName` field value to ${expr.value.prettyPrint}")
               .map(toName -> _)

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -689,4 +689,12 @@ class IssuesSpec extends ChimneySpec {
 
     (new Foo()).into[Bar].withFieldRenamed(_.baz1(), _.getBaz2()).transform.getBaz2() ==> "test"
   }
+
+  test("fix issue #434") {
+    import Issue434.*
+
+    val expected = MyClass(1, 2, "asd", None)
+    val actual = (1, 2, "asd").into[MyClass].enableOptionDefaultsToNone.transform
+    actual ==> expected
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -188,3 +188,7 @@ object Issue403 {
     def setBaz2(baz: String): Unit = this.baz = baz
   }
 }
+
+object Issue434 {
+  case class MyClass(x: Int, y: Int, z: String, zz: Option[Int])
+}


### PR DESCRIPTION
Resolve #434 by moving the failure for incompatible source tuple until after fallback values are attempted.