### PR TITLE
Add PartialUnwrapsOption flag

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -215,6 +215,8 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           weakTypeTag[runtime.TransformerFlags.BeanSettersIgnoreUnmatched]
         val OptionDefaultsToNone: Type[runtime.TransformerFlags.OptionDefaultsToNone] =
           weakTypeTag[runtime.TransformerFlags.OptionDefaultsToNone]
+        val PartialUnwrapsOption: Type[runtime.TransformerFlags.PartialUnwrapsOption] =
+          weakTypeTag[runtime.TransformerFlags.PartialUnwrapsOption]
         object ImplicitConflictResolution extends ImplicitConflictResolutionModule {
           def apply[R <: dsls.ImplicitTransformerPreference: Type]
               : Type[runtime.TransformerFlags.ImplicitConflictResolution[R]] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -205,6 +205,8 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           quoted.Type.of[runtime.TransformerFlags.BeanSettersIgnoreUnmatched]
         val OptionDefaultsToNone: Type[runtime.TransformerFlags.OptionDefaultsToNone] =
           quoted.Type.of[runtime.TransformerFlags.OptionDefaultsToNone]
+        val PartialUnwrapsOption: Type[runtime.TransformerFlags.PartialUnwrapsOption] =
+          quoted.Type.of[runtime.TransformerFlags.PartialUnwrapsOption]
         object ImplicitConflictResolution extends ImplicitConflictResolutionModule {
           def apply[R <: dsls.ImplicitTransformerPreference: Type]
               : Type[runtime.TransformerFlags.ImplicitConflictResolution[R]] =

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -154,6 +154,26 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
   def disableOptionDefaultsToNone: UpdateFlag[Disable[OptionDefaultsToNone, Flags]] =
     disableFlag[OptionDefaultsToNone]
 
+  /** Enable safe Option unwrapping by `PartialTransformer` - `Option` is automatically unwrapped to non-`Option` values, `None` is treated as empty value errors.
+    *
+    * This is the default behavior.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @since 1.0.0
+    */
+  def enablePartialUnwrapsOption: UpdateFlag[Enable[PartialUnwrapsOption, Flags]] =
+    enableFlag[PartialUnwrapsOption]
+
+  /** Disable safe `Option` unwrapping by `PartialTransformer` - each `Option` to non-Option` has to be handled manually.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @since 1.0.0
+    */
+  def disablePartialUnwrapsOption: UpdateFlag[Disable[PartialUnwrapsOption, Flags]] =
+    disableFlag[PartialUnwrapsOption]
+
   /** Enable conflict resolution when both `Transformer` and `PartialTransformer` are available in the implicit scope.
     *
     * @param preference parameter specifying which implicit transformer to pick in case of conflict

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -158,7 +158,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
     *
     * This is the default behavior.
     *
-    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#controlling-automatic-option-unwrapping]] for more details
     *
     * @since 1.0.0
     */
@@ -167,7 +167,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Disable safe `Option` unwrapping by `PartialTransformer` - each `Option` to non-Option` has to be handled manually.
     *
-    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#controlling-automatic-option-unwrapping]] for more details
     *
     * @since 1.0.0
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -174,6 +174,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
         val BeanSetters: Type[runtime.TransformerFlags.BeanSetters]
         val BeanSettersIgnoreUnmatched: Type[runtime.TransformerFlags.BeanSettersIgnoreUnmatched]
         val OptionDefaultsToNone: Type[runtime.TransformerFlags.OptionDefaultsToNone]
+        val PartialUnwrapsOption: Type[runtime.TransformerFlags.PartialUnwrapsOption]
         val ImplicitConflictResolution: ImplicitConflictResolutionModule
         trait ImplicitConflictResolutionModule
             extends Type.Ctor1UpperBounded[

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -17,6 +17,7 @@ private[compiletime] trait Configurations { this: Derivation =>
       beanSettersIgnoreUnmatched: Boolean = false,
       beanGetters: Boolean = false,
       optionDefaultsToNone: Boolean = false,
+      partialUnwrapsOption: Boolean = true,
       implicitConflictResolution: Option[ImplicitTransformerPreference] = None,
       displayMacrosLogging: Boolean = false
   ) {
@@ -36,6 +37,8 @@ private[compiletime] trait Configurations { this: Derivation =>
         copy(beanGetters = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.OptionDefaultsToNone) {
         copy(optionDefaultsToNone = value)
+      } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.PartialUnwrapsOption) {
+        copy(partialUnwrapsOption = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.MacrosLogging) {
         copy(displayMacrosLogging = value)
       } else {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
@@ -15,8 +15,14 @@ private[compiletime] trait TransformPartialOptionToNonOptionRuleModule { this: D
         case (Type.Option(from2)) if !Type[To].isOption =>
           ctx match {
             case TransformationContext.ForPartial(_, _) =>
-              import from2.Underlying as InnerFrom
-              mapOptionToPartial[From, To, InnerFrom]
+              if (ctx.config.flags.partialUnwrapsOption) {
+                import from2.Underlying as InnerFrom
+                mapOptionToPartial[From, To, InnerFrom]
+              } else {
+                DerivationResult.attemptNextRuleBecause(
+                  "Safe Option unwrapping was disabled by a flag"
+                )
+              }
             case _ =>
               DerivationResult.attemptNextRuleBecause(
                 "Safe Option unwrapping is available only for PartialTransformers"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
@@ -16,6 +16,7 @@ object TransformerFlags {
   final class BeanSettersIgnoreUnmatched extends Flag
   final class BeanGetters extends Flag
   final class OptionDefaultsToNone extends Flag
+  final class PartialUnwrapsOption extends Flag
   final class ImplicitConflictResolution[R <: ImplicitTransformerPreference] extends Flag
   final class MacrosLogging extends Flag
 }


### PR DESCRIPTION
TODO:

 - [x] add tests with and without flag
 - [x] add MkDocs documentation explaining the flag
 - [x] replace TODO with a proper section link in Scaladocs `@see` section of the flags methods

---

ATM I am leaning towards adding this flag in 1.0.0. However, I am against enabling it by default:

The issue only arises when one uses Chimney as a compile time proof that some transformation is valid. This is WRONG. Chimney is only able to prove that there exists a path of a least resistance converting value of one type into another.

If the input type is `String` but the output expects non-empty `String` - without making it explicitly a distinct type with a smart constructor (e.g. `NonEmptyString` from Refined/Iron/etc) compile-time logic would not be able to validate that. Same with `Int`s and non-negative `Int`s, checking regexps, etc. If types are the same, then anything more than passing the value unchanged can only be verified by runtime tests. Basically, by default `A => A` conversion always succeeds for every `A`.

`Option`, most of the time, is a replacement for nullable values. In a world when `null` is not supposed to be a thing, verifying that nullable has to be different than null to make it non-nullable is rather obvious and expected outcome. Requiring explicit `Option[A] => A` (or `Option[A] => B`) parsing is rather non-standard.

And that's the problem: handling empty `Option`s is a primary reason users try to use `PartialTransformer`s. It is the main use case that advertised the feature on landing page, half the documentation examples, it lowers the barrier to entry for everyone who uses Chimney to decode JSONs or Protobufs into domain models. Disabling it by default would be discouraging as suddenly 90% of use cases would require additional flag. I would stop using Partials myself if I had to do this every time.

If the code performs any sort of validation `PartialTransformer`s helps write that logic - but that logic would inevitably have branches depending on runtime data, and as such Chimney was, is, and will be only removing the boilerplate in the production code, tests still have to be written and run. (For similar reasons I still write JSON roundtrip tests even if I derive codecs with Circe, Play JSON, Jsoniter or whatever - the fact that I used derivation doesn't remove the need to write tests, and writing tests don't undermine usability of code generators).

If one intends to make `Option[A] => A` "type-safe", I suggest:

 * replacing the target `A` with `opaque type` or `NewType`
 * optionally, creating a smart constructor for it

then types would enforce a manual intervention.