### PR TITLE
Add ability to provie a custom constructor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ val versions = new {
 
 Global / excludeLintKeys += git.useGitDescribe
 Global / excludeLintKeys += ideSkipProject
+Global / excludeLintKeys += sourceDirectories
 val only1VersionInIDE =
   MatrixAction
     .ForPlatform(versions.idePlatform)
@@ -59,6 +60,16 @@ val only1VersionInIDE =
         .ForPlatform(platform)
         .Configure(_.settings(ideSkipProject := true, bspEnabled := false, scalafmtOnCompile := false))
     }
+
+val non212tests =
+  MatrixAction
+    .ForScala(v => (v.value == versions.scala213) || v.isScala3)
+    .Configure(
+      _.settings(
+        // sourceDirectories += sourceDirectory.value.toPath.resolve("./main/scala-2.13+").toFile,
+        Test / sourceDirectories += sourceDirectory.value.toPath.resolve("test/scala-2.13+").toFile
+      )
+    )
 
 val settings = Seq(
   git.useGitDescribe := true,
@@ -364,7 +375,7 @@ lazy val chimneyMacroCommons = projectMatrix
 
 lazy val chimney = projectMatrix
   .in(file("chimney"))
-  .someVariations(versions.scalas, versions.platforms)(only1VersionInIDE*)
+  .someVariations(versions.scalas, versions.platforms)((non212tests +: only1VersionInIDE)*)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin, ProtocPlugin)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,6 @@ val versions = new {
 
 Global / excludeLintKeys += git.useGitDescribe
 Global / excludeLintKeys += ideSkipProject
-Global / excludeLintKeys += sourceDirectories
 val only1VersionInIDE =
   MatrixAction
     .ForPlatform(versions.idePlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -66,8 +66,8 @@ val non212tests =
     .ForScala(v => (v.value == versions.scala213) || v.isScala3)
     .Configure(
       _.settings(
-        // sourceDirectories += sourceDirectory.value.toPath.resolve("./main/scala-2.13+").toFile,
-        Test / sourceDirectories += sourceDirectory.value.toPath.resolve("test/scala-2.13+").toFile
+        // Compile / unmanagedSourceDirectories += sourceDirectory.value.toPath.resolve("./main/scala-2.13+").toFile,
+        Test / unmanagedSourceDirectories += sourceDirectory.value.toPath.resolve("test/scala-2.13+").toFile
       )
     )
 

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -232,7 +232,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
         val (constructorArguments, _) = checkArguments[A](parameters, arguments)
 
         val methodType: ?? = args.foldRight[??](Type[A].as_??) { (paramList, resultType) =>
-          val paramTypes = paramList.view.values.map(_.Underlying.tpe).toList
+          val paramTypes = paramList.values.map(_.Underlying.tpe).toList
           // tq returns c.Tree, to turn it to c.Type we need .tpe, which without a .typecheck is null
           fromUntyped(c.typecheck(tq"(..$paramTypes) => ${resultType.Underlying.tpe}", mode = c.TYPEmode).tpe).as_??
         }

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -238,7 +238,6 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
         }
 
         import methodType.Underlying as MethodType
-        println(methodType)
         val tree = expr.asInstanceOfExpr[MethodType].tree
         c.Expr[A](q"$tree(...${(args.map(_.map { case (paramName, _) =>
             constructorArguments(paramName).value.tree

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -230,7 +230,14 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
       val constructor: Product.Arguments => Expr[A] = arguments => {
         val (constructorArguments, _) = checkArguments[A](parameters, arguments)
-        val methodType: ?? = null.asInstanceOf[??] // TODO: figure out the type
+
+        val methodType: ?? = args.foldRight[??](Type[A].as_??) { (paramList, resultType) =>
+          val paramTypes = paramList.view.values.map(_.Underlying.tpe).toList
+          fromUntyped(c.typecheck(tq"(..$paramTypes) => ${resultType.Underlying.tpe}", mode = c.TYPEmode).tpe).as_??
+        }
+
+        println(methodType.Underlying)
+
         import methodType.Underlying as MethodType
         val tree = expr.asInstanceOfExpr[MethodType].tree
         c.Expr[A](q"$tree(...${(args.map(_.map { case (paramName, _) =>

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -233,10 +233,9 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
         val methodType: ?? = args.foldRight[??](Type[A].as_??) { (paramList, resultType) =>
           val paramTypes = paramList.view.values.map(_.Underlying.tpe).toList
+          // tq returns c.Tree, to turn it to c.Type we need .tpe, which without a .typecheck is null
           fromUntyped(c.typecheck(tq"(..$paramTypes) => ${resultType.Underlying.tpe}", mode = c.TYPEmode).tpe).as_??
         }
-
-        println(methodType.Underlying)
 
         import methodType.Underlying as MethodType
         val tree = expr.asInstanceOfExpr[MethodType].tree

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -238,6 +238,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
         }
 
         import methodType.Underlying as MethodType
+        println(methodType)
         val tree = expr.asInstanceOfExpr[MethodType].tree
         c.Expr[A](q"$tree(...${(args.map(_.map { case (paramName, _) =>
             constructorArguments(paramName).value.tree

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -216,6 +216,21 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
       } else None
     }
 
+    def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A] =
+      Product.Constructor[A](
+        ListMap.from(for {
+          list <- args
+          pair <- list.toList
+          (paramName, paramType) = pair
+        } yield {
+          import paramType.Underlying as ParamType
+          paramName -> Existential[Product.Parameter, ParamType](
+            Product.Parameter(Product.Parameter.TargetType.ConstructorParameter, None)
+          )
+        }),
+        _ => Expr.Nothing.asInstanceOfExpr[A] // TODO
+      )
+
     private val getDecodedName = (s: Symbol) => s.name.decodedName.toString
 
     private val isGarbageSymbol = getDecodedName andThen isGarbage

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -242,6 +242,21 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
         Some(Product.Constructor(parameters, constructor))
       } else None
 
+    def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A] =
+      Product.Constructor[A](
+        ListMap.from(for {
+          list <- args
+          pair <- list.toList
+          (paramName, paramType) = pair
+        } yield {
+          import paramType.Underlying as ParamType
+          paramName -> Existential[Product.Parameter, ParamType](
+            Product.Parameter(Product.Parameter.TargetType.ConstructorParameter, None)
+          )
+        }),
+        _ => Expr.Nothing.asInstanceOfExpr[A] // TODO
+      )
+
     private val isGarbageSymbol = ((s: Symbol) => s.name) andThen isGarbage
   }
 }

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -74,6 +74,9 @@ trait ProductTypes { this: Definitions =>
     object Constructor {
       def unapply[To](To: Type[To]): Option[(Parameters, Arguments => Expr[To])] =
         ProductType.parseConstructor(To).map(constructor => constructor.parameters -> constructor.constructor)
+
+      def exprAsInstanceOfMethod[To: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Constructor[To] =
+        ProductType.exprAsInstanceOfMethod[To](args)(expr)
     }
   }
 
@@ -91,6 +94,9 @@ trait ProductTypes { this: Definitions =>
       case (getters, constructor) => Product(getters, constructor)
     }
     final def unapply[A](tpe: Type[A]): Option[Product[A]] = parse(tpe)
+
+    def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A] =
+      ??? // TODO: implement in ProductTypesPlatform
 
     // cached in companion (regexps are expensive to initialize)
     def areNamesMatching(fromName: String, toName: String): Boolean = ProductTypes.areNamesMatching(fromName, toName)

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -95,8 +95,7 @@ trait ProductTypes { this: Definitions =>
     }
     final def unapply[A](tpe: Type[A]): Option[Product[A]] = parse(tpe)
 
