### PR TITLE
Change how logos are being displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# <img src="gfx/chimney-logo.svg" alt="Chimney logo" height="60" />  Chimney
+<p style="text-align: center"><img src="gfx/chimney-logo-circle-dark.svg" alt="Chimney logo" height="250px" /></p>
 
-[![chimney Scala version support](https://index.scala-lang.org/scalalandio/chimney/chimney/latest.svg)](https://index.scala-lang.org/scalalandio/chimney/chimney)
+# Chimney
+
+[![Chimney Scala version support](https://index.scala-lang.org/scalalandio/chimney/chimney/latest.svg)](https://index.scala-lang.org/scalalandio/chimney/chimney)
 
 [![CI build](https://github.com/scalalandio/chimney/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/scalalandio/chimney/actions)
 [![codecov.io](http://codecov.io/github/scalalandio/chimney/coverage.svg?branch=master)](http://codecov.io/github/scalalandio/chimney?branch=master)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,3 +1,5 @@
+<p style="text-align: center"><img src="https://raw.githubusercontent.com/scalalandio/chimney/{{ git.commit }}/gfx/chimney-logo-circle-dark.svg" alt="Chimney logo" style="height: 250px" /></p>
+
 <h1 style="margin-bottom:0">Chimney</h1>
 <h2 style="margin-top:0">The battle-tested Scala library for data transformations</h2>
 

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -2093,6 +2093,8 @@ to be automatically recognized as such:
       println(StringIP("127", "0", "0", "1").transformIntoPartial[IP].asEither.map(_.show))
     ```
 
+!!! example
+
     ```scala
     package models
     


### PR DESCRIPTION
Display logo in circle, centered on both README and landing page of docs