### PR TITLE
Add new utilities to partial.Result, improve existing Scaladocs a bit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Information about Scala macros can be found on:
  * [EPFL papers](https://infoscience.epfl.ch/search?ln=en&as=1&m1=p&p1=macros&f1=keyword&op1=a&m2=p&p2=scala&f2=&op2=a&m3=a&p3=&f3=&dt=&d1d=&d1m=&d1y=&d2d=&d2m=&d2y=&rm=&action_search=Search&sf=title&so=a&rg=10&c=Infoscience&of=hb)
 
 Very basic introduction can be found in [design doc](DESIGN.md) and in the
-[Under the hood](https://chimney.readthedocs.io/en/stable/under-the-hood/) section of the documentation.
+[Under the hood](https://chimney.readthedocs.io/under-the-hood/) section of the documentation.
 From then on we suggest looking at tests, and using`.enableMacrosLogging` to see how some branches are triggered.
 If still at doubt, you can ask us on GH discussions.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you are looking to up-to-date artifacts versions ready to copy-paste into you
 ## Contribution
 
 A way to get started is described in [CONTRIBUTING.md](CONTRIBUTING.md) and the general overview of the architecture
-is given in [DESIGN.md](DESIGN.md) and in [Under the hood](https://chimney.readthedocs.io/en/stable/under-the-hood/)
+is given in [DESIGN.md](DESIGN.md) and in [Under the hood](https://chimney.readthedocs.io/under-the-hood/)
 section of the documentation.
 
 ## Thanks

--- a/chimney/src/main/scala-2/io/scalaland/chimney/partial/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/partial/syntax/package.scala
@@ -1,20 +1,63 @@
 package io.scalaland.chimney.partial
 
-// TODO: docs
-
 package object syntax {
 
+  /** Provides operations lifting [[scala.Option]] to [[io.scalaland.chimney.partial.Result]].
+    *
+    * @tparam A successful value type
+    * @param option value to convert
+    *
+    * @since 0.8.5
+    */
   implicit class PartialResultOptionOps[A](private val option: Option[A]) extends AnyVal {
 
+    /** Converts [[scala.Some]] to [[io.scalaland.chimney.partial.Result.Value]] and uses user-provided
+      * [[io.scalaland.chimney.partial.Error]] on [[scala.None]].
+      *
+      * @param onEmpty thunk creating error on [[scala.None]]
+      * @return        result with [[scala.None]] handled
+      *
+      * @since 0.8.5
+      */
     def orErrorAsResult(onEmpty: => Error): Result[A] = Result.fromOptionOrError(option, onEmpty)
 
+    /** Converts [[scala.Some]] to [[io.scalaland.chimney.partial.Result.Value]] and uses user-provided
+      * [[java.lang.String]] on [[scala.None]].
+      *
+      * @param onEmpty thunk creating error message on [[scala.None]]
+      * @return        result with [[scala.None]] handled
+      *
+      * @since 0.8.5
+      */
     def orStringAsResult(onEmpty: => String): Result[A] = Result.fromOptionOrString(option, onEmpty)
 
+    /** Converts [[scala.Some]] to [[io.scalaland.chimney.partial.Result.Value]] and uses user-provided
+      * [[java.lang.Throwable]] on [[scala.None]].
+      *
+      * @param onEmpty thunk creating exception on [[scala.None]]
+      * @return        result with [[scala.None]] handled
+      *
+      * @since 0.8.5
+      */
     def orThrowableAsResult(onEmpty: => Throwable): Result[A] = Result.fromOptionOrThrowable(option, onEmpty)
   }
 
+  /** Provides operations lifting `F[A]` to [[io.scalaland.chimney.partial.Result]].
+    *
+    * @tparam F wrapper type
+    * @tparam A successful value type
+    * @param fa value to convert
+    *
+    * @since 0.8.5
+    */
   implicit class PartialResultAsResultOps[F[_], A](private val fa: F[A]) extends AnyVal {
 
+    /** Converts `F[A]` to [[io.scalaland.chimney.partial.Result]].
+      *
+      * @return result with error values handled
+      *
+      * @since 0.8.5
+      */
     def asResult(implicit F: AsResult[F]): Result[A] = F.asResult(fa)
   }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/partial/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/partial/syntax/package.scala
@@ -4,6 +4,8 @@ package object syntax {
 
   /** Provides operations lifting [[scala.Option]] to [[io.scalaland.chimney.partial.Result]].
     *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#partialresult-utilities]] for more details
+    *
     * @tparam A successful value type
     * @param option value to convert
     *
@@ -44,6 +46,7 @@ package object syntax {
 
   /** Provides operations lifting `F[A]` to [[io.scalaland.chimney.partial.Result]].
     *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#partialresult-utilities]] for more details
     * @tparam F wrapper type
     * @tparam A successful value type
     * @param fa value to convert

--- a/chimney/src/main/scala-2/io/scalaland/chimney/partial/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/partial/syntax/package.scala
@@ -1,0 +1,20 @@
+package io.scalaland.chimney.partial
+
+// TODO: docs
+
+package object syntax {
+
+  implicit class PartialResultOptionOps[A](private val option: Option[A]) extends AnyVal {
+
+    def orErrorAsResult(onEmpty: => Error): Result[A] = Result.fromOptionOrError(option, onEmpty)
+
+    def orStringAsResult(onEmpty: => String): Result[A] = Result.fromOptionOrString(option, onEmpty)
+
+    def orThrowableAsResult(onEmpty: => Throwable): Result[A] = Result.fromOptionOrThrowable(option, onEmpty)
+  }
+
+  implicit class PartialResultAsResultOps[F[_], A](private val fa: F[A]) extends AnyVal {
+
+    def asResult(implicit F: AsResult[F]): Result[A] = F.asResult(fa)
+  }
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/partial/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/partial/syntax/syntax.scala
@@ -4,6 +4,8 @@ import io.scalaland.chimney.partial.{AsResult, Error, Result}
 
 /** Provides operations lifting [[scala.Option]] to [[io.scalaland.chimney.partial.Result]].
   *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#partialresult-utilities]] for more details
+  *
   * @tparam A successful value type
   * @param option value to convert
   *
@@ -42,6 +44,8 @@ extension [A](option: Option[A])
   def orThrowableAsResult(onEmpty: => Throwable): Result[A] = Result.fromOptionOrThrowable(option, onEmpty)
 
 /** Provides operations lifting `F[A]` to [[io.scalaland.chimney.partial.Result]].
+  *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#partialresult-utilities]] for more details
   *
   * @tparam F wrapper type
   * @tparam A successful value type

--- a/chimney/src/main/scala-3/io/scalaland/chimney/partial/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/partial/syntax/syntax.scala
@@ -1,0 +1,16 @@
+package io.scalaland.chimney.partial.syntax
+
+import io.scalaland.chimney.partial.{AsResult, Error, Result}
+
+// TODO: docs
+
+extension [A](option: Option[A])
+  
+  def orErrorAsResult(onEmpty: => Error): Result[A] = Result.fromOptionOrError(option, onEmpty)
+  
+  def orStringAsResult(onEmpty: => String): Result[A] = Result.fromOptionOrString(option, onEmpty)
+  
+  def orThrowableAsResult(onEmpty: => Throwable): Result[A] = Result.fromOptionOrThrowable(option, onEmpty)
+
+extension [F[_], A](fa: F[A])
+  def asResult(using F: AsResult[F]): Result[A] = F.asResult(fa)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/partial/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/partial/syntax/syntax.scala
@@ -2,15 +2,58 @@ package io.scalaland.chimney.partial.syntax
 
 import io.scalaland.chimney.partial.{AsResult, Error, Result}
 
-// TODO: docs
-
+/** Provides operations lifting [[scala.Option]] to [[io.scalaland.chimney.partial.Result]].
+  *
+  * @tparam A successful value type
+  * @param option value to convert
+  *
+  * @since 0.8.5
+  */
 extension [A](option: Option[A])
-  
+
+  /** Converts [[scala.Some]] to [[io.scalaland.chimney.partial.Result.Value]] and uses user-provided
+    * [[io.scalaland.chimney.partial.Error]] on [[scala.None]].
+    *
+    * @param onEmpty thunk creating error on [[scala.None]]
+    * @return        result with [[scala.None]] handled
+    *
+    * @since 0.8.5
+    */
   def orErrorAsResult(onEmpty: => Error): Result[A] = Result.fromOptionOrError(option, onEmpty)
-  
+
+  /** Converts [[scala.Some]] to [[io.scalaland.chimney.partial.Result.Value]] and uses user-provided
+    * [[java.lang.String]] on [[scala.None]].
+    *
+    * @param onEmpty thunk creating error message on [[scala.None]]
+    * @return        result with [[scala.None]] handled
+    *
+    * @since 0.8.5
+    */
   def orStringAsResult(onEmpty: => String): Result[A] = Result.fromOptionOrString(option, onEmpty)
-  
+
+  /** Converts [[scala.Some]] to [[io.scalaland.chimney.partial.Result.Value]] and uses user-provided
+    * [[java.lang.Throwable]] on [[scala.None]].
+    *
+    * @param onEmpty thunk creating exception on [[scala.None]]
+    * @return        result with [[scala.None]] handled
+    *
+    * @since 0.8.5
+    */
   def orThrowableAsResult(onEmpty: => Throwable): Result[A] = Result.fromOptionOrThrowable(option, onEmpty)
 
+/** Provides operations lifting `F[A]` to [[io.scalaland.chimney.partial.Result]].
+  *
+  * @tparam F wrapper type
+  * @tparam A successful value type
+  * @param fa value to convert
+  *
+  * @since 0.8.5
+  */
 extension [F[_], A](fa: F[A])
+  /** Converts `F[A]` to [[io.scalaland.chimney.partial.Result]].
+    *
+    * @return result with error values handled
+    *
+    * @since 0.8.5
+    */
   def asResult(using F: AsResult[F]): Result[A] = F.asResult(fa)

--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -4,6 +4,8 @@ import io.scalaland.chimney.dsl.PatcherDefinition
 import io.scalaland.chimney.internal.runtime.{PatcherCfg, PatcherFlags}
 
 /** Type class definition that wraps patching behavior.
+ *
+ * @see [[https://chimney.readthedocs.io/supported-patching/]]
   *
   * @tparam A type of object to apply patch to
   * @tparam Patch type of patch object
@@ -23,11 +25,16 @@ trait Patcher[A, Patch] extends Patcher.AutoDerived[A, Patch] {
   def patch(obj: A, patch: Patch): A
 }
 
-/** @since 0.1.3 */
+/** Companion of [[io.scalaland.chimney.Patcher]].
+  *
+  * @see [[https://chimney.readthedocs.io/supported-patching/]]
+  *
+  * @since 0.1.3
+  */
 object Patcher extends PatcherCompanionPlatform {
 
-  /** Creates an empty [[io.scalaland.chimney.dsl.PatcherDefinition]] that
-    * you can customize to derive [[io.scalaland.chimney.Patcher]].
+  /** Creates an empty [[io.scalaland.chimney.dsl.PatcherDefinition]] that you can customize to derive
+    * [[io.scalaland.chimney.Patcher]].
     *
     * @see [[io.scalaland.chimney.dsl.PatcherDefinition]] for available settings
     *
@@ -40,8 +47,22 @@ object Patcher extends PatcherCompanionPlatform {
   def define[A, Patch]: PatcherDefinition[A, Patch, PatcherCfg.Empty, PatcherFlags.Default] =
     new PatcherDefinition
 
+  /** Type class used when you want o allow using automatically derived patchings.
+    *
+    * When we want to only allow semiautomatically derived/manually defined instances you should use
+    * [[io.scalaland.chimney.Patcher]].
+    *
+    * @see [[https://chimney.readthedocs.io/cookbook/#automatic-semiautomatic-and-inlined-derivation]] for more details
+    *
+    * @tparam A type of object to apply patch to
+    * @tparam Patch type of patch object
+    *
+    * @since 0.8.0
+    */
   trait AutoDerived[A, Patch] {
     def patch(obj: A, patch: Patch): A
   }
+
+  /** @since 0.8.0 */
   object AutoDerived extends PatcherAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -4,8 +4,8 @@ import io.scalaland.chimney.dsl.PatcherDefinition
 import io.scalaland.chimney.internal.runtime.{PatcherCfg, PatcherFlags}
 
 /** Type class definition that wraps patching behavior.
- *
- * @see [[https://chimney.readthedocs.io/supported-patching/]]
+  *
+  * @see [[https://chimney.readthedocs.io/supported-patching/]]
   *
   * @tparam A type of object to apply patch to
   * @tparam Patch type of patch object

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -3,8 +3,10 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.{PartialTransformerDefinition, TransformerDefinition, TransformerDefinitionCommons}
 import io.scalaland.chimney.internal.runtime.{TransformerCfg, TransformerFlags}
 
-/** Type class expressing total transformation between
-  * source type `From` and target type `To`.
+/** Type class expressing total transformation between source type `From` and target type `To`.
+  *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/]]
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#total-transformers-vs-partialtransformers]]
   *
   * @tparam From type of input value
   * @tparam To   type of output value
@@ -23,10 +25,17 @@ trait Transformer[From, To] extends Transformer.AutoDerived[From, To] {
   def transform(src: From): To
 }
 
+/** Companion of [[io.scalaland.chimney.Transformer]].
+  *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/]]
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#total-transformers-vs-partialtransformers]]
+  *
+  * @since 0.2.0
+  */
 object Transformer extends TransformerCompanionPlatform {
 
-  /** Creates an empty [[io.scalaland.chimney.dsl.TransformerDefinition]] that
-    * you can customize to derive [[io.scalaland.chimney.Transformer]].
+  /** Creates an empty [[io.scalaland.chimney.dsl.TransformerDefinition]] that you can customize to derive
+    * [[io.scalaland.chimney.Transformer]].
     *
     * @see [[io.scalaland.chimney.dsl.TransformerDefinition]] for available settings
     *
@@ -39,8 +48,8 @@ object Transformer extends TransformerCompanionPlatform {
   def define[From, To]: TransformerDefinition[From, To, TransformerCfg.Empty, TransformerFlags.Default] =
     new TransformerDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore)
 
-  /** Creates an empty [[io.scalaland.chimney.dsl.PartialTransformerDefinition]] that
-    * you can customize to derive [[io.scalaland.chimney.PartialTransformer]].
+  /** Creates an empty [[io.scalaland.chimney.dsl.PartialTransformerDefinition]] that you can customize to derive
+    * [[io.scalaland.chimney.PartialTransformer]].
     *
     * @see [[io.scalaland.chimney.dsl.PartialTransformerDefinition]] for available settings
     *
@@ -53,8 +62,22 @@ object Transformer extends TransformerCompanionPlatform {
   def definePartial[From, To]: PartialTransformerDefinition[From, To, TransformerCfg.Empty, TransformerFlags.Default] =
     new PartialTransformerDefinition(TransformerDefinitionCommons.emptyRuntimeDataStore)
 
+  /** Type class used when you want o allow using automatically derived transformations.
+    *
+    * When we want to only allow semiautomatically derived/manually defined instances you should use
+    * [[io.scalaland.chimney.Transformer]].
+    *
+    * @see [[https://chimney.readthedocs.io/cookbook/#automatic-semiautomatic-and-inlined-derivation]] for more details
+    *
+    * @tparam From type of input value
+    * @tparam To   type of output value
+    *
+    * @since 0.8.0
+    */
   trait AutoDerived[From, To] {
     def transform(src: From): To
   }
+
+  /** @since 0.8.0 */
   object AutoDerived extends TransformerAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/ImplicitTransformerPreference.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/ImplicitTransformerPreference.scala
@@ -2,17 +2,23 @@ package io.scalaland.chimney.dsl
 
 /** Whether derivation should prefer total or partial transformers if both are provided for some field transformation.
   *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#resolving-priority-of-implicit-total-vs-partial-transformers]] for more details
+  *
   * @since 0.7.0
   */
 sealed abstract class ImplicitTransformerPreference
 
 /** Tell the derivation to prefer total transformers.
   *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#resolving-priority-of-implicit-total-vs-partial-transformers]] for more details
+  *
   * @since 0.7.0
   */
 case object PreferTotalTransformer extends ImplicitTransformerPreference
 
 /** Tell the derivation to prefer partial transformers.
+  *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#resolving-priority-of-implicit-total-vs-partial-transformers]] for more details
   *
   * @since 0.7.0
   */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/PatcherFlagsDsl.scala
@@ -9,12 +9,10 @@ import io.scalaland.chimney.internal.runtime.PatcherFlags
   */
 private[dsl] trait PatcherFlagsDsl[UpdateFlag[_ <: PatcherFlags], Flags <: PatcherFlags] {
 
-  /** In case when both object to patch and patch value contain field
-    * of type `Option[T]`, this option allows to treat `None` value in
-    * patch like the value was not provided.
+  /** In case when both object to patch and patch value contain field of type [[scala.Option]], this option allows
+    * to treat [[scala.None]] value in patch as if the value was not provided.
     *
-    * By default, when `None` is delivered in patch, Chimney clears
-    * the value of such field on patching.
+    * By default, when [[scala.None]] is delivered in patch, Chimney clears the value of such field on patching.
     *
     * @see [[https://chimney.readthedocs.io/supported-patching/#treating-none-as-no-update-instead-of-set-to-none]] for more details
     *
@@ -25,7 +23,7 @@ private[dsl] trait PatcherFlagsDsl[UpdateFlag[_ <: PatcherFlags], Flags <: Patch
   def ignoreNoneInPatch: UpdateFlag[Enable[IgnoreNoneInPatch, Flags]] =
     enableFlag[IgnoreNoneInPatch]
 
-  /** Then there Option is patching Option, on None value will be cleared.
+  /** Then there [[scala.Option]] is patching [[scala.Option]], on [[scala.None]] value will be cleared.
     *
     * @see [[https://chimney.readthedocs.io/supported-patching/#treating-none-as-no-update-instead-of-set-to-none]] for more details
     *
@@ -36,13 +34,11 @@ private[dsl] trait PatcherFlagsDsl[UpdateFlag[_ <: PatcherFlags], Flags <: Patch
   def clearOnNoneInPatch: UpdateFlag[Disable[IgnoreNoneInPatch, Flags]] =
     disableFlag[IgnoreNoneInPatch]
 
-  /** In case that patch object contains a redundant field (i.e. field that
-    * is not present in patched object type), this option enables ignoring
-    * value of such fields and generate patch successfully.
+  /** In case that patch object contains a redundant field (i.e. field that is not present in patched object type), this
+    * option enables ignoring value of such fields and generate patch successfully.
     *
-    * By default, when Chimney detects a redundant field in patch object, it
-    * fails the compilation in order to prevent silent oversight of field name
-    * typos.
+    * By default, when Chimney detects a redundant field in patch object, it fails the compilation in order to prevent
+    * silent oversight of field name typos.
     *
     * @see [[https://chimney.readthedocs.io/supported-patching/#ignoring-fields-in-patches]] for more details
     *

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -5,7 +5,8 @@ import io.scalaland.chimney.internal.runtime.TransformerFlags
 
 import scala.annotation.unused
 
-/** Type-level representation of derivation flags which can be enabled/disabled for a specific transformation or globally.
+/** Type-level representation of derivation flags which can be enabled/disabled for a specific transformation or
+  * globally.
   *
   * @since 0.6.0
   */
@@ -13,7 +14,8 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable lookup in definitions inherited from supertype.
     *
-    * By default only values defined directly in the type are considered. With this flag supertype methods would not be filtered out
+    * By default only values defined directly in the type are considered. With this flag supertype methods would not be
+    * filtered out
     *
     * @see [[https://chimney.readthedocs.io/supported-transformations/#reading-from-inherited-valuesmethods]] for more details
     *

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsFunction.scala
@@ -3,9 +3,10 @@ package io.scalaland.chimney.internal.runtime
 import scala.annotation.implicitNotFound
 
 /** Allow us to provide some better IDE support than just accepting everything as a parameter and waiting for the macro
-  * to scream with compilation error, in the world where different function types have no common ancestor (other and AnyRef).
+  * to scream with compilation error, in the world where different function types have no common ancestor
+  * (other than AnyRef).
   *
-  * @since 0.7.4
+  * @since 0.8.4
   */
 @implicitNotFound(
   "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of the target type, got ${Fn}"

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/AsResult.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/AsResult.scala
@@ -2,26 +2,50 @@ package io.scalaland.chimney.partial
 
 import scala.util.Try
 
-// TODO: docs
-
+/** Utility allowing conversion from some type into [[io.scalaland.chimney.partial.Result]].
+  *
+  * Should define logic what is considered successful value, what is considered failed value and how to convert it into
+  * [[io.scalaland.chimney.partial.Result]].
+  *
+  * @tparam F generic data type which should be convertible to `Result` for all possible values
+  *
+  * @since 0.8.5
+  */
 trait AsResult[F[_]] {
 
+  /** Converts `F[A]` into `Result[A]`.
+    *
+    * @tparam A  type of successful value
+    * @param  fa converted value
+    * @return    converted value
+    *
+    * @since 0.8.5
+    */
   def asResult[A](fa: F[A]): Result[A]
 }
+
+/** Companion of [[io.scalaland.chimney.partial.AsResult]].
+  *
+  * @since 0.8.5
+  */
 object AsResult {
 
+  /** @since 0.8.5 */
   implicit val optionAsResult: AsResult[Option] = new AsResult[Option] {
     def asResult[A](fa: Option[A]): Result[A] = Result.fromOption(fa)
   }
 
+  /** @since 0.8.5 */
   implicit val eitherErrorAsResult: AsResult[Either[Result.Errors, *]] = new AsResult[Either[Result.Errors, *]] {
     def asResult[A](fa: Either[Result.Errors, A]): Result[A] = Result.fromEither(fa)
   }
 
+  /** @since 0.8.5 */
   implicit val eitherStringAsResult: AsResult[Either[String, *]] = new AsResult[Either[String, *]] {
     def asResult[A](fa: Either[String, A]): Result[A] = Result.fromEitherString(fa)
   }
-  
+
+  /** @since 0.8.5 */
   implicit val tryAsResult: AsResult[Try] = new AsResult[Try] {
     def asResult[A](fa: Try[A]): Result[A] = Result.fromTry(fa)
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/AsResult.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/AsResult.scala
@@ -7,6 +7,8 @@ import scala.util.Try
   * Should define logic what is considered successful value, what is considered failed value and how to convert it into
   * [[io.scalaland.chimney.partial.Result]].
   *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#total-transformers-vs-partialtransformers]]
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#partialresult-utilities]]
   * @tparam F generic data type which should be convertible to `Result` for all possible values
   *
   * @since 0.8.5

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/AsResult.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/AsResult.scala
@@ -1,0 +1,28 @@
+package io.scalaland.chimney.partial
+
+import scala.util.Try
+
+// TODO: docs
+
+trait AsResult[F[_]] {
+
+  def asResult[A](fa: F[A]): Result[A]
+}
+object AsResult {
+
+  implicit val optionAsResult: AsResult[Option] = new AsResult[Option] {
+    def asResult[A](fa: Option[A]): Result[A] = Result.fromOption(fa)
+  }
+
+  implicit val eitherErrorAsResult: AsResult[Either[Result.Errors, *]] = new AsResult[Either[Result.Errors, *]] {
+    def asResult[A](fa: Either[Result.Errors, A]): Result[A] = Result.fromEither(fa)
+  }
+
+  implicit val eitherStringAsResult: AsResult[Either[String, *]] = new AsResult[Either[String, *]] {
+    def asResult[A](fa: Either[String, A]): Result[A] = Result.fromEitherString(fa)
+  }
+  
+  implicit val tryAsResult: AsResult[Try] = new AsResult[Try] {
+    def asResult[A](fa: Try[A]): Result[A] = Result.fromTry(fa)
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Path.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Path.scala
@@ -37,6 +37,10 @@ final case class Path(private val elems: List[PathElement]) extends AnyVal {
     }
 }
 
+/** Companion of [[io.scalaland.chimney.partial.Path]]
+  *
+  * @since 0.7.0
+  */
 object Path {
 
   /** Empty error path

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/PathElement.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/PathElement.scala
@@ -2,6 +2,8 @@ package io.scalaland.chimney.partial
 
 /** Data type for representing path element in a (possibly) nested object structure.
   *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#total-transformers-vs-partialtransformers]]
+  *
   * @since 0.7.0
   */
 sealed trait PathElement {
@@ -13,6 +15,12 @@ sealed trait PathElement {
   def asString: String
 }
 
+/** Companion of [[io.scalaland.chimney.partial.PathElement]].
+  *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#total-transformers-vs-partialtransformers]]
+  *
+  * @since 0.7.0
+  */
 object PathElement {
 
   /** Object property accessor (e.g case class param name).

--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -1,3 +1,9 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 <style>
     .benchmarks-content {
         min-width: 100%;

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,3 +1,9 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 <p style="text-align: center"><img src="https://raw.githubusercontent.com/scalalandio/chimney/{{ git.commit }}/gfx/chimney-logo-circle-matching.svg" alt="Chimney logo" style="height: 250px" /></p>
 
 <h1 style="margin-bottom:0">Chimney</h1>


### PR DESCRIPTION
TODO:

 - [x] add new utilities for `partial.Result`
 - [x] add docs for new utilities
 - [x] improve Scaladocs for type classes and `partial` data types 
 - [x] add tests for new utilitites
 - [x] use new utilities in MkDocs
 