### PR TITLE
Prefix all cats instances with cats, add Alternative instance for partial.Result and PartialTransformer, change instances name to something which won't change as often

### DIFF
--- a/chimney-cats/src/main/scala/io/scalaland/chimney/cats/CatsTotalTransformerImplicits.scala
+++ b/chimney-cats/src/main/scala/io/scalaland/chimney/cats/CatsTotalTransformerImplicits.scala
@@ -7,7 +7,7 @@ import io.scalaland.chimney.Transformer
 trait CatsTotalTransformerImplicits {
 
   /** @since 1.0.0 */
-  implicit final val commutativeArrowChoiceForTransformer: ArrowChoice[Transformer] & CommutativeArrow[Transformer] =
+  implicit final val catsCategoryForTransformer: ArrowChoice[Transformer] & CommutativeArrow[Transformer] =
     new ArrowChoice[Transformer] with CommutativeArrow[Transformer] {
       override def lift[A, B](f: A => B): Transformer[A, B] = f(_)
 
@@ -28,7 +28,7 @@ trait CatsTotalTransformerImplicits {
     }
 
   /** @since 1.0.0 */
-  implicit final def monadCoflatMapForTransformer[Source]
+  implicit final def catsCovariantForTransformer[Source]
       : Monad[Transformer[Source, *]] & CoflatMap[Transformer[Source, *]] =
     new Monad[Transformer[Source, *]] with CoflatMap[Transformer[Source, *]] {
       override def pure[A](x: A): Transformer[Source, A] = _ => x
@@ -56,7 +56,7 @@ trait CatsTotalTransformerImplicits {
     }
 
   /** @since 1.0.0 */
-  implicit final def contravariantForTransformer[Target]: Contravariant[Transformer[*, Target]] =
+  implicit final def catsContravariantForTransformer[Target]: Contravariant[Transformer[*, Target]] =
     new Contravariant[Transformer[*, Target]] {
       def contramap[A, B](fa: Transformer[A, Target])(f: B => A): Transformer[B, Target] =
         b => fa.transform(f(b))

--- a/chimney-cats/src/test/scala/io/scalaland/chimney/cats/PartialResultLaws.scala
+++ b/chimney-cats/src/test/scala/io/scalaland/chimney/cats/PartialResultLaws.scala
@@ -12,7 +12,7 @@ class PartialResultLaws extends ChimneySpec with utils.ArbitraryUtils {
   }
 
   group(
-    "MonadError[partial.Result, partial.Result.Errors] & CoflatMap[partial.Result] & Traverse[partial.Result] should follow laws"
+    "MonadError[partial.Result, partial.Result.Errors] & CoflatMap[partial.Result] & Traverse[partial.Result] & Alternative[partial.Result] should follow laws"
   ) {
     checkLawsAsTests(InvariantTests[partial.Result].invariant[Int, String, Double])
     checkLawsAsTests(SemigroupalTests[partial.Result].semigroupal[Int, String, Double])
@@ -29,5 +29,6 @@ class PartialResultLaws extends ChimneySpec with utils.ArbitraryUtils {
       UnorderedTraverseTests[partial.Result].unorderedTraverse[Int, Long, Double, Const[Unit, *], Const[Int, *]]
     )
     checkLawsAsTests(TraverseTests[partial.Result].traverse[Int, Long, Double, Byte, Const[Unit, *], Const[Int, *]])
+    checkLawsAsTests(AlternativeTests[partial.Result].alternative[Int, String, Double])
   }
 }

--- a/chimney-cats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerLaws.scala
+++ b/chimney-cats/src/test/scala/io/scalaland/chimney/cats/PartialTransformerLaws.scala
@@ -17,9 +17,10 @@ class PartialTransformerLaws extends ChimneySpec with utils.ArbitraryUtils {
   }
 
   group(
-    "MonadError[Transformer[Source, *], partial.Result.Errors] & CoflatMap[Transformer[Source, *]] instance should follow laws"
+    "MonadError[PartialTransformer[Source, *], partial.Result.Errors] & CoflatMap[PartialTransformer[Source, *]] & Alternative[PartialTransformer[Source, *]] instance should follow laws"
   ) {
     checkLawsAsTests(InvariantTests[PartialTransformer[String, *]].invariant[Int, String, Double])
+    checkLawsAsTests(SemigroupalTests[PartialTransformer[String, *]].semigroupal[Int, String, Double])
     checkLawsAsTests(FunctorTests[PartialTransformer[String, *]].functor[Int, String, Double])
     checkLawsAsTests(ApplicativeTests[PartialTransformer[String, *]].applicative[Int, String, Double])
     checkLawsAsTests(FlatMapTests[PartialTransformer[String, *]].flatMap[Int, String, Double])
@@ -31,14 +32,15 @@ class PartialTransformerLaws extends ChimneySpec with utils.ArbitraryUtils {
       MonadErrorTests[PartialTransformer[String, *], partial.Result.Errors].monadError[Int, String, Double]
     )
     checkLawsAsTests(CoflatMapTests[PartialTransformer[String, *]].coflatMap[Int, String, Double])
+    checkLawsAsTests(AlternativeTests[PartialTransformer[String, *]].alternative[Int, String, Double])
   }
 
-  group("Parallel[Transformer[From, *]] instance should follow laws") {
+  group("Parallel[PartialTransformer[From, *]] instance should follow laws") {
     checkLawsAsTests(NonEmptyParallelTests[PartialTransformer[String, *]].nonEmptyParallel[Int, String])
     checkLawsAsTests(ParallelTests[PartialTransformer[String, *]].parallel[Int, String])
   }
 
-  group("Contravariant[Transformer[*, To]] instance should follow laws") {
+  group("Contravariant[PartialTransformer[*, To]] instance should follow laws") {
     checkLawsAsTests(ContravariantTests[PartialTransformer[*, String]].contravariant[Int, String, Double])
   }
 }

--- a/chimney-cats/src/test/scala/io/scalaland/chimney/cats/utils/ArbitraryUtils.scala
+++ b/chimney-cats/src/test/scala/io/scalaland/chimney/cats/utils/ArbitraryUtils.scala
@@ -4,7 +4,7 @@ import cats.Eq
 import cats.data.Const
 import cats.syntax.eq.*
 import io.scalaland.chimney.{partial, ChimneySpec, PartialTransformer, Transformer}
-import io.scalaland.chimney.cats.eqPartialResult
+import io.scalaland.chimney.cats.catsEqForPartialResult
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Test.check
 import org.scalacheck.Prop.forAll


### PR DESCRIPTION
TODO:
 - [ ] add tests for `partial.Result.orElse`
 - [ ] create Scaladoc for `orElse`
 - [ ] update mkdocs for Cats instances
 - [ ] perhaps use `arrow` name instead of `category` in `cats.arrow` instances names