### PR TITLE
Better support for collections outside Scala's std lib

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/IteratorOf.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/IteratorOf.scala
@@ -1,0 +1,8 @@
+package io.scalaland.chimney.integrations
+
+// TODO: add deprecated type alias in io.scalaland.chimney.javacollections
+trait IteratorOf[A, CC] {
+  def iterator(collection: CC): Iterator[A]
+
+  final def foreach(collection: CC)(f: A => Any): Unit = iterator(collection).foreach(f)
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/OptionalOf.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/OptionalOf.scala
@@ -1,0 +1,27 @@
+package io.scalaland.chimney.integrations
+
+trait OptionalOf[F[_]] {
+  def someOf[A](a: A): F[A]
+  
+  def noneOf[A]: F[A]
+
+  def map[A, B](fa: F[A])(f: A => B): F[B]
+
+  def getOrElse[A](fa: F[A])(orElse: => A): A
+}
+
+// TODO: 
+// in dsl/auto - Transformer.AutoDerived/PartialTransformer.AutoDerived
+// in companion object? - Transformer.OrUpcast/PartialTransformer.OrUpcast
+// operations:
+// - Total Optional -> Optional
+// - Total Optional -> Option
+// - Total Option -> Optional
+// - Total pure -> Optional
+// - Partial Optional -> pure
+// - low priority
+// - Partial Optional -> Optional
+// - Partial Optional -> Option
+// - Partial Option -> Optional
+// - Partial pure -> Optional
+

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/PartialFactoryOf.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/PartialFactoryOf.scala
@@ -1,0 +1,23 @@
+package io.scalaland.chimney.integrations
+
+import io.scalaland.chimney.partial
+import scala.collection.compat.IterableOnce
+
+trait PartialFactoryOf[A, CC] {
+
+  def newBuilder: PartialFactoryOf.Builder[A, CC]
+
+  def partialFromSpecific(it: IterableOnce[A]): partial.Result[CC]
+
+  final def narrowPartial[CC2 >: CC]: TotalFactoryOf[A, CC2] = this.asInstanceOf[TotalFactoryOf[A, CC2]]
+}
+object PartialFactoryOf {
+
+  trait Builder[A, CC] {
+    def addOne(a: A): Unit
+
+    def partialResult(): partial.Result[CC]
+  }
+
+  // TODO: implicit to Factory
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalFactoryOf.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalFactoryOf.scala
@@ -1,0 +1,29 @@
+package io.scalaland.chimney.integrations
+
+import io.scalaland.chimney.partial
+import scala.collection.compat.IterableOnce
+
+// TODO: add deprecated type alias in io.scalaland.chimney.javacollections
+trait TotalFactoryOf[A, CC] extends PartialFactoryOf[A, CC] {
+
+  def newBuilder: TotalFactoryOf.Builder[A, CC]
+
+  def totalFromSpecific(it: IterableOnce[A]): CC
+
+  final def narrowTotal[CC2 >: CC]: TotalFactoryOf[A, CC2] = this.asInstanceOf[TotalFactoryOf[A, CC2]]
+
+  final def partialFromSpecific(it: IterableOnce[A]): partial.Result[CC] =
+    partial.Result.fromCatching(totalFromSpecific(it))
+}
+object TotalFactoryOf {
+
+  trait Builder[A, CC] extends PartialFactoryOf.Builder[A, CC] {
+    def addOne(a: A): Unit
+
+    def result(): CC
+
+    final def partialResult(): partial.Result[CC] = partial.Result.fromCatching(result())
+  }
+
+  // TODO: implicit to Factory
+}


### PR DESCRIPTION
Java collections module introduced on 0.8.0 solved some problems:

 * provided support for Java optional type (`java.util.Optional`) similar to support for `scala.Option`
 * provided support for Java collections

It has however a few drawbacks:

 * it uses `TransformerOrUpcast` type to avoid issues with automatic vs semiautomatic derivation (prevents having to pick between 2 imports, one for automatically derived internal types and one for only semiautomatically derived)
 * it only handles Scala StdLib <=> Java Collections, or Java Collections <=> Java Collections
 * if we introduced support for e.g. Cata NonEmpty collection we could convert Cats' NonEmptyList to Scala's List and Scala's List to Java's List but not Cats' NonEmptyList to Java's list which might be counterintuitive
 * problem would got even worse if someone wanted to add support for more collections from some other library

To handle it, the best solution would be to:

 * create a typeclass for optional types
 * create a typeclass for iterating over the collection
 * create a typeclass for creating the collection
 * define implicits using these typeclasses in core module (allowing to select automatic or semiautomatic support)
 * make Java Collections module only a collections of instances for iterating and building collections
 * allow creating instances for NonEmpty* Cats collection in some sane manner

This would be a breaking change, so it should not be merged as a part of 0.8.x but it can become a part of future 1.0.0-RC line.

TODO:

 - [x] define new type classes
 - [ ] define new implicits (both automatic and semiautomatic) based on these type classes
   - [ ] test that these implicits work and do not create conflicts!
 - [ ] define instances in Java Collections module
   - [ ] test them
 - [ ] remove old solution
   - [ ] optionally make some "old" types deprecated aliases to the new types
 - [ ] document changes in docs
   - [ ] document how to provide support for custom Option (update existing section) or custom collection (create a new section)