-    def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A] =
-      ??? // TODO: implement in ProductTypesPlatform
+    def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A]
 
     // cached in companion (regexps are expensive to initialize)
     def areNamesMatching(fromName: String, toName: String): Boolean = ProductTypes.areNamesMatching(fromName, toName)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -161,6 +161,29 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
   ): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerDefinitionMacros.withCoproductInstancePartialImpl[From, To, Cfg, Flags, Inst]
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): PartialTransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f).asInstanceOf[PartialTransformerDefinition[
+      From,
+      To,
+      TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg],
+      Flags
+    ]]
+
+  // TODO: implement me
+  def withConstructorPartial[In](
+      f: In => partial.Result[To]
+  ): PartialTransformerDefinition[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f).asInstanceOf[PartialTransformerDefinition[
+      From,
+      To,
+      TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
+      Flags
+    ]]
+
   /** Build Partial Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]`.

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.{partial, PartialTransformer}
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerDefinitionMacros
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 import scala.language.experimental.macros
 
@@ -161,28 +161,19 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
   ): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerDefinitionMacros.withCoproductInstancePartialImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
-  ): PartialTransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f).asInstanceOf[PartialTransformerDefinition[
-      From,
-      To,
-      TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg],
-      Flags
-    ]]
+  // TODO: docs
+  def withConstructor[Ctor](
+      f: Ctor
+  )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
+    macro PartialTransformerDefinitionMacros.withConstructorImpl[From, To, Cfg, Flags]
 
-  // TODO: implement me
-  def withConstructorPartial[In](
-      f: In => partial.Result[To]
-  ): PartialTransformerDefinition[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f).asInstanceOf[PartialTransformerDefinition[
-      From,
-      To,
-      TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
-      Flags
-    ]]
+  // TODO: docs
+  def withConstructorPartial[Ctor](
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, partial.Result[To]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
+    macro PartialTransformerDefinitionMacros.withConstructorPartialImpl[From, To, Cfg, Flags]
 
   /** Build Partial Transformer using current configuration.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -130,7 +130,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
     *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically
@@ -148,7 +148,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
     *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -161,13 +161,39 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
   ): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerDefinitionMacros.withCoproductInstancePartialImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 0.8.4
+    */
   def withConstructor[Ctor](
       f: Ctor
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorImpl[From, To, Cfg, Flags]
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `partial.Result[To]`
+    * @param f method name or lambda which constructs `partial.Result[To]`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 0.8.4
+    */
   def withConstructorPartial[Ctor](
       f: Ctor
   )(implicit

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -164,13 +164,39 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerIntoMacros.withCoproductInstancePartialImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 0.8.4
+    */
   def withConstructor[Ctor](
       f: Ctor
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerIntoMacros.withConstructorImpl[From, To, Cfg, Flags]
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `partial.Result[To]`
+    * @param f method name or lambda which constructs `partial.Result[To]`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 0.8.4
+    */
   def withConstructorPartial[Ctor](
       f: Ctor
   )(implicit

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -133,7 +133,7 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
     *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically
@@ -151,7 +151,7 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
     *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -164,6 +164,26 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerIntoMacros.withCoproductInstancePartialImpl[From, To, Cfg, Flags, Inst]
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+
+  // TODO: implement me
+  def withConstructorPartial[In](
+      f: In => partial.Result[To]
+  ): PartialTransformerInto[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[PartialTransformerInto[
+        From,
+        To,
+        TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
+        Flags
+      ]]
+
   /** Apply configured partial transformation in-place.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]`

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.partial
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoMacros
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 import scala.language.experimental.macros
 
@@ -164,25 +164,19 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     macro PartialTransformerIntoMacros.withCoproductInstancePartialImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
-  ): PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+  // TODO: docs
+  def withConstructor[Ctor](
+      f: Ctor
+  )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
+    macro PartialTransformerIntoMacros.withConstructorImpl[From, To, Cfg, Flags]
 
-  // TODO: implement me
-  def withConstructorPartial[In](
-      f: In => partial.Result[To]
-  ): PartialTransformerInto[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[PartialTransformerInto[
-        From,
-        To,
-        TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
-        Flags
-      ]]
+  // TODO: docs
+  def withConstructorPartial[Ctor](
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, partial.Result[To]]
+  ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
+    macro PartialTransformerIntoMacros.withConstructorPartialImpl[From, To, Cfg, Flags]
 
   /** Apply configured partial transformation in-place.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -111,6 +111,14 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
   def withCoproductInstance[Inst](f: Inst => To): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     macro TransformerDefinitionMacros.withCoproductInstanceImpl[From, To, Cfg, Flags, Inst]
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+
   /** Build Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `Transformer[From, To]`.

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -111,7 +111,20 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
   def withCoproductInstance[Inst](f: Inst => To): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     macro TransformerDefinitionMacros.withCoproductInstanceImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
+    *
+    * @since 0.8.4
+    */
   def withConstructor[Ctor](
       f: Ctor
   )(implicit ev: IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -100,7 +100,7 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
     *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.TransformerDefinitionMacros
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 import scala.language.experimental.macros
 
@@ -111,13 +111,11 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
   def withCoproductInstance[Inst](f: Inst => To): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     macro TransformerDefinitionMacros.withCoproductInstanceImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
-  ): TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+  // TODO: docs
+  def withConstructor[Ctor](
+      f: Ctor
+  )(implicit ev: IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
+    macro TransformerDefinitionMacros.withConstructorImpl[From, To, Cfg, Flags]
 
   /** Build Transformer using current configuration.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -106,7 +106,20 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   def withCoproductInstance[Inst](f: Inst => To): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
     macro TransformerIntoMacros.withCoproductInstanceImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 0.8.4
+    */
   def withConstructor[Ctor](
       f: Ctor
   )(implicit ev: IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerCfg, Flags] =

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -111,7 +111,7 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   def withConstructor[Fn](
       f: Fn
   )(implicit
-      ev: IsFunction.Aux[Fn, To]
+      ev: IsFunction.Of[Fn, To]
   ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
     addOverride(f)
       .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -96,7 +96,7 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it will fail.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
     *
     * @tparam Inst type of coproduct instance@param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -106,6 +106,14 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   def withCoproductInstance[Inst](f: Inst => To): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
     macro TransformerIntoMacros.withCoproductInstanceImpl[From, To, Cfg, Flags, Inst]
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+
   /** Apply configured transformation in-place.
     *
     * It runs macro that tries to derive instance of `Transformer[From, To]`

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -106,15 +106,11 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   def withCoproductInstance[Inst](f: Inst => To): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
     macro TransformerIntoMacros.withCoproductInstanceImpl[From, To, Cfg, Flags, Inst]
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[Fn](
-      f: Fn
-  )(implicit
-      ev: IsFunction.Of[Fn, To]
-  ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+  // TODO: docs
+  def withConstructor[Ctor](
+      f: Ctor
+  )(implicit ev: IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
+    macro TransformerIntoMacros.withConstructorImpl[From, To, Cfg, Flags]
 
   /** Apply configured transformation in-place.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.TransformerIntoMacros
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 import scala.language.experimental.macros
 
@@ -108,8 +108,10 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
 
   // TODO: implement me
   import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
+  def withConstructor[Fn](
+      f: Fn
+  )(implicit
+      ev: IsFunction.Aux[Fn, To]
   ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
     addOverride(f)
       .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
@@ -52,6 +52,7 @@ package object dsl {
       * [[io.scalaland.chimney.dsl.TransformerOps#into]] method.
       *
       * @see [[io.scalaland.chimney.Transformer.AutoDerived#deriveAutomatic]] for default implicit instance
+      *
       * @tparam To target type
       * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
       * @return transformed value of target type `To`
@@ -77,6 +78,7 @@ package object dsl {
       * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
       *
       * @see [[io.scalaland.chimney.PartialTransformer.AutoDerived#deriveAutomatic]] for default implicit instance
+      *
       * @tparam To result target type of partial transformation
       * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
       * @return partial transformation result value of target type `To`
@@ -94,6 +96,7 @@ package object dsl {
       * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
       *
       * @see [[io.scalaland.chimney.PartialTransformer.AutoDerived#deriveAutomatic]] for default implicit instance
+      *
       * @tparam To result target type of partial transformation
       * @param failFast    should fail as early as the first set of errors appear
       * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
@@ -122,6 +125,7 @@ package object dsl {
       * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
       *
       * @see [[io.scalaland.chimney.Patcher.AutoDerived#deriveAutomatic]] for default implicit instance
+      *
       * @tparam Patch type of patch object
       * @param patch   patch object value
       * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -124,6 +124,9 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
       ): Expr[partial.Result[B]] =
         c.Expr[partial.Result[B]](q"$pr.flatMap[${Type[B]}]($f)")
 
+      def flatten[A: Type](pr: Expr[partial.Result[partial.Result[A]]]): Expr[partial.Result[A]] =
+        c.Expr[partial.Result[A]](q"$pr.flatten[${Type[A]}]")
+
       def map[A: Type, B: Type](pr: Expr[partial.Result[A]])(f: Expr[A => B]): Expr[partial.Result[B]] =
         c.Expr[partial.Result[B]](q"$pr.map[${Type[B]}]($f)")
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -67,6 +67,32 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
     val RuntimeDataStore: Type[dsls.TransformerDefinitionCommons.RuntimeDataStore] =
       weakTypeTag[dsls.TransformerDefinitionCommons.RuntimeDataStore]
 
+    object ArgumentList extends ArgumentListModule {
+      val Empty: Type[runtime.ArgumentList.Empty] = weakTypeTag[runtime.ArgumentList.Empty]
+      object Argument extends ArgumentModule {
+        def apply[Name <: String: Type, Tpe: Type, Args <: runtime.ArgumentList: Type]
+            : Type[runtime.ArgumentList.Argument[Name, Tpe, Args]] =
+          weakTypeTag[runtime.ArgumentList.Argument[Name, Tpe, Args]]
+        def unapply[A](A: Type[A]): Option[(?<[String], ??, ?<[runtime.ArgumentList])] =
+          if (A.isCtor[runtime.ArgumentList.Argument[?, ?, ?]])
+            Some((A.param_<[String](0), A.param(1), A.param_<[runtime.ArgumentList](2)))
+          else scala.None
+      }
+    }
+
+    object ArgumentLists extends ArgumentListsModule {
+      val Empty: Type[runtime.ArgumentLists.Empty] = weakTypeTag[runtime.ArgumentLists.Empty]
+      object List extends ListModule {
+        def apply[Head <: runtime.ArgumentList: Type, Tail <: runtime.ArgumentLists: Type]
+            : Type[runtime.ArgumentLists.List[Head, Tail]] =
+          weakTypeTag[runtime.ArgumentLists.List[Head, Tail]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.ArgumentList], ?<[runtime.ArgumentLists])] =
+          if (A.isCtor[runtime.ArgumentLists.List[?, ?]])
+            Some((A.param_<[runtime.ArgumentList](0), A.param_<[runtime.ArgumentLists](1)))
+          else scala.None
+      }
+    }
+
     object TransformerCfg extends TransformerCfgModule {
       val Empty: Type[runtime.TransformerCfg.Empty] = weakTypeTag[runtime.TransformerCfg.Empty]
       object FieldConst extends FieldConstModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -158,6 +158,24 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             Some((fixJavaEnums(A.param(0)), A.param(1), A.param_<[runtime.TransformerCfg](2)))
           else scala.None
       }
+      object Constructor extends ConstructorModule {
+        def apply[Args <: runtime.ArgumentLists: Type, TargetType: Type, Cfg <: runtime.TransformerCfg: Type]
+            : Type[runtime.TransformerCfg.Constructor[Args, TargetType, Cfg]] =
+          weakTypeTag[runtime.TransformerCfg.Constructor[Args, TargetType, Cfg]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.ArgumentLists], ??, ?<[runtime.TransformerCfg])] =
+          if (A.isCtor[runtime.TransformerCfg.Constructor[?, ?, ?]])
+            Some((A.param_<[runtime.ArgumentLists](0), A.param(1), A.param_<[runtime.TransformerCfg](2)))
+          else scala.None
+      }
+      object ConstructorPartial extends ConstructorPartialModule {
+        def apply[Args <: runtime.ArgumentLists: Type, TargetType: Type, Cfg <: runtime.TransformerCfg: Type]
+            : Type[runtime.TransformerCfg.ConstructorPartial[Args, TargetType, Cfg]] =
+          weakTypeTag[runtime.TransformerCfg.ConstructorPartial[Args, TargetType, Cfg]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.ArgumentLists], ??, ?<[runtime.TransformerCfg])] =
+          if (A.isCtor[runtime.TransformerCfg.ConstructorPartial[?, ?, ?]])
+            Some((A.param_<[runtime.ArgumentLists](0), A.param(1), A.param_<[runtime.TransformerCfg](2)))
+          else scala.None
+      }
     }
 
     object TransformerFlags extends TransformerFlagsModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.PartialTransformerDefinition
-import io.scalaland.chimney.internal.runtime.{Path, TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.{ArgumentLists, Path, TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -107,4 +107,26 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Inst](f)
+
+  def withConstructorImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Cfg <: TransformerCfg: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Ctor <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerDefinition[From, To, Constructor[Ctor, To, Cfg], Flags]]
+  }.applyFromBody(f)
+
+  def withConstructorPartialImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Cfg <: TransformerCfg: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Ctor <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerDefinition[From, To, ConstructorPartial[Ctor, To, Cfg], Flags]]
+  }.applyFromBody(f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.PartialTransformerInto
-import io.scalaland.chimney.internal.runtime.{Path, TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.{ArgumentLists, Path, TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -103,4 +103,26 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       .addOverride(f)
       .asInstanceOfExpr[PartialTransformerInto[From, To, CoproductInstancePartial[FixedInstance, To, Cfg], Flags]]
   }.applyJavaEnumFixFromClosureSignature[Inst](f)
+
+  def withConstructorImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Cfg <: TransformerCfg: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Ctor <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerInto[From, To, Constructor[Ctor, To, Cfg], Flags]]
+  }.applyFromBody(f)
+
+  def withConstructorPartialImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Cfg <: TransformerCfg: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Ctor <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerInto[From, To, ConstructorPartial[Ctor, To, Cfg], Flags]]
+  }.applyFromBody(f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.TransformerDefinition
-import io.scalaland.chimney.internal.runtime.{Path, TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.{ArgumentLists, Path, TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -63,4 +63,15 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       .addOverride(f)
       .asInstanceOfExpr[TransformerDefinition[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
   }.applyJavaEnumFixFromClosureSignature[Inst](f)
+
+  def withConstructorImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Cfg <: TransformerCfg: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Ctor <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[TransformerDefinition[From, To, Constructor[Ctor, To, Cfg], Flags]]
+  }.applyFromBody(f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.internal.compiletime.dsl
 
 import io.scalaland.chimney.dsl.TransformerInto
-import io.scalaland.chimney.internal.runtime.{Path, TransformerCfg, TransformerFlags}
+import io.scalaland.chimney.internal.runtime.{ArgumentLists, Path, TransformerCfg, TransformerFlags}
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 
 import scala.annotation.unused
@@ -63,4 +63,15 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       .addOverride(f)
       .asInstanceOfExpr[TransformerInto[From, To, CoproductInstance[FixedInstance, To, Cfg], Flags]]
   }.applyJavaEnumFixFromClosureSignature[Inst](f)
+
+  def withConstructorImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Cfg <: TransformerCfg: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Ctor <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[TransformerInto[From, To, Constructor[Ctor, To, Cfg], Flags]]
+  }.applyFromBody(f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -93,37 +93,13 @@ private[chimney] trait DslMacroUtils {
           }
         // Scala 2.12
         case Block(Nil, term) => extractParams(term)
-        // TODO: remove once everything works
-        case _ =>
-          println(s"""Expression:
-                     |${Console.MAGENTA}${show(t)}${Console.RESET}
-                     |defined as:
-                     |${Console.MAGENTA}${showRaw(t)}${Console.RESET}
-                     |of type:
-                     |${Console.MAGENTA}${t.tpe}${Console.RESET}
-                     |of type:
-                     |${Console.MAGENTA}${showRaw(t.tpe)}${Console.RESET}
-                     |""".stripMargin)
-          Left(invalidConstructor(t))
+        case _                => Left(invalidConstructor(t))
       }
 
       extractParams(t).map { params =>
-        val tpe = paramsToType(params)
-        println(s"""Expression:
-                   |${Console.MAGENTA}${show(t)}${Console.RESET}
-                   |defined as:
-                   |${Console.MAGENTA}${showRaw(t)}${Console.RESET}
-                   |of type:
-                   |${Console.MAGENTA}${t.tpe}${Console.RESET}
-                   |of type:
-                   |${Console.MAGENTA}${showRaw(t.tpe)}${Console.RESET}
-                   |resolved as:
-                   |${Console.MAGENTA}$tpe${Console.RESET}
-                   |""".stripMargin)
-
         new ExistentialCtor {
           type Underlying = runtime.ArgumentLists
-          implicit val Underlying: WeakTypeTag[runtime.ArgumentLists] = tpe
+          implicit val Underlying: WeakTypeTag[runtime.ArgumentLists] = paramsToType(params)
         }
       }
     }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -86,15 +86,13 @@ private[chimney] trait DslMacroUtils {
 
     def parse(t: Tree): Either[String, ExistentialCtor] = {
       def extractParams(t: Tree): Either[String, List[List[ValDef]]] = t match {
-        // TODO: add support for multiple parameter lists
         case Function(params, tail) =>
           extractParams(tail) match {
             case Left(_)     => Right(List(params))
             case Right(tail) => Right(params :: tail)
           }
         // Scala 2.12
-        // case Apply(_, params) =>
-        // TODO: ???
+        case Block(Nil, term) => extractParams(term)
         // TODO: remove once everything works
         case _ =>
           println(s"""Expression:

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -91,7 +91,7 @@ private[chimney] trait DslMacroUtils {
             case Left(_)     => Right(List(params))
             case Right(tail) => Right(params :: tail)
           }
-        // Scala 2.12
+        // Eta-expansion wrapper in Scala 2.12
         case Block(Nil, term) => extractParams(term)
         case _                => Left(invalidConstructor(t))
       }
@@ -198,9 +198,9 @@ private[chimney] trait DslMacroUtils {
         val Inst = weakTypeOf[Inst]
         val Function(List(ValDef(_, _, lhs: TypeTree, _)), _) = f
         lhs.original match {
-          // java enum value in Scala 2.13
+          // Java enum value in Scala 2.13
           case SingletonTypeTree(Literal(Constant(t: TermSymbol))) => apply(refineJavaEnum[Inst](t))
-          // java enum value in Scala 2.12
+          // Java enum value in Scala 2.12
           case SingletonTypeTree(Select(t, n)) if t.isTerm =>
             val t = Inst.companion.decls
               .find(_.name == n)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -92,8 +92,20 @@ private[chimney] trait DslMacroUtils {
             case Left(_)     => Right(List(params))
             case Right(tail) => Right(params :: tail)
           }
+        // Scala 2.12
+        // case Apply(_, params) =>
+        // TODO: ???
         // TODO: remove once everything works
         case _ =>
+          println(s"""Expression:
+                     |${Console.MAGENTA}${show(t)}${Console.RESET}
+                     |defined as:
+                     |${Console.MAGENTA}${showRaw(t)}${Console.RESET}
+                     |of type:
+                     |${Console.MAGENTA}${t.tpe}${Console.RESET}
+                     |of type:
+                     |${Console.MAGENTA}${showRaw(t.tpe)}${Console.RESET}
+                     |""".stripMargin)
           Left(invalidConstructor(t))
       }
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
@@ -26,6 +26,7 @@ package object syntax {
       * [[io.scalaland.chimney.dsl.TransformerOps#into]] method.
       *
       * @see [[io.scalaland.chimney.auto#deriveAutomaticTransformer]] for default implicit instance
+      *
       * @tparam To target type
       * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
       * @return transformed value of target type `To`
@@ -51,6 +52,7 @@ package object syntax {
       * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
       *
       * @see [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]] for default implicit instance
+      *
       * @tparam To result target type of partial transformation
       * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
       * @return partial transformation result value of target type `To`
@@ -68,6 +70,7 @@ package object syntax {
       * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
       *
       * @see [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]] for default implicit instance
+      *
       * @tparam To result target type of partial transformation
       * @param failFast    should fail as early as the first set of errors appear
       * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
@@ -96,6 +99,7 @@ package object syntax {
       * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
       *
       * @see [[io.scalaland.chimney.auto#deriveAutomaticPatcher]] for default implicit instance
+      *
       * @tparam Patch type of patch object
       * @param patch   patch object value
       * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -156,6 +156,29 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
   ): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerDefinitionMacros.withCoproductInstancePartial('this, 'f) }
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): PartialTransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f).asInstanceOf[PartialTransformerDefinition[
+      From,
+      To,
+      TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg],
+      Flags
+    ]]
+
+  // TODO: implement me
+  def withConstructorPartial[In](
+      f: In => partial.Result[To]
+  ): PartialTransformerDefinition[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f).asInstanceOf[PartialTransformerDefinition[
+      From,
+      To,
+      TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
+      Flags
+    ]]
+
   /** Build Partial Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]`.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -162,13 +162,39 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
   ): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerDefinitionMacros.withCoproductInstancePartial('this, 'f) }
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 0.8.4
+    */
   transparent inline def withConstructor[Ctor](
       inline f: Ctor
   )(using IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorImpl('this, 'f) }
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `partial.Result[To]`
+    * @param f method name or lambda which constructs `partial.Result[To]`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 0.8.4
+    */
   transparent inline def withConstructorPartial[Ctor](
       inline f: Ctor
   )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.{partial, PartialTransformer}
 import io.scalaland.chimney.internal.compiletime.dsl.*
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 /** Allows customization of [[io.scalaland.chimney.PartialTransformer]] derivation.
   *
@@ -156,28 +156,17 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
   ): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerDefinitionMacros.withCoproductInstancePartial('this, 'f) }
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
-  ): PartialTransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f).asInstanceOf[PartialTransformerDefinition[
-      From,
-      To,
-      TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg],
-      Flags
-    ]]
+  // TODO: docs
+  transparent inline def withConstructor[Ctor](
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
+    ${ PartialTransformerDefinitionMacros.withConstructorImpl('this, 'f) }
 
-  // TODO: implement me
-  def withConstructorPartial[In](
-      f: In => partial.Result[To]
-  ): PartialTransformerDefinition[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f).asInstanceOf[PartialTransformerDefinition[
-      From,
-      To,
-      TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
-      Flags
-    ]]
+  // TODO: docs
+  transparent inline def withConstructorPartial[Ctor](
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
+    ${ PartialTransformerDefinitionMacros.withConstructorPartialImpl('this, 'f) }
 
   /** Build Partial Transformer using current configuration.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -27,6 +27,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * By default if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of provided value
     * @param selector target field in `To`, defined like `_.name`
@@ -46,6 +47,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * By default if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of computed value
     * @param selector target field in `To`, defined like `_.name`
@@ -65,6 +67,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * By default if `From` is missing field picked by `selector` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of computed value
     * @param selector target field in `To`, defined like `_.name`
@@ -84,6 +87,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * By default if `From` is missing field picked by `selector` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of computed value
     * @param selector target field in `To`, defined like `_.name`
@@ -103,6 +107,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]] for more details
+    *
     * @tparam T type of source field
     * @tparam U type of target field
     * @param selectorFrom source field in `From`, defined like `_.originalName`
@@ -124,7 +129,8 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
+    *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
@@ -143,7 +149,7 @@ final class PartialTransformerDefinition[From, To, Cfg <: TransformerCfg, Flags 
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
     *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -156,6 +156,26 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerIntoMacros.withCoproductInstancePartialImpl('this, 'f) }
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+
+  // TODO: implement me
+  def withConstructorPartial[In](
+      f: In => partial.Result[To]
+  ): PartialTransformerInto[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[PartialTransformerInto[
+        From,
+        To,
+        TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
+        Flags
+      ]]
+
   /** Apply configured partial transformation in-place.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]`

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -28,6 +28,7 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * By default if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of provided value
     * @param selector target field in `To`, defined like `_.name`
@@ -47,6 +48,7 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * By default if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of provided value
     * @param selector target field in `To`, defined like `_.name`
@@ -66,6 +68,7 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * By default if `From` is missing field picked by `selector` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of computed value
     * @param selector target field in `To`, defined like `_.name`
@@ -85,6 +88,7 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * By default if `From` is missing field picked by `selector` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of computed value
     * @param selector target field in `To`, defined like `_.name`
@@ -104,6 +108,7 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]] for more details
+    *
     * @tparam T type of source field
     * @tparam U type of target field
     * @param selectorFrom source field in `From`, defined like `_.originalName`
@@ -125,7 +130,8 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
+    *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.PartialTransformerInto]]
@@ -144,7 +150,8 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
+    *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.PartialTransformerInto]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.internal.compiletime.dsl
 import io.scalaland.chimney.partial
 import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoMacros
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 /** Provides DSL for configuring [[io.scalaland.chimney.PartialTransformer]]'s
   * generation and using the result to transform value at the same time
@@ -156,25 +156,17 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerIntoMacros.withCoproductInstancePartialImpl('this, 'f) }
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
-  ): PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[PartialTransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+  // TODO: docs
+  transparent inline def withConstructor[Ctor](
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
+    ${ PartialTransformerIntoMacros.withConstructorImpl('this, 'f) }
 
-  // TODO: implement me
-  def withConstructorPartial[In](
-      f: In => partial.Result[To]
-  ): PartialTransformerInto[From, To, TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[PartialTransformerInto[
-        From,
-        To,
-        TransformerCfg.ConstructorPartial[ArgumentLists.Empty, To, Cfg],
-        Flags
-      ]]
+  // TODO: docs
+  transparent inline def withConstructorPartial[Ctor](
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
+    ${ PartialTransformerIntoMacros.withConstructorPartialImpl('this, 'f) }
 
   /** Apply configured partial transformation in-place.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -163,13 +163,39 @@ final class PartialTransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Tra
   ): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerIntoMacros.withCoproductInstancePartialImpl('this, 'f) }
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 0.8.4
+    */
   transparent inline def withConstructor[Ctor](
       inline f: Ctor
   )(using IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorImpl('this, 'f) }
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `partial.Result[To]`
+    * @param f method name or lambda which constructs `partial.Result[To]`
+    * @return [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 0.8.4
+    */
   transparent inline def withConstructorPartial[Ctor](
       inline f: Ctor
   )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerInto[From, To, ? <: TransformerCfg, Flags] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.internal.*
 import io.scalaland.chimney.internal.compiletime.dsl.*
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 import scala.quoted.*
 
@@ -108,13 +108,11 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
   ): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     ${ TransformerDefinitionMacros.withCoproductInstance('this, 'f) }
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
-  ): TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+  // TODO: docs
+  transparent inline def withConstructor[Ctor](
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
+    ${ TransformerDefinitionMacros.withConstructorImpl('this, 'f) }
 
   /** Build Transformer using current configuration.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -108,6 +108,14 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
   ): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     ${ TransformerDefinitionMacros.withCoproductInstance('this, 'f) }
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[TransformerDefinition[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+
   /** Build Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `Transformer[From, To]`.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -112,7 +112,20 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
   ): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =
     ${ TransformerDefinitionMacros.withCoproductInstance('this, 'f) }
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
+    *
+    * @since 0.8.4
+    */
   transparent inline def withConstructor[Ctor](
       inline f: Ctor
   )(using IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerCfg, Flags] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -37,6 +37,7 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
     * By default if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of provided value
     * @param selector target field in `To`, defined like `_.name`
@@ -56,6 +57,7 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
     * By default if `From` is missing field picked by `selector` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-the-computed-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of computed value
     * @param selector target field in `To`, defined like `_.name`
@@ -75,6 +77,7 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]] for more details
+    *
     * @tparam T type of source field
     * @tparam U type of target field
     * @param selectorFrom source field in `From`, defined like `_.originalName`
@@ -96,7 +99,8 @@ final class TransformerDefinition[From, To, Cfg <: TransformerCfg, Flags <: Tran
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it fails compilation unless provided replacement with this operation.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
+    *
     * @tparam Inst type of coproduct instance
     * @param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -38,6 +38,7 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
     * By default if `From` is missing field picked by `selector` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]] for more details
+    *
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     *
     * @since 0.1.5
@@ -53,6 +54,7 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
     * By default if `From` is missing field picked by `selector` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]] for more details
+    *
     * @tparam T type of target field
     * @tparam U type of computed value
     * @param selector target field in `To`, defined like `_.name`
@@ -72,6 +74,7 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]] for more details
+    *
     * @tparam T type of source field
     * @tparam U type of target field
     * @param selectorFrom source field in `From`, defined like `_.originalName`
@@ -93,7 +96,8 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
     * in `To` field's type there is matching component in `From` type. If some component is missing
     * it will fail.
     *
-    * @see [[]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]] for more details
+    *
     * @tparam Inst type of coproduct instance@param f function to calculate values of components that cannot be mapped automatically
     * @return [[io.scalaland.chimney.dsl.TransformerInto]]
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -108,7 +108,20 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   ): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
     ${ TransformerIntoMacros.withCoproductInstanceImpl('this, 'f) }
 
-  // TODO: docs
+  /** Use `f` instead of the primary constructor to construct the `To` value.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more details
+    *
+    * @tparam Ctor type of the Eta-expanded method/lambda which should return `To`
+    * @param f method name or lambda which constructs `To`
+    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 0.8.4
+    */
   transparent inline def withConstructor[Ctor](
       inline f: Ctor
   )(using IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerCfg, Flags] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -107,7 +107,7 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   // TODO: implement me
   import io.scalaland.chimney.internal.runtime.ArgumentLists
   def withConstructor[Fn](f: Fn)(implicit
-      ev: IsFunction.Aux[Fn, To]
+      ev: IsFunction.Of[Fn, To]
   ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
     addOverride(f)
       .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -104,6 +104,14 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   ): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
     ${ TransformerIntoMacros.withCoproductInstanceImpl('this, 'f) }
 
+  // TODO: implement me
+  import io.scalaland.chimney.internal.runtime.ArgumentLists
+  def withConstructor[In](
+      f: In => To
+  ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
+    addOverride(f)
+      .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+
   /** Apply configured transformation in-place.
     *
     * It runs macro that tries to derive instance of `Transformer[From, To]`

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -104,13 +104,11 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
   ): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
     ${ TransformerIntoMacros.withCoproductInstanceImpl('this, 'f) }
 
-  // TODO: implement me
-  import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[Fn](f: Fn)(implicit
-      ev: IsFunction.Of[Fn, To]
-  ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
-    addOverride(f)
-      .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]
+  // TODO: docs
+  transparent inline def withConstructor[Ctor](
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerCfg, Flags] =
+    ${ TransformerIntoMacros.withConstructorImpl('this, 'f) }
 
   /** Apply configured transformation in-place.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.internal.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.TransformerIntoMacros
-import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{IsFunction, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
 
 /** Provides DSL for configuring [[io.scalaland.chimney.Transformer]]'s
   * generation and using the result to transform value at the same time
@@ -106,8 +106,8 @@ final class TransformerInto[From, To, Cfg <: TransformerCfg, Flags <: Transforme
 
   // TODO: implement me
   import io.scalaland.chimney.internal.runtime.ArgumentLists
-  def withConstructor[In](
-      f: In => To
+  def withConstructor[Fn](f: Fn)(implicit
+      ev: IsFunction.Aux[Fn, To]
   ): TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags] =
     addOverride(f)
       .asInstanceOf[TransformerInto[From, To, TransformerCfg.Constructor[ArgumentLists.Empty, To, Cfg], Flags]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
@@ -25,6 +25,7 @@ extension [From](source: From) {
     * [[io.scalaland.chimney.dsl.TransformerOps#into]] method.
     *
     * @see [[io.scalaland.chimney.Transformer.AutoDerived#deriveAutomatic]] for default implicit instance
+    *
     * @tparam To target type
     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
     * @return transformed value of target type `To`
@@ -50,6 +51,7 @@ extension [From](source: From) {
     * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
     *
     * @see [[io.scalaland.chimney.PartialTransformer#deriveAutomatic]] for default implicit instance
+    *
     * @tparam To result target type of partial transformation
     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
     * @return partial transformation result value of target type `To`
@@ -67,6 +69,7 @@ extension [From](source: From) {
     * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
     *
     * @see [[io.scalaland.chimney.PartialTransformer#deriveAutomatic]] for default implicit instance
+    *
     * @tparam To result target type of partial transformation
     * @param failFast    should fail as early as the first set of errors appear
     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
@@ -95,6 +98,7 @@ extension [A](obj: A) {
     * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
     *
     * @see [[io.scalaland.chimney.Patcher#deriveAutomatic]] for default implicit instance
+    *
     * @tparam Patch type of patch object
     * @param patch   patch object value
     * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -106,6 +106,9 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
       ): Expr[partial.Result[B]] =
         '{ ${ pr }.flatMap(${ f }) }
 
+      def flatten[A: Type](pr: Expr[partial.Result[partial.Result[A]]]): Expr[partial.Result[A]] =
+        '{ ${ pr }.flatten[A] }
+
       def map[A: Type, B: Type](pr: Expr[partial.Result[A]])(f: Expr[A => B]): Expr[partial.Result[B]] =
         '{ ${ pr }.map(${ f }) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -142,6 +142,28 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             Some((Type[instType].as_??, Type[targetType].as_??, Type[c].as_?<[runtime.TransformerCfg]))
           case _ => scala.None
       }
+      object Constructor extends ConstructorModule {
+        def apply[Args <: runtime.ArgumentLists: Type, TargetType: Type, Cfg <: runtime.TransformerCfg: Type]
+            : Type[runtime.TransformerCfg.Constructor[Args, TargetType, Cfg]] =
+          quoted.Type.of[runtime.TransformerCfg.Constructor[Args, TargetType, Cfg]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.ArgumentLists], ??, ?<[runtime.TransformerCfg])] = tpe match
+          case '[runtime.TransformerCfg.Constructor[args, targetType, c]] =>
+            Some(
+              (Type[args].as_?<[runtime.ArgumentLists], Type[targetType].as_??, Type[c].as_?<[runtime.TransformerCfg])
+            )
+          case _ => scala.None
+      }
+      object ConstructorPartial extends ConstructorPartialModule {
+        def apply[Args <: runtime.ArgumentLists: Type, TargetType: Type, Cfg <: runtime.TransformerCfg: Type]
+            : Type[runtime.TransformerCfg.ConstructorPartial[Args, TargetType, Cfg]] =
+          quoted.Type.of[runtime.TransformerCfg.ConstructorPartial[Args, TargetType, Cfg]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.ArgumentLists], ??, ?<[runtime.TransformerCfg])] = tpe match
+          case '[runtime.TransformerCfg.ConstructorPartial[args, targetType, c]] =>
+            Some(
+              (Type[args].as_?<[runtime.ArgumentLists], Type[targetType].as_??, Type[c].as_?<[runtime.TransformerCfg])
+            )
+          case _ => scala.None
+      }
     }
 
     object TransformerFlags extends TransformerFlagsModule {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -44,6 +44,32 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
     val RuntimeDataStore: Type[dsls.TransformerDefinitionCommons.RuntimeDataStore] =
       quoted.Type.of[dsls.TransformerDefinitionCommons.RuntimeDataStore]
 
+    object ArgumentList extends ArgumentListModule {
+      val Empty: Type[runtime.ArgumentList.Empty] = quoted.Type.of[runtime.ArgumentList.Empty]
+      object Argument extends ArgumentModule {
+        def apply[Name <: String: Type, Tpe: Type, Args <: runtime.ArgumentList: Type]
+            : Type[runtime.ArgumentList.Argument[Name, Tpe, Args]] =
+          quoted.Type.of[runtime.ArgumentList.Argument[Name, Tpe, Args]]
+        def unapply[A](tpe: Type[A]): Option[(?<[String], ??, ?<[runtime.ArgumentList])] = tpe match
+          case '[runtime.ArgumentList.Argument[name, tpe, args]] =>
+            Some((Type[name].as_?<[String], Type[tpe].as_??, Type[args].as_?<[runtime.ArgumentList]))
+          case _ => scala.None
+      }
+    }
+
+    object ArgumentLists extends ArgumentListsModule {
+      val Empty: Type[runtime.ArgumentLists.Empty] = quoted.Type.of[runtime.ArgumentLists.Empty]
+      object List extends ListModule {
+        def apply[Head <: runtime.ArgumentList: Type, Tail <: runtime.ArgumentLists: Type]
+            : Type[runtime.ArgumentLists.List[Head, Tail]] =
+          quoted.Type.of[runtime.ArgumentLists.List[Head, Tail]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.ArgumentList], ?<[runtime.ArgumentLists])] = tpe match
+          case '[runtime.ArgumentLists.List[head, tail]] =>
+            Some((Type[head].as_?<[runtime.ArgumentList], Type[tail].as_?<[runtime.ArgumentLists]))
+          case _ => scala.None
+      }
+    }
+
     object TransformerCfg extends TransformerCfgModule {
       val Empty: Type[runtime.TransformerCfg.Empty] = quoted.Type.of[runtime.TransformerCfg.Empty]
       object FieldConst extends FieldConstModule {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -4,7 +4,13 @@ import io.scalaland.chimney.PartialTransformer
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
-import io.scalaland.chimney.internal.runtime.{Path, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  ArgumentLists,
+  Path,
+  TransformerCfg,
+  TransformerFlags,
+  WithRuntimeDataStore
+}
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 import io.scalaland.chimney.partial
 
@@ -164,6 +170,46 @@ object PartialTransformerDefinitionMacros {
         .update($td, $f)
         .asInstanceOf[PartialTransformerDefinition[From, To, CoproductInstancePartial[Inst, To, Cfg], Flags]]
     }
+
+  def withConstructorImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [ctor <: ArgumentLists] =>
+        (_: Type[ctor]) ?=>
+          '{
+            WithRuntimeDataStore
+              .update($ti, $f)
+              .asInstanceOf[PartialTransformerDefinition[From, To, Constructor[ctor, To, Cfg], Flags]]
+        }
+    }(f)
+
+  def withConstructorPartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerDefinition[From, To, Cfg, Flags]],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerCfg, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [ctor <: ArgumentLists] =>
+        (_: Type[ctor]) ?=>
+          '{
+            WithRuntimeDataStore
+              .update($ti, $f)
+              .asInstanceOf[PartialTransformerDefinition[From, To, ConstructorPartial[ctor, To, Cfg], Flags]]
+        }
+    }(f)
 
   def buildTransformer[
       From: Type,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -4,7 +4,13 @@ import io.scalaland.chimney.PartialTransformer
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
-import io.scalaland.chimney.internal.runtime.{Path, TransformerCfg, TransformerFlags, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  ArgumentLists,
+  Path,
+  TransformerCfg,
+  TransformerFlags,
+  WithRuntimeDataStore
+}
 import io.scalaland.chimney.internal.runtime.TransformerCfg.*
 import io.scalaland.chimney.partial
 
@@ -154,6 +160,46 @@ object PartialTransformerIntoMacros {
         .update($ti, $f)
         .asInstanceOf[PartialTransformerInto[From, To, CoproductInstancePartial[Inst, To, Cfg], Flags]]
     }
+
+  def withConstructorImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [ctor <: ArgumentLists] =>
+        (_: Type[ctor]) ?=>
+          '{
+            WithRuntimeDataStore
+              .update($ti, $f)
+              .asInstanceOf[PartialTransformerInto[From, To, Constructor[ctor, To, Cfg], Flags]]
+        }
+    }(f)
+
+  def withConstructorPartialImpl[
+      From: Type,
+      To: Type,
+      Cfg <: TransformerCfg: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Cfg, Flags]],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerCfg, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [ctor <: ArgumentLists] =>
+        (_: Type[ctor]) ?=>
+          '{
+            WithRuntimeDataStore
+              .update($ti, $f)
+              .asInstanceOf[PartialTransformerInto[From, To, ConstructorPartial[ctor, To, Cfg], Flags]]
+        }
+    }(f)
 
   def transform[
       From: Type,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -66,6 +66,7 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
       case Inlined(_, _, block) => parse(block)
       case _                    => Left(invalidSelectorErrorMessage(t))
     }
+    List(1 -> 2).fol
 
     private def invalidSelectorErrorMessage(t: Tree): String =
       s"Invalid selector expression: ${t.show(using Printer.TreeAnsiCode)}"

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -92,4 +92,12 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
       case (Left(error), _) => report.errorAndAbort(error, Position.ofMacroExpansion)
       case (_, Left(error)) => report.errorAndAbort(error, Position.ofMacroExpansion)
     }
+
+  def applyConstructorType[Out](
+      f: [Ctor <: runtime.ArgumentLists] => Type[Ctor] ?=> Out
+  )(ctor: Expr[?]): Out = {
+    // TODO: analyze f and implement the type
+    val _ = ctor
+    f[runtime.ArgumentLists.Empty]
+  }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
@@ -22,6 +22,7 @@ extension [From](source: From) {
     * [[io.scalaland.chimney.dsl.TransformerOps#into]] method.
     *
     * @see [[io.scalaland.chimney.auto#deriveAutomaticTransformer]] for default implicit instance
+    *
     * @tparam To target type
     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
     * @return transformed value of target type `To`
@@ -46,6 +47,7 @@ extension [From](source: From) {
     * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
     *
     * @see [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]] for default implicit instance
+    *
     * @tparam To result target type of partial transformation
     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
     * @return partial transformation result value of target type `To`
@@ -63,6 +65,7 @@ extension [From](source: From) {
     * [[io.scalaland.chimney.dsl.PartialTransformerOps#intoPartial]] method.
     *
     * @see [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]] for default implicit instance
+    *
     * @tparam To result target type of partial transformation
     * @param failFast    should fail as early as the first set of errors appear
     * @param transformer implicit instance of [[io.scalaland.chimney.Transformer]] type class
@@ -91,6 +94,7 @@ extension [T](obj: T) {
     * [[io.scalaland.chimney.dsl.PatcherOps#using using]] method.
     *
     * @see [[io.scalaland.chimney.auto#deriveAutomaticPatcher]] for default implicit instance
+    *
     * @tparam P type of patch object
     * @param patch   patch object value
     * @param patcher implicit instance of [[io.scalaland.chimney.Patcher]] type class

--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -30,6 +30,7 @@ object Patcher extends PatcherCompanionPlatform {
     * you can customize to derive [[io.scalaland.chimney.Patcher]].
     *
     * @see [[io.scalaland.chimney.dsl.PatcherDefinition]] for available settings
+    *
     * @tparam A     type of object to apply patch to
     * @tparam Patch type of patch object
     * @return [[io.scalaland.chimney.dsl.PatcherDefinition]] with defaults

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherConfiguration.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherConfiguration.scala
@@ -5,6 +5,7 @@ import io.scalaland.chimney.internal.runtime.PatcherFlags
 /** Type-level set of derivation flags that can be shared between derivations through implicit scope.
   *
   * @see [[https://chimney.readthedocs.io/cookbook/#reusing-flags-for-several-transformationspatchings]] for more details
+  *
   * @tparam Flags type-level encoded flags
   *
   * @since 0.8.0

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherFlagsDsl.scala
@@ -17,6 +17,7 @@ private[dsl] trait PatcherFlagsDsl[UpdateFlag[_ <: PatcherFlags], Flags <: Patch
     * the value of such field on patching.
     *
     * @see [[https://chimney.readthedocs.io/supported-patching/#treating-none-as-no-update-instead-of-set-to-none]] for more details
+    *
     * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
     *
     * @since 0.4.0
@@ -27,6 +28,7 @@ private[dsl] trait PatcherFlagsDsl[UpdateFlag[_ <: PatcherFlags], Flags <: Patch
   /** Then there Option is patching Option, on None value will be cleared.
     *
     * @see [[https://chimney.readthedocs.io/supported-patching/#treating-none-as-no-update-instead-of-set-to-none]] for more details
+    *
     * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
     *
     * @since 0.8.0
@@ -43,6 +45,7 @@ private[dsl] trait PatcherFlagsDsl[UpdateFlag[_ <: PatcherFlags], Flags <: Patch
     * typos.
     *
     * @see [[https://chimney.readthedocs.io/supported-patching/#ignoring-fields-in-patches]] for more details
+    *
     * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
     *
     * @since 0.4.0
@@ -53,6 +56,7 @@ private[dsl] trait PatcherFlagsDsl[UpdateFlag[_ <: PatcherFlags], Flags <: Patch
   /** Fail the compilation if there is a redundant field in patching object.
     *
     * @see [[https://chimney.readthedocs.io/supported-patching/#ignoring-fields-in-patches]] for more details
+    *
     * @return [[io.scalaland.chimney.dsl.PatcherUsing]]
     *
     * @since 0.8.0

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerConfiguration.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerConfiguration.scala
@@ -5,6 +5,7 @@ import io.scalaland.chimney.internal.runtime.TransformerFlags
 /** Type-level set of derivation flags that can be shared between derivations through implicit scope.
   *
   * @see [[https://chimney.readthedocs.io/cookbook/#reusing-flags-for-several-transformationspatchings]] for more details
+  *
   * @tparam Flags type-level encoded flags
   *
   * @since 0.6.0

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
@@ -80,6 +80,8 @@ private[compiletime] trait ChimneyExprs { this: ChimneyDefinitions =>
           f: Expr[A => partial.Result[B]]
       ): Expr[partial.Result[B]]
 
+      def flatten[A: Type](pr: Expr[partial.Result[partial.Result[A]]]): Expr[partial.Result[A]]
+
       def map[A: Type, B: Type](pr: Expr[partial.Result[A]])(f: Expr[A => B]): Expr[partial.Result[B]]
 
       def map2[A: Type, B: Type, C: Type](
@@ -159,6 +161,13 @@ private[compiletime] trait ChimneyExprs { this: ChimneyDefinitions =>
 
     def prependErrorPath(path: Expr[partial.PathElement]): Expr[partial.Result[A]] =
       ChimneyExpr.PartialResult.prependErrorPath(resultExpr, path)
+  }
+
+  implicit final protected class PartialResultFlattenExprOps[A: Type](
+      private val resultExpr: Expr[partial.Result[partial.Result[A]]]
+  ) {
+
+    def flatten: Expr[partial.Result[A]] = ChimneyExpr.PartialResult.flatten(resultExpr)
   }
 
   implicit final protected class PartialResultValueExprOps[A: Type](

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -126,9 +126,23 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerCfg.CoproductInstancePartial
           ] { this: CoproductInstancePartial.type => }
 
-      // TODO: Constructor
+      val Constructor: ConstructorModule
+      trait ConstructorModule
+          extends Type.Ctor3UpperBounded[
+            runtime.ArgumentLists,
+            Any,
+            runtime.TransformerCfg,
+            runtime.TransformerCfg.Constructor
+          ] { this: Constructor.type => }
 
-      // TODO: ConstructorPartial
+      val ConstructorPartial: ConstructorPartialModule
+      trait ConstructorPartialModule
+          extends Type.Ctor3UpperBounded[
+            runtime.ArgumentLists,
+            Any,
+            runtime.TransformerCfg,
+            runtime.TransformerCfg.ConstructorPartial
+          ] { this: ConstructorPartial.type => }
     }
 
     val TransformerFlags: TransformerFlagsModule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -36,8 +36,35 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
 
     val RuntimeDataStore: Type[dsls.TransformerDefinitionCommons.RuntimeDataStore]
 
+    val ArgumentList: ArgumentListModule
+    trait ArgumentListModule { this: ArgumentList.type =>
+      val Empty: Type[runtime.ArgumentList.Empty]
+
+      val Argument: ArgumentModule
+      trait ArgumentModule
+          extends Type.Ctor3UpperBounded[
+            String,
+            Any,
+            runtime.ArgumentList,
+            runtime.ArgumentList.Argument
+          ] { this: Argument.type => }
+    }
+
+    val ArgumentLists: ArgumentListsModule
+    trait ArgumentListsModule { this: ArgumentLists.type =>
+      val Empty: Type[runtime.ArgumentLists.Empty]
+
+      val List: ListModule
+      trait ListModule
+          extends Type.Ctor2UpperBounded[
+            runtime.ArgumentList,
+            runtime.ArgumentLists,
+            runtime.ArgumentLists.List
+          ] { this: List.type => }
+    }
+
     val TransformerCfg: TransformerCfgModule
-    trait TransformerCfgModule {
+    trait TransformerCfgModule { this: TransformerCfg.type =>
       val Empty: Type[runtime.TransformerCfg.Empty]
 
       val FieldConst: FieldConstModule
@@ -98,6 +125,10 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerCfg,
             runtime.TransformerCfg.CoproductInstancePartial
           ] { this: CoproductInstancePartial.type => }
+
+      // TODO: Constructor
+
+      // TODO: ConstructorPartial
     }
 
     val TransformerFlags: TransformerFlagsModule
@@ -140,12 +171,12 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
     }
 
     val PatcherCfg: PatcherCfgModule
-    trait PatcherCfgModule {
+    trait PatcherCfgModule { this: PatcherCfg.type =>
       val Empty: Type[runtime.PatcherCfg.Empty]
     }
 
     val PatcherFlags: PatcherFlagsModule
-    trait PatcherFlagsModule {
+    trait PatcherFlagsModule { this: PatcherFlags.type =>
       val Default: Type[runtime.PatcherFlags.Default]
 
       val Enable: EnableModule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
@@ -14,7 +14,7 @@ object DerivationError {
       .collectFirst {
         case MacroException(exception) =>
           val stackTrace =
-            exception.getStackTrace.view.take(100).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
+            exception.getStackTrace.view.take(10).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
           s"  macro expansion thrown exception!: $exception:\n$stackTrace\n  \t${Console.RED}...${Console.RESET}"
         case NotYetImplemented(what) =>
           s"  derivation failed because functionality $what is not yet implemented!"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
@@ -14,7 +14,7 @@ object DerivationError {
       .collectFirst {
         case MacroException(exception) =>
           val stackTrace =
-            exception.getStackTrace.view.take(10).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
+            exception.getStackTrace.view.take(100).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
           s"  macro expansion thrown exception!: $exception:\n$stackTrace\n  \t${Console.RED}...${Console.RESET}"
         case NotYetImplemented(what) =>
           s"  derivation failed because functionality $what is not yet implemented!"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentList.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentList.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.internal.runtime
+
+sealed abstract class ArgumentList
+object ArgumentList {
+  final class Empty extends ArgumentList
+  final class Argument[Name <: String, Type, Args <: ArgumentList]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentList.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentList.scala
@@ -3,5 +3,5 @@ package io.scalaland.chimney.internal.runtime
 sealed abstract class ArgumentList
 object ArgumentList {
   final class Empty extends ArgumentList
-  final class Argument[Name <: String, Type, Args <: ArgumentList]
+  final class Argument[Name <: String, Type, Args <: ArgumentList] extends ArgumentList
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentLists.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentLists.scala
@@ -3,5 +3,5 @@ package io.scalaland.chimney.internal.runtime
 sealed abstract class ArgumentLists
 object ArgumentLists {
   final class Empty extends ArgumentLists
-  final class List[Head <: ArgumentList, Tail <: ArgumentLists]
+  final class List[Head <: ArgumentList, Tail <: ArgumentLists] extends ArgumentLists
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentLists.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ArgumentLists.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.internal.runtime
+
+sealed abstract class ArgumentLists
+object ArgumentLists {
+  final class Empty extends ArgumentLists
+  final class List[Head <: ArgumentList, Tail <: ArgumentLists]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -2,9 +2,8 @@ package io.scalaland.chimney.internal.runtime
 
 import scala.annotation.implicitNotFound
 
-// TODO: move implicit not found to use DSL, to be able to use ${To} in error message
 @implicitNotFound(
-  "Expected function of any arity (Function0, Function1, Function2, ...) that returns a value of the target type"
+  "Expected function of any arity (Function0, Function1, Function2, ...) that returns a value of the target type, got ${Fn}"
 )
 sealed trait IsFunction[Fn] {
   type Out
@@ -14,6 +13,7 @@ object IsFunction extends IsFunctionLowPriorityImplicits {
 
   private def cast[A, Out](of: Of[?, Out]): Of[A, Out] = of.asInstanceOf[Of[A, Out]]
 
+  implicit def curriedFunction0[Mid, Out](implicit ev: Of[Mid, Out]): Of[() => Mid, Out] = cast(ev)
   implicit def curriedFunction1[A, Mid, Out](implicit ev: Of[Mid, Out]): Of[A => Mid, Out] = cast(ev)
   implicit def curriedFunction2[A, B, Mid, Out](implicit ev: Of[Mid, Out]): Of[(A, B) => Mid, Out] = cast(ev)
   implicit def curriedFunction3[A, B, C, Mid, Out](implicit ev: Of[Mid, Out]): Of[(A, B, C) => Mid, Out] = cast(ev)
@@ -79,6 +79,7 @@ private[runtime] trait IsFunctionLowPriorityImplicits { this: IsFunction.type =>
   private val impl = new IsFunction[Any] {}
   private def cast[Fn, Out]: Of[Fn, Out] = impl.asInstanceOf[Of[Fn, Out]]
 
+  implicit def function0[Out]: Of[() => Out, Out] = cast
   implicit def function1[A, Out]: Of[A => Out, Out] = cast
   implicit def function2[A, B, Out]: Of[(A, B) => Out, Out] = cast
   implicit def function3[A, B, C, Out]: Of[(A, B, C) => Out, Out] = cast

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -1,0 +1,24 @@
+package io.scalaland.chimney.internal.runtime
+
+import scala.annotation.implicitNotFound
+
+// TODO: move implicit not found to use DSL, to be able to use ${To} in error message
+@implicitNotFound(
+  "Expected function of any arity (Function0, Function1, Function2, ...) that returns a value of the target type"
+)
+sealed trait IsFunction[Fn] {
+  type Out
+}
+object IsFunction {
+  type Aux[Fn, Out0] = IsFunction[Fn] { type Out = Out0 }
+
+  private val impl = new IsFunction[Any] {}
+
+  implicit def function0[Out]: IsFunction.Aux[() => Out, Out] =
+    impl.asInstanceOf[IsFunction.Aux[() => Out, Out]]
+  implicit def function1[A, Out]: IsFunction.Aux[A => Out, Out] =
+    impl.asInstanceOf[IsFunction.Aux[A => Out, Out]]
+  implicit def function2[A, B, Out]: IsFunction.Aux[(A, B) => Out, Out] =
+    impl.asInstanceOf[IsFunction.Aux[(A, B) => Out, Out]]
+  // TODO: arities up to 22
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -2,8 +2,13 @@ package io.scalaland.chimney.internal.runtime
 
 import scala.annotation.implicitNotFound
 
+/** Allow us to provide some better IDE support than just accepting everything as a parameter and waiting for the macro
+  * to scream with compilation error, in the world where different function types have no common ancestor (other and AnyRef).
+  *
+  * @since 0.7.4
+  */
 @implicitNotFound(
-  "Expected function of any arity (Function0, Function1, Function2, ...) that returns a value of the target type, got ${Fn}"
+  "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of the target type, got ${Fn}"
 )
 sealed trait IsFunction[Fn] {
   type Out

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -9,48 +9,108 @@ import scala.annotation.implicitNotFound
 sealed trait IsFunction[Fn] {
   type Out
 }
-object IsFunction {
+object IsFunction extends IsFunctionLowPriorityImplicits {
   type Of[Fn, Out0] = IsFunction[Fn] { type Out = Out0 }
 
+  private def cast[A, Out](of: Of[?, Out]): Of[A, Out] = of.asInstanceOf[Of[A, Out]]
+
+  implicit def curriedFunction1[A, Mid, Out](implicit ev: Of[Mid, Out]): Of[A => Mid, Out] = cast(ev)
+  implicit def curriedFunction2[A, B, Mid, Out](implicit ev: Of[Mid, Out]): Of[(A, B) => Mid, Out] = cast(ev)
+  implicit def curriedFunction3[A, B, C, Mid, Out](implicit ev: Of[Mid, Out]): Of[(A, B, C) => Mid, Out] = cast(ev)
+  implicit def curriedFunction4[A, B, C, D, Mid, Out](implicit ev: Of[Mid, Out]): Of[(A, B, C, D) => Mid, Out] = cast(
+    ev
+  )
+  implicit def curriedFunction5[A, B, C, D, E, Mid, Out](implicit ev: Of[Mid, Out]): Of[(A, B, C, D, E) => Mid, Out] =
+    cast(ev)
+  implicit def curriedFunction6[A, B, C, D, E, F, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F) => Mid, Out] = cast(ev)
+  implicit def curriedFunction7[A, B, C, D, E, F, G, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G) => Mid, Out] = cast(ev)
+  implicit def curriedFunction8[A, B, C, D, E, F, G, H, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H) => Mid, Out] = cast(ev)
+  implicit def curriedFunction9[A, B, C, D, E, F, G, H, I, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I) => Mid, Out] = cast(ev)
+  implicit def curriedFunction10[A, B, C, D, E, F, G, H, I, J, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J) => Mid, Out] = cast(ev)
+  implicit def curriedFunction11[A, B, C, D, E, F, G, H, I, J, K, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K) => Mid, Out] = cast(ev)
+  implicit def curriedFunction12[A, B, C, D, E, F, G, H, I, J, K, L, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L) => Mid, Out] = cast(ev)
+  implicit def curriedFunction13[A, B, C, D, E, F, G, H, I, J, K, L, M, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Mid, Out] = cast(ev)
+  implicit def curriedFunction14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Mid, Out] = cast(ev)
+  implicit def curriedFunction15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Mid, Out] = cast(ev)
+  implicit def curriedFunction16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Mid, Out] = cast(ev)
+  implicit def curriedFunction17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Mid, Out] = cast(ev)
+  implicit def curriedFunction18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Mid, Out] = cast(ev)
+  implicit def curriedFunction19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Mid, Out] = cast(ev)
+  implicit def curriedFunction20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Mid, Out] = cast(ev)
+  implicit def curriedFunction21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Mid, Out] = cast(ev)
+  implicit def curriedFunction22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Mid, Out](implicit
+      ev: Of[Mid, Out]
+  ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Mid, Out] = cast(ev)
+}
+private trait IsFunctionLowPriorityImplicits { this: IsFunction.type =>
+
   private val impl = new IsFunction[Any] {}
-  private def cast[Fn, Out]: IsFunction.Of[Fn, Out] = impl.asInstanceOf[IsFunction.Of[Fn, Out]]
+  private def cast[Fn, Out]: Of[Fn, Out] = impl.asInstanceOf[Of[Fn, Out]]
 
-  implicit def function0[Out]: IsFunction.Of[() => Out, Out] = cast // TODO: is it needed or is it Function1?
-  implicit def function1[A, Out]: IsFunction.Of[A => Out, Out] = cast
-  implicit def function2[A, B, Out]: IsFunction.Of[(A, B) => Out, Out] = cast
-  implicit def function3[A, B, C, Out]: IsFunction.Of[(A, B, C) => Out, Out] = cast
-  implicit def function4[A, B, C, D, Out]: IsFunction.Of[(A, B, C, D) => Out, Out] = cast
-  implicit def function5[A, B, C, D, E, Out]: IsFunction.Of[(A, B, C, D, E) => Out, Out] = cast
-  implicit def function6[A, B, C, D, E, F, Out]: IsFunction.Of[(A, B, C, D, E, F) => Out, Out] = cast
-  implicit def function7[A, B, C, D, E, F, G, Out]: IsFunction.Of[(A, B, C, D, E, F, G) => Out, Out] = cast
-  implicit def function8[A, B, C, D, E, F, G, H, Out]: IsFunction.Of[(A, B, C, D, E, F, G, H) => Out, Out] = cast
-  implicit def function9[A, B, C, D, E, F, G, H, I, Out]: IsFunction.Of[(A, B, C, D, E, F, G, H, I) => Out, Out] = cast
-  implicit def function10[A, B, C, D, E, F, G, H, I, J, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J) => Out, Out] = cast
-  implicit def function11[A, B, C, D, E, F, G, H, I, J, K, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K) => Out, Out] = cast
+  implicit def function1[A, Out]: Of[A => Out, Out] = cast
+  implicit def function2[A, B, Out]: Of[(A, B) => Out, Out] = cast
+  implicit def function3[A, B, C, Out]: Of[(A, B, C) => Out, Out] = cast
+  implicit def function4[A, B, C, D, Out]: Of[(A, B, C, D) => Out, Out] = cast
+  implicit def function5[A, B, C, D, E, Out]: Of[(A, B, C, D, E) => Out, Out] = cast
+  implicit def function6[A, B, C, D, E, F, Out]: Of[(A, B, C, D, E, F) => Out, Out] = cast
+  implicit def function7[A, B, C, D, E, F, G, Out]: Of[(A, B, C, D, E, F, G) => Out, Out] = cast
+  implicit def function8[A, B, C, D, E, F, G, H, Out]: Of[(A, B, C, D, E, F, G, H) => Out, Out] = cast
+  implicit def function9[A, B, C, D, E, F, G, H, I, Out]: Of[(A, B, C, D, E, F, G, H, I) => Out, Out] = cast
+  implicit def function10[A, B, C, D, E, F, G, H, I, J, Out]: Of[(A, B, C, D, E, F, G, H, I, J) => Out, Out] = cast
+  implicit def function11[A, B, C, D, E, F, G, H, I, J, K, Out]: Of[(A, B, C, D, E, F, G, H, I, J, K) => Out, Out] =
+    cast
   implicit def function12[A, B, C, D, E, F, G, H, I, J, K, L, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L) => Out, Out] = cast
   implicit def function13[A, B, C, D, E, F, G, H, I, J, K, L, M, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Out, Out] = cast
   implicit def function14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Out, Out] = cast
   implicit def function15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Out, Out] = cast
   implicit def function16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Out, Out] = cast
   implicit def function17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Out, Out] = cast
   implicit def function18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Out, Out] = cast
   implicit def function19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Out, Out] = cast
   implicit def function20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Out, Out] = cast
   implicit def function21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Out, Out] = cast
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Out, Out] = cast
   implicit def function22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Out]
-      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Out, Out] = cast
-
-  // TODO: multiple parameter lists
+      : Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Out, Out] = cast
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -14,6 +14,9 @@ sealed trait IsFunction[Fn] {
   type Out
 }
 object IsFunction extends IsFunctionLowPriorityImplicits {
+  @implicitNotFound(
+    "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ${Out0}, got ${Fn}"
+  )
   type Of[Fn, Out0] = IsFunction[Fn] { type Out = Out0 }
 
   private def cast[A, Out](of: Of[?, Out]): Of[A, Out] = of.asInstanceOf[Of[A, Out]]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -74,7 +74,7 @@ object IsFunction extends IsFunctionLowPriorityImplicits {
       ev: Of[Mid, Out]
   ): Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Mid, Out] = cast(ev)
 }
-private trait IsFunctionLowPriorityImplicits { this: IsFunction.type =>
+private[runtime] trait IsFunctionLowPriorityImplicits { this: IsFunction.type =>
 
   private val impl = new IsFunction[Any] {}
   private def cast[Fn, Out]: Of[Fn, Out] = impl.asInstanceOf[Of[Fn, Out]]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -13,12 +13,44 @@ object IsFunction {
   type Of[Fn, Out0] = IsFunction[Fn] { type Out = Out0 }
 
   private val impl = new IsFunction[Any] {}
+  private def cast[Fn, Out]: IsFunction.Of[Fn, Out] = impl.asInstanceOf[IsFunction.Of[Fn, Out]]
 
-  implicit def function0[Out]: IsFunction.Of[() => Out, Out] =
-    impl.asInstanceOf[IsFunction.Of[() => Out, Out]]
-  implicit def function1[A, Out]: IsFunction.Of[A => Out, Out] =
-    impl.asInstanceOf[IsFunction.Of[A => Out, Out]]
-  implicit def function2[A, B, Out]: IsFunction.Of[(A, B) => Out, Out] =
-    impl.asInstanceOf[IsFunction.Of[(A, B) => Out, Out]]
-  // TODO: arities up to 22
+  implicit def function0[Out]: IsFunction.Of[() => Out, Out] = cast // TODO: is it needed or is it Function1?
+  implicit def function1[A, Out]: IsFunction.Of[A => Out, Out] = cast
+  implicit def function2[A, B, Out]: IsFunction.Of[(A, B) => Out, Out] = cast
+  implicit def function3[A, B, C, Out]: IsFunction.Of[(A, B, C) => Out, Out] = cast
+  implicit def function4[A, B, C, D, Out]: IsFunction.Of[(A, B, C, D) => Out, Out] = cast
+  implicit def function5[A, B, C, D, E, Out]: IsFunction.Of[(A, B, C, D, E) => Out, Out] = cast
+  implicit def function6[A, B, C, D, E, F, Out]: IsFunction.Of[(A, B, C, D, E, F) => Out, Out] = cast
+  implicit def function7[A, B, C, D, E, F, G, Out]: IsFunction.Of[(A, B, C, D, E, F, G) => Out, Out] = cast
+  implicit def function8[A, B, C, D, E, F, G, H, Out]: IsFunction.Of[(A, B, C, D, E, F, G, H) => Out, Out] = cast
+  implicit def function9[A, B, C, D, E, F, G, H, I, Out]: IsFunction.Of[(A, B, C, D, E, F, G, H, I) => Out, Out] = cast
+  implicit def function10[A, B, C, D, E, F, G, H, I, J, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J) => Out, Out] = cast
+  implicit def function11[A, B, C, D, E, F, G, H, I, J, K, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K) => Out, Out] = cast
+  implicit def function12[A, B, C, D, E, F, G, H, I, J, K, L, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L) => Out, Out] = cast
+  implicit def function13[A, B, C, D, E, F, G, H, I, J, K, L, M, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Out, Out] = cast
+  implicit def function14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Out, Out] = cast
+  implicit def function15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Out, Out] = cast
+  implicit def function16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Out, Out] = cast
+  implicit def function17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Out, Out] = cast
+  implicit def function18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Out, Out] = cast
+  implicit def function19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Out, Out] = cast
+  implicit def function20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Out, Out] = cast
+  implicit def function21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Out, Out] = cast
+  implicit def function22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Out]
+      : IsFunction.Of[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Out, Out] = cast
+
+  // TODO: multiple parameter lists
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -10,15 +10,15 @@ sealed trait IsFunction[Fn] {
   type Out
 }
 object IsFunction {
-  type Aux[Fn, Out0] = IsFunction[Fn] { type Out = Out0 }
+  type Of[Fn, Out0] = IsFunction[Fn] { type Out = Out0 }
 
   private val impl = new IsFunction[Any] {}
 
-  implicit def function0[Out]: IsFunction.Aux[() => Out, Out] =
-    impl.asInstanceOf[IsFunction.Aux[() => Out, Out]]
-  implicit def function1[A, Out]: IsFunction.Aux[A => Out, Out] =
-    impl.asInstanceOf[IsFunction.Aux[A => Out, Out]]
-  implicit def function2[A, B, Out]: IsFunction.Aux[(A, B) => Out, Out] =
-    impl.asInstanceOf[IsFunction.Aux[(A, B) => Out, Out]]
+  implicit def function0[Out]: IsFunction.Of[() => Out, Out] =
+    impl.asInstanceOf[IsFunction.Of[() => Out, Out]]
+  implicit def function1[A, Out]: IsFunction.Of[A => Out, Out] =
+    impl.asInstanceOf[IsFunction.Of[A => Out, Out]]
+  implicit def function2[A, B, Out]: IsFunction.Of[(A, B) => Out, Out] =
+    impl.asInstanceOf[IsFunction.Of[(A, B) => Out, Out]]
   // TODO: arities up to 22
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerCfg.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerCfg.scala
@@ -10,4 +10,6 @@ object TransformerCfg {
   final class FieldRelabelled[FromField <: Path, ToField <: Path, Cfg <: TransformerCfg] extends TransformerCfg
   final class CoproductInstance[InstType, TargetType, Cfg <: TransformerCfg] extends TransformerCfg
   final class CoproductInstancePartial[InstType, TargetType, Cfg <: TransformerCfg] extends TransformerCfg
+  final class Constructor[Args <: ArgumentLists, TargetType, Cfg <: TransformerCfg] extends TransformerCfg
+  final class ConstructorPartial[Args <: ArgumentLists, TargetType, Cfg <: TransformerCfg] extends TransformerCfg
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
@@ -83,6 +83,12 @@ sealed trait Result[+A] {
     case _: Result.Errors    => this.asInstanceOf[Result[B]]
   }
 
+  // TODO: docs
+  final def flatten[B](implicit ev: A <:< Result[B]): Result[B] = this match {
+    case Result.Value(value) => ev(value)
+    case _: Result.Errors    => this.asInstanceOf[Result[B]]
+  }
+
   /** Prepends a path element to all errors represented by this result.
     *
     * @param pathElement path element to be prepended

--- a/chimney/src/test/scala-2.13+/io/scalaland/chimney/PartialTransformerCustomConstructor2_13plusSyntaxSpec.scala
+++ b/chimney/src/test/scala-2.13+/io/scalaland/chimney/PartialTransformerCustomConstructor2_13plusSyntaxSpec.scala
@@ -1,0 +1,81 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class PartialTransformerCustomConstructor2_13plusSyntaxSpec extends ChimneySpec {
+
+  // 2.13+ doesn't require explicit Eta-expansion (no need to "method _")
+  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+    import products.{Foo, Bar, BarParams}
+
+    val uncurriedExpected = Bar(6, (6.28, 6.28))
+
+    def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+    val result = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor(uncurriedConstructor)
+      .transform
+    result.asOption ==> Some(uncurriedExpected)
+    result.asEither ==> Right(uncurriedExpected)
+    result.asErrorPathMessageStrings ==> Iterable.empty
+
+    def uncurriedConstructorPartial(x: Int, z: (Double, Double)): partial.Result[Bar] =
+      partial.Result.fromValue(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+    val result2 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial(uncurriedConstructorPartial)
+      .transform
+    result2.asOption ==> Some(uncurriedExpected)
+    result2.asEither ==> Right(uncurriedExpected)
+    result2.asErrorPathMessageStrings ==> Iterable.empty
+
+    val curriedExpected = Bar(9, (9.42, 9.42))
+
+    def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+
+    val result3 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor(curriedConstructor)
+      .transform
+    result3.asOption ==> Some(curriedExpected)
+    result3.asEither ==> Right(curriedExpected)
+    result3.asErrorPathMessageStrings ==> Iterable.empty
+
+    def curriedConstructorPartial(x: Int)(z: (Double, Double)): partial.Result[Bar] =
+      partial.Result.fromValue(Bar(x * 3, (z._1 * 3, z._2 * 3)))
+
+    val result4 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial(curriedConstructorPartial)
+      .transform
+    result4.asOption ==> Some(curriedExpected)
+    result4.asEither ==> Right(curriedExpected)
+    result4.asErrorPathMessageStrings ==> Iterable.empty
+
+    val typeParametricExpected = BarParams(3, (3.14, 12.56))
+
+    def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+
+    val result5 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[BarParams[Int, Double]]
+      .withConstructor(typeParametricConstructor[Int, Double])
+      .transform
+    result5.asOption ==> Some(typeParametricExpected)
+    result5.asEither ==> Right(typeParametricExpected)
+    result5.asErrorPathMessageStrings ==> Iterable.empty
+
+    def typeParametricConstructorPartial[A, B](x: A, z: (B, Double)): partial.Result[BarParams[A, B]] =
+      partial.Result.fromValue(BarParams(x, (z._1, z._2 * 4)))
+
+    val result6 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[BarParams[Int, Double]]
+      .withConstructorPartial(typeParametricConstructorPartial[Int, Double])
+      .transform
+    result6.asOption ==> Some(typeParametricExpected)
+    result6.asEither ==> Right(typeParametricExpected)
+    result6.asErrorPathMessageStrings ==> Iterable.empty
+  }
+}

--- a/chimney/src/test/scala-2.13+/io/scalaland/chimney/PartialTransformerCustomConstructor2_13plusSyntaxSpec.scala
+++ b/chimney/src/test/scala-2.13+/io/scalaland/chimney/PartialTransformerCustomConstructor2_13plusSyntaxSpec.scala
@@ -6,7 +6,7 @@ import io.scalaland.chimney.fixtures.*
 class PartialTransformerCustomConstructor2_13plusSyntaxSpec extends ChimneySpec {
 
   // 2.13+ doesn't require explicit Eta-expansion (no need to "method _")
-  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+  test("""allow transformation from using Eta-expanded method or lambda""") {
     import products.{Foo, Bar, BarParams}
 
     val uncurriedExpected = Bar(6, (6.28, 6.28))

--- a/chimney/src/test/scala-2.13+/io/scalaland/chimney/TotalTransformerCustomConstructor2_13plusSyntaxSpec.scala
+++ b/chimney/src/test/scala-2.13+/io/scalaland/chimney/TotalTransformerCustomConstructor2_13plusSyntaxSpec.scala
@@ -1,0 +1,33 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class TotalTransformerCustomConstructor2_13plusSyntaxSpec extends ChimneySpec {
+
+  // 2.13+ doesn't require explicit Eta-expansion (no need to "method _")
+  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+    import products.{Foo, Bar, BarParams}
+
+    def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor(uncurriedConstructor)
+      .transform ==> Bar(6, (6.28, 6.28))
+
+    def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor(curriedConstructor)
+      .transform ==> Bar(9, (9.42, 9.42))
+
+    def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+
+    Foo(3, "pi", (3.14, 3.14))
+      .into[BarParams[Int, Double]]
+      .withConstructor(typeParametricConstructor[Int, Double])
+      .transform ==> BarParams(3, (3.14, 12.56))
+  }
+}

--- a/chimney/src/test/scala-2.13+/io/scalaland/chimney/TotalTransformerCustomConstructor2_13plusSyntaxSpec.scala
+++ b/chimney/src/test/scala-2.13+/io/scalaland/chimney/TotalTransformerCustomConstructor2_13plusSyntaxSpec.scala
@@ -6,7 +6,7 @@ import io.scalaland.chimney.fixtures.*
 class TotalTransformerCustomConstructor2_13plusSyntaxSpec extends ChimneySpec {
 
   // 2.13+ doesn't require explicit Eta-expansion (no need to "method _")
-  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+  test("""allow transformation from using Eta-expanded method or lambda""") {
     import products.{Foo, Bar, BarParams}
 
     def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))

--- a/chimney/src/test/scala-3/io/scalaland/chimney/PartialTransformerOpaqueTypSpec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/PartialTransformerOpaqueTypSpec.scala
@@ -1,0 +1,20 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class PartialTransformerOpaqueTypSpec extends ChimneySpec {
+
+  test("opaque types with manually provided constructor should work as product types") {
+    import opaquetypes.*
+
+    given PartialTransformer[Foo, Bar] = PartialTransformer
+      .define[Foo, Bar]
+      .withConstructorPartial { (value: String) =>
+        partial.Result.fromEitherString(Bar.parse(value))
+      }
+      .buildTransformer
+
+    Foo("10").transformIntoPartial[Bar].asEither ==> Bar.parse("10")
+  }
+}

--- a/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/OpaqueTypes.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/OpaqueTypes.scala
@@ -1,0 +1,14 @@
+package io.scalaland.chimney.fixtures
+
+package opaquetypes {
+
+  case class Foo(value: String)
+
+  opaque type Bar = Int
+  extension (bar: Bar)
+    def value: Int = bar
+  object Bar {
+    def parse(value: String): Either[String, Bar] =
+      scala.util.Try(value.toInt).toEither.left.map(_.getMessage)
+  }
+}

--- a/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/OpaqueTypes.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/OpaqueTypes.scala
@@ -5,8 +5,7 @@ package opaquetypes {
   case class Foo(value: String)
 
   opaque type Bar = Int
-  extension (bar: Bar)
-    def value: Int = bar
+  extension (bar: Bar) def value: Int = bar
   object Bar {
     def parse(value: String): Either[String, Bar] =
       scala.util.Try(value.toInt).toEither.left.map(_.getMessage)

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
@@ -176,4 +176,23 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
     result14.asEither ==> Right(typeParametricExpected)
     result14.asErrorPathMessageStrings ==> Iterable.empty
   }
+
+  test("""allow defining transformers with overrides""") {
+    import products.NonCaseDomain.*
+
+    implicit val transformer: PartialTransformer[ClassSource, TraitSource] = PartialTransformer
+      .define[ClassSource, TraitSource]
+      .withConstructorPartial { (name: String, id: String) =>
+        // swap
+        partial.Result.fromValue[TraitSource](new TraitSourceImpl(name = id, id = name))
+      }
+      // another swap
+      .withFieldRenamed(_.id, _.name)
+      .withFieldRenamed(_.name, _.id)
+      .buildTransformer
+
+    val result = (new ClassSource("id", "name")).transformIntoPartial[TraitSource].asOption.get
+    result.id ==> "id"
+    result.name ==> "name"
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
@@ -1,0 +1,164 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class PartialTransformerCustomConstructorSpec extends ChimneySpec {
+
+  // TODO: test rejecting non-constructors
+
+  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+    import products.{Foo, Bar, BarParams}
+
+    val nullaryExpected = Bar(0, (0.0, 0.0))
+
+    def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
+
+    val result = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor(nullaryConstructor _)
+      .transform
+    result.asOption ==> Some(nullaryExpected)
+    result.asEither ==> Right(nullaryExpected)
+    result.asErrorPathMessageStrings ==> Iterable.empty
+
+    val result2 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor { () =>
+        nullaryConstructor()
+      }
+      .transform
+    result2.asOption ==> Some(nullaryExpected)
+    result2.asEither ==> Right(nullaryExpected)
+    result2.asErrorPathMessageStrings ==> Iterable.empty
+
+    def nullaryConstructorPartial(): partial.Result[Bar] = partial.Result.fromValue(Bar(0, (0.0, 0.0)))
+
+    val result3 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial(nullaryConstructorPartial _)
+      .transform
+    result3.asOption ==> Some(nullaryExpected)
+    result3.asEither ==> Right(nullaryExpected)
+    result3.asErrorPathMessageStrings ==> Iterable.empty
+
+    val result4 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial { () =>
+        nullaryConstructorPartial()
+      }
+      .transform
+    result4.asOption ==> Some(nullaryExpected)
+    result4.asEither ==> Right(nullaryExpected)
+    result4.asErrorPathMessageStrings ==> Iterable.empty
+
+    val uncurriedExpected = Bar(6, (6.28, 6.28))
+
+    def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+    val result5 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor(uncurriedConstructor _)
+      .transform
+    result5.asOption ==> Some(uncurriedExpected)
+    result5.asEither ==> Right(uncurriedExpected)
+    result5.asErrorPathMessageStrings ==> Iterable.empty
+
+    val result6 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor { (x: Int, z: (Double, Double)) =>
+        uncurriedConstructor(x, z)
+      }
+      .transform
+    result6.asOption ==> Some(uncurriedExpected)
+    result6.asEither ==> Right(uncurriedExpected)
+    result6.asErrorPathMessageStrings ==> Iterable.empty
+
+    def uncurriedConstructorPartial(x: Int, z: (Double, Double)): partial.Result[Bar] =
+      partial.Result.fromValue(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+    val result7 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial(uncurriedConstructorPartial _)
+      .transform
+    result7.asOption ==> Some(uncurriedExpected)
+    result7.asEither ==> Right(uncurriedExpected)
+    result7.asErrorPathMessageStrings ==> Iterable.empty
+
+    val result8 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial { (x: Int, z: (Double, Double)) =>
+        uncurriedConstructorPartial(x, z)
+      }
+      .transform
+    result8.asOption ==> Some(uncurriedExpected)
+    result8.asEither ==> Right(uncurriedExpected)
+    result8.asErrorPathMessageStrings ==> Iterable.empty
+
+    val curriedExpected = Bar(9, (9.42, 9.42))
+
+    def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+
+    val result9 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor(curriedConstructor _)
+      .transform
+    result9.asOption ==> Some(curriedExpected)
+    result9.asEither ==> Right(curriedExpected)
+    result9.asErrorPathMessageStrings ==> Iterable.empty
+
+    val result10 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructor { (x: Int) => (z: (Double, Double)) =>
+        curriedConstructor(x)(z)
+      }
+      .transform
+    result10.asOption ==> Some(curriedExpected)
+    result10.asEither ==> Right(curriedExpected)
+    result10.asErrorPathMessageStrings ==> Iterable.empty
+
+    def curriedConstructorPartial(x: Int)(z: (Double, Double)): partial.Result[Bar] =
+      partial.Result.fromValue(Bar(x * 3, (z._1 * 3, z._2 * 3)))
+
+    val result11 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial(curriedConstructorPartial _)
+      .transform
+    result11.asOption ==> Some(curriedExpected)
+    result11.asEither ==> Right(curriedExpected)
+    result11.asErrorPathMessageStrings ==> Iterable.empty
+
+    val result12 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[Bar]
+      .withConstructorPartial { (x: Int) => (z: (Double, Double)) =>
+        curriedConstructorPartial(x)(z)
+      }
+      .transform
+    result12.asOption ==> Some(curriedExpected)
+    result12.asEither ==> Right(curriedExpected)
+    result12.asErrorPathMessageStrings ==> Iterable.empty
+
+    val typeParametricExpected = BarParams(3, (3.14, 12.56))
+
+    def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+
+    val result13 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[BarParams[Int, Double]]
+      .withConstructor(typeParametricConstructor[Int, Double] _)
+      .transform
+    result13.asOption ==> Some(typeParametricExpected)
+    result13.asEither ==> Right(typeParametricExpected)
+    result13.asErrorPathMessageStrings ==> Iterable.empty
+
+    def typeParametricConstructorPartial[A, B](x: A, z: (B, Double)): partial.Result[BarParams[A, B]] =
+      partial.Result.fromValue(BarParams(x, (z._1, z._2 * 4)))
+
+    val result14 = Foo(3, "pi", (3.14, 3.14))
+      .intoPartial[BarParams[Int, Double]]
+      .withConstructorPartial(typeParametricConstructorPartial[Int, Double] _)
+      .transform
+    result14.asOption ==> Some(typeParametricExpected)
+    result14.asEither ==> Right(typeParametricExpected)
+    result14.asErrorPathMessageStrings ==> Iterable.empty
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
@@ -5,9 +5,24 @@ import io.scalaland.chimney.fixtures.*
 
 class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
-  // TODO: test rejecting non-constructors
+  test("""not allow transformation when passed value is not a function/method""") {
+    import products.{Foo, Bar}
 
-  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+    compileErrorsFixed("""Foo(3, "pi", (3.14, 3.14)).intoPartial[Bar].withConstructor(Bar(4, (5.0, 5.0))).transform""")
+      .check(
+        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+        ", got io.scalaland.chimney.fixtures.products.Bar"
+      )
+
+    compileErrorsFixed(
+      """Foo(3, "pi", (3.14, 3.14)).intoPartial[Bar].withConstructorPartial(partial.Result.fromValue(Bar(4, (5.0, 5.0)))).transform"""
+    ).check(
+      "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+      ", got io.scalaland.chimney.partial.Result[io.scalaland.chimney.fixtures.products.Bar]"
+    )
+  }
+
+  test("""allow transformation from using Eta-expanded method or lambda""") {
     import products.{Foo, Bar, BarParams}
 
     val nullaryExpected = Bar(0, (0.0, 0.0))

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -1,0 +1,34 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class TotalTransformerCustomConstructorSpec extends ChimneySpec {
+
+  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+    import products.{Foo, Bar}
+
+    def customConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor(customConstructor _)
+      .transform ==> Bar(6, (6.28, 6.28))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor((customConstructor _).tupled)
+      .transform ==> Bar(6, (6.28, 6.28))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor({ (x: Int, z: (Double, Double)) =>
+        customConstructor(x, z)
+      }.tupled)
+      .transform ==> Bar(6, (6.28, 6.28))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor({ (x: Int, z: (Double, Double)) =>
+        customConstructor(x, z)
+      })
+      .transform ==> Bar(6, (6.28, 6.28))
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -5,9 +5,16 @@ import io.scalaland.chimney.fixtures.*
 
 class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
-  // TODO: test rejecting non-constructors
+  test("""not allow transformation when passed value is not a function/method""") {
+    import products.{Foo, Bar}
 
-  test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
+    compileErrorsFixed("""Foo(3, "pi", (3.14, 3.14)).into[Bar].withConstructor(Bar(4, (5.0, 5.0))).transform""").check(
+      "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+      ", got io.scalaland.chimney.fixtures.products.Bar"
+    )
+  }
+
+  test("""allow transformation from using Eta-expanded method or lambda""") {
     import products.{Foo, Bar, BarParams}
 
     def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -8,35 +8,52 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
   // TODO: test rejecting non-constructors
 
   test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
-    import products.{Foo, Bar}
+    import products.{Foo, Bar, BarParams}
 
-    // TODO: test unary/nulllary - constConstructor
-    // TODO: rename customConstructor -> binaryConstructor
-    // TODO: add tests with multiple parameter lists - paramListsConstructor
-    // TODO: test eta expansion of method with type params - typeParametricConstructor
+    def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
 
-    def customConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
-
-    // Scala 2.12 :/
-//    Foo(3, "pi", (3.14, 3.14))
-//      .into[Bar]
-//      .withConstructor(customConstructor)
-//      .transform ==> Bar(6, (6.28, 6.28))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
-      .withConstructor(customConstructor _)
+      .withConstructor(nullaryConstructor _)
+      .transform ==> Bar(0, (0.0, 0.0))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor { () =>
+        nullaryConstructor()
+      }
+      .transform ==> Bar(0, (0.0, 0.0))
+
+    def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor(uncurriedConstructor _)
       .transform ==> Bar(6, (6.28, 6.28))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
-      .withConstructor({ (x: Int, z: (Double, Double)) =>
-        customConstructor(x, z)
-      })
+      .withConstructor { (x: Int, z: (Double, Double)) =>
+        uncurriedConstructor(x, z)
+      }
       .transform ==> Bar(6, (6.28, 6.28))
+
+    def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
-      .withConstructor({ (x: Int) => (z: (Double, Double)) =>
-        customConstructor(x, z)
-      })
-      .transform ==> Bar(6, (6.28, 6.28))
+      .withConstructor(curriedConstructor _)
+      .transform ==> Bar(9, (9.42, 9.42))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor { (x: Int) => (z: (Double, Double)) =>
+        curriedConstructor(x)(z)
+      }
+      .transform ==> Bar(9, (9.42, 9.42))
+
+    def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+
+    Foo(3, "pi", (3.14, 3.14))
+      .into[BarParams[Int, Double]]
+      .withConstructor(typeParametricConstructor[Int, Double] _)
+      .transform ==> BarParams(3, (3.14, 12.56))
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -5,10 +5,15 @@ import io.scalaland.chimney.fixtures.*
 
 class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
+  // TODO: test rejecting non-constructors
+
   test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
     import products.{Foo, Bar}
 
-    // TODO: add tests with multiple parameter lists
+    // TODO: test unary/nulllary - constConstructor
+    // TODO: rename customConstructor -> binaryConstructor
+    // TODO: add tests with multiple parameter lists - paramListsConstructor
+    // TODO: test eta expansion of method with type params - typeParametricConstructor
 
     def customConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -22,10 +22,10 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 //      .into[Bar]
 //      .withConstructor(customConstructor)
 //      .transform ==> Bar(6, (6.28, 6.28))
-//    Foo(3, "pi", (3.14, 3.14))
-//      .into[Bar]
-//      .withConstructor(customConstructor _)
-//      .transform ==> Bar(6, (6.28, 6.28))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor(customConstructor _)
+      .transform ==> Bar(6, (6.28, 6.28))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
       .withConstructor({ (x: Int, z: (Double, Double)) =>

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -31,5 +31,11 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
         customConstructor(x, z)
       })
       .transform ==> Bar(6, (6.28, 6.28))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
+      .withConstructor({ (x: Int) => (z: (Double, Double)) =>
+        customConstructor(x, z)
+      })
+      .transform ==> Bar(6, (6.28, 6.28))
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -8,21 +8,17 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
   test("""transformation from a "superset" of fields into a "subset" of fields without modifiers""") {
     import products.{Foo, Bar}
 
+    // TODO: add tests with multiple parameter lists
+
     def customConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
 
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
+      .withConstructor(customConstructor)
+      .transform ==> Bar(6, (6.28, 6.28))
+    Foo(3, "pi", (3.14, 3.14))
+      .into[Bar]
       .withConstructor(customConstructor _)
-      .transform ==> Bar(6, (6.28, 6.28))
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor((customConstructor _).tupled)
-      .transform ==> Bar(6, (6.28, 6.28))
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor({ (x: Int, z: (Double, Double)) =>
-        customConstructor(x, z)
-      }.tupled)
       .transform ==> Bar(6, (6.28, 6.28))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -17,14 +17,15 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
     def customConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
 
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor(customConstructor)
-      .transform ==> Bar(6, (6.28, 6.28))
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor(customConstructor _)
-      .transform ==> Bar(6, (6.28, 6.28))
+    // Scala 2.12 :/
+//    Foo(3, "pi", (3.14, 3.14))
+//      .into[Bar]
+//      .withConstructor(customConstructor)
+//      .transform ==> Bar(6, (6.28, 6.28))
+//    Foo(3, "pi", (3.14, 3.14))
+//      .into[Bar]
+//      .withConstructor(customConstructor _)
+//      .transform ==> Bar(6, (6.28, 6.28))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
       .withConstructor({ (x: Int, z: (Double, Double)) =>

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -63,4 +63,23 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
       .withConstructor(typeParametricConstructor[Int, Double] _)
       .transform ==> BarParams(3, (3.14, 12.56))
   }
+
+  test("""allow defining transformers with overrides""") {
+    import products.NonCaseDomain.*
+
+    implicit val transformer: Transformer[ClassSource, TraitSource] = Transformer
+      .define[ClassSource, TraitSource]
+      .withConstructor { (name: String, id: String) =>
+        // swap
+        new TraitSourceImpl(name = id, id = name): TraitSource
+      }
+      // another swap
+      .withFieldRenamed(_.id, _.name)
+      .withFieldRenamed(_.name, _.id)
+      .buildTransformer
+
+    val result = (new ClassSource("id", "name")).transformInto[TraitSource]
+    result.id ==> "id"
+    result.name ==> "name"
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
@@ -42,6 +42,7 @@ object NonCaseDomain {
 
 case class Foo(x: Int, y: String, z: (Double, Double))
 case class Bar(x: Int, z: (Double, Double))
+case class BarParams[A, B](x: A, z: (B, Double))
 case class HaveY(y: String)
 
 object Renames {

--- a/chimney/src/test/scala/io/scalaland/chimney/internal/IsFunctionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/internal/IsFunctionSpec.scala
@@ -94,5 +94,113 @@ class IsFunctionSpec extends ChimneySpec {
       ) => String,
       String
     ]
+
+    resolves[() => (String, String) => String, String]
+    resolves[(Int) => (String, String) => String, String]
+    resolves[(Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String, String]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (String, String) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (
+          String,
+          String
+      ) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (
+          String,
+          String
+      ) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (
+          String,
+          String
+      ) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => (
+          String,
+          String
+      ) => String,
+      String
+    ]
+    resolves[
+      (
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int
+      ) => (String, String) => String,
+      String
+    ]
+    resolves[
+      (
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int
+      ) => (String, String) => String,
+      String
+    ]
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/internal/IsFunctionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/internal/IsFunctionSpec.scala
@@ -1,0 +1,98 @@
+package io.scalaland.chimney.internal
+import io.scalaland.chimney.ChimneySpec
+import io.scalaland.chimney.internal.runtime.IsFunction
+
+class IsFunctionSpec extends ChimneySpec {
+
+  test("IsFunction.Of checks out arities from 0 to 22") {
+
+    def resolves[Fn, Out](implicit isFunction: IsFunction.Of[Fn, Out]): Unit = {
+      val _ = isFunction
+      ()
+    }
+
+    resolves[() => String, String]
+    resolves[(Int) => String, String]
+    resolves[(Int, Int) => String, String]
+    resolves[(Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String, String]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String,
+      String
+    ]
+    resolves[
+      (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => String,
+      String
+    ]
+    resolves[
+      (
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int
+      ) => String,
+      String
+    ]
+    resolves[
+      (
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int,
+          Int
+      ) => String,
+      String
+    ]
+  }
+}

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -2014,11 +2014,16 @@ constructor for `PartialTransformer`:
     def smartConstructor(value: String): partial.Result[Bar] =
       partial.Result.fromEitherString(Bar.parse(value))
 
-    Foo("10").intoPartial[Bar].withConstructorPartial(smartConstructor).transform.asEither // Right(Bar(10))
+    Foo("10")
+      .intoPartial[Bar]
+      .withConstructorPartial(smartConstructor)
+      .transform.asEither // Right(Bar(10))
     
-    Foo("10").intoPartial[Bar].withConstructorPartial { (value: String) =>
-      partial.Result.fromEitherString(Bar.parse(value))
-    }.transform.asEither // Right(Bar(1000))
+    Foo("10")
+      .intoPartial[Bar]
+      .withConstructorPartial { (value: String) =>
+        partial.Result.fromEitherString(Bar.parse(value))
+      }.transform.asEither // Right(Bar(1000))
     ```
 
 You can use this to automatically match the source's getters e.g. against Scala 3's `opaque type`'s constructor's
@@ -2027,8 +2032,8 @@ be difficult to be automatically recognized as such:
 
 !!! example
  
-    Due to nature of `opaque type`s to work this example needs to have opaque types defined in a different file than
-    where they are being used:
+    Due to nature of `opaque type`s to work this example needs to have opaque types defined in a different `.scala`
+    file than where they are being used:
 
     ```scala
     package models
@@ -2053,13 +2058,21 @@ be difficult to be automatically recognized as such:
     import io.scalaland.chimney.{partial, PartialTransformer}
     import models.{Foo, Bar}
     
-    given PartialTransformer[Foo, Bar] = PartialTransformer.define[Foo, Bar].withConstructorPa>
-      partial.Result.fromEitherString(Bar.parse(value))
-    }.buildTransformer
+    given PartialTransformer[Foo, Bar] = PartialTransformer.define[Foo, Bar]
+      .withConstructorPartial { (value: String) =>
+        partial.Result.fromEitherString(Bar.parse(value))
+      }.buildTransformer
     
     @main def example: Unit =
       println(Foo("10").transformIntoPartial[Bar].asEither)
     ```
+
+!!! tip 
+
+    `opaque type`s usually have only one constructor argument and usually it is easier to not transform them that way,
+    but rather call their constructor directly. If `opaque type`s are nested in the transformed structure, it might be
+    easier to define [a custom transformer](#custom-transformations), perhaps by using a dedicated new type/refined type
+    library and [providing an integration for all of its types](cookbook.md#libraries-with-smart-constructors).  
 
 ## Custom transformations
 

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -1994,6 +1994,14 @@ Then Chimney will try to match the source type's getters against the method's pa
     }.transform // Bar("1000")
     ```
 
+!!! warning
+
+    The current implementation has a limit of 22 arguments even on Scala 3 (it doesn't use `scala.FunctionXXL`).
+    
+    It also requires that you either pass a method (which will be Eta-expanded) or a lambda with _all_ parameters names
+    (to allow matching parameters by name). It allows the method to have multiple parameters list and lambda to be
+    defined as curried (`(a: A, b: B) => (c: C) => { ... }`). 
+
 If your type only has smart a constructor which e.g. validates the input and might fail, you can provide a that smart
 constructor for `PartialTransformer`:
 


### PR DESCRIPTION
TODO:

 - [x] create the type-level representation for storing arguments' names and types
 - [x] parse the type-level representation in `TransformerCfg` in macros 
 - [x] convert function's/method's type-level representation + expression which contains the lambda into `Product.Constructor`
 - [x] wire custom constructor in `ProductToProduct` rule
 - [x] create `withConstructor` and `withConstructorPartial` in DSL
   - [x] parse `withConstructor(objectWithApply)` (allowing multiple parameter lists) in Scala 2
   - [x] parse `withConstructor { (arg: Arg, arg2: Arg2) => ... }` in Scala 2
   - [x] parse `withConstructor(objectWithApply)` (allowing multiple parameter lists) in Scala 3
   - [x] parse `withConstructor { (arg: Arg, arg2: Arg2) => ... }` in Scala 3
   - [x] same for `withConstructorPartial`
- [x] create `TotalTransformerCustomConstructorSpec`
- [x] create `PartialTransformerCustomConstructorSpec`
- [x] create MkDocs documentation
  - [x] warning, mention 22-limit even on Scala 3
- [x] create Scaladoc documentation