### PR TITLE
Customize field/subtype name comparison during macro expansion

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -159,7 +159,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
                 if (isVar(setter)) n.stripSuffix("_$eq").stripSuffix("_=") else n
               name -> setter
             }
-            .filter { case (name, _) => !paramTypes.keySet.exists(areNamesMatching(_, name)) }
+            .filter { case (name, _) => !paramTypes.keySet.contains(name) }
             .map { case (name, setter) =>
               val termName = setter.asTerm.name.toTermName
               val tpe = ExistentialType(fromUntyped(paramListsOf(Type[A].tpe, setter).flatten.head.typeSignature))

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -27,11 +27,11 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
       // assuming isAccessor was tested earlier
       def isJavaGetter(getter: MethodSymbol): Boolean =
-        isGetterName(getter.name.toString)
+        ProductTypes.BeanAware.isGetterName(getter.name.toString)
 
       def isJavaSetter(setter: MethodSymbol): Boolean =
         setter.isPublic && setter.paramLists.size == 1 && setter.paramLists.head.size == 1 &&
-          isSetterName(setter.asMethod.name.toString)
+          ProductTypes.BeanAware.isSetterName(setter.asMethod.name.toString)
 
       def isVar(setter: Symbol): Boolean =
         setter.isPublic && setter.isTerm && setter.asTerm.name.toString.endsWith("_$eq")
@@ -159,7 +159,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
                 if (isVar(setter)) n.stripSuffix("_$eq").stripSuffix("_=") else n
               name -> setter
             }
-            .filter { case (name, _) => !paramTypes.keySet.contains(name) }
+            .filter { case (name, _) => !paramTypes.keySet.contains(name) } // _exact_ name match!
             .map { case (name, setter) =>
               val termName = setter.asTerm.name.toTermName
               val tpe = ExistentialType(fromUntyped(paramListsOf(Type[A].tpe, setter).flatten.head.typeSignature))
@@ -249,7 +249,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
     private val getDecodedName = (s: Symbol) => s.name.decodedName.toString
 
-    private val isGarbageSymbol = getDecodedName andThen isGarbage
+    private val isGarbageSymbol = getDecodedName andThen ProductTypes.isGarbageName
 
     // Borrowed from jsoniter-scala: https://github.com/plokhotnyuk/jsoniter-scala/blob/b14dbe51d3ae6752e5a9f90f1f3caf5bceb5e4b0/jsoniter-scala-macros/shared/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala#L462
     private def companionSymbol[A: Type]: Symbol = {

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -179,7 +179,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
           .map { setter =>
             setter.name -> setter
           }
-          .filter { case (name, _) => !paramTypes.keySet.exists(areNamesMatching(_, name)) }
+          .filter { case (name, _) => !paramTypes.keySet.contains(name) }
           .map { case (name, setter) =>
             val tpe = ExistentialType(fromUntyped[Any](paramsWithTypes(A, setter, isConstructor = false).head._2))
             (

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -31,10 +31,11 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
       // assuming isAccessor was tested earlier
       def isJavaGetter(getter: Symbol): Boolean =
-        isGetterName(getter.name)
+        ProductTypes.BeanAware.isGetterName(getter.name)
 
       def isJavaSetter(setter: Symbol): Boolean =
-        setter.isPublic && setter.isDefDef && setter.paramSymss.flatten.size == 1 && isSetterName(setter.name)
+        setter.isPublic && setter.isDefDef && setter.paramSymss.flatten.size == 1 && ProductTypes.BeanAware
+          .isSetterName(setter.name)
 
       def isVar(setter: Symbol): Boolean =
         setter.isPublic && setter.isValDef && setter.flags.is(Flags.Mutable)
@@ -179,7 +180,7 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
           .map { setter =>
             setter.name -> setter
           }
-          .filter { case (name, _) => !paramTypes.keySet.contains(name) }
+          .filter { case (name, _) => !paramTypes.keySet.contains(name) } // _exact_ name match!
           .map { case (name, setter) =>
             val tpe = ExistentialType(fromUntyped[Any](paramsWithTypes(A, setter, isConstructor = false).head._2))
             (
@@ -313,6 +314,6 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
       22 -> TypeRepr.of[scala.Function22]
     )
 
-    private val isGarbageSymbol = ((s: Symbol) => s.name) andThen isGarbage
+    private val isGarbageSymbol = ((s: Symbol) => s.name) andThen ProductTypes.isGarbageName
   }
 }

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -98,13 +98,9 @@ trait ProductTypes { this: Definitions =>
     def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A]
 
     // cached in companion (regexps are expensive to initialize)
-    def areNamesMatching(fromName: String, toName: String): Boolean = ProductTypes.areNamesMatching(fromName, toName)
     def isGarbage(name: String): Boolean = ProductTypes.isGarbage(name)
     def isGetterName(name: String): Boolean = ProductTypes.isGetterName(name)
     def isSetterName(name: String): Boolean = ProductTypes.isSetterName(name)
-    def dropGetIs(name: String): String = ProductTypes.dropGetIs(name)
-    def dropSet(name: String): String = ProductTypes.dropSet(name)
-    def normalize(name: String): String = ProductTypes.normalize(name)
 
     // defaults methods are 1-indexed
     protected def caseClassApplyDefaultScala2(idx: Int): String = "apply$default$" + idx
@@ -167,26 +163,12 @@ object ProductTypes {
     def isMatching(value: String): Boolean = regexp.pattern.matcher(value).matches() // 2.12 doesn't have .matches
   }
 
-  def areNamesMatching(fromName: String, toName: String): Boolean =
-    fromName == toName || normalize(fromName) == normalize(toName)
-
   private val getAccessor = raw"(?i)get(.)(.*)".r
   private val isAccessor = raw"(?i)is(.)(.*)".r
-  val dropGetIs: String => String = {
-    case getAccessor(head, tail) => head.toLowerCase + tail
-    case isAccessor(head, tail)  => head.toLowerCase + tail
-    case other                   => other
-  }
   val isGetterName: String => Boolean = name => getAccessor.isMatching(name) || isAccessor.isMatching(name)
 
   private val setAccessor = raw"(?i)set(.)(.*)".r
-  val dropSet: String => String = {
-    case setAccessor(head, tail) => head.toLowerCase + tail
-    case other                   => other
-  }
   val isSetterName: String => Boolean = name => setAccessor.isMatching(name)
-
-  val normalize: String => String = dropGetIs.andThen(dropSet)
 
   // methods we can drop from searching scope
   private val garbage = Set(

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -226,6 +226,23 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
               Some(A.param_<[dsls.ImplicitTransformerPreference](0))
             else scala.None
         }
+        object FieldNameComparison extends FieldNameComparisonModule {
+          def apply[C <: dsls.TransformedNamesComparison: Type]: Type[runtime.TransformerFlags.FieldNameComparison[C]] =
+            weakTypeTag[runtime.TransformerFlags.FieldNameComparison[C]]
+          def unapply[A](A: Type[A]): Option[?<[dsls.TransformedNamesComparison]] =
+            if (A.isCtor[runtime.TransformerFlags.FieldNameComparison[?]])
+              Some(A.param_<[dsls.TransformedNamesComparison](0))
+            else scala.None
+        }
+        object SubtypeNameComparison extends SubtypeNameComparisonModule {
+          def apply[C <: dsls.TransformedNamesComparison: Type]
+              : Type[runtime.TransformerFlags.SubtypeNameComparison[C]] =
+            weakTypeTag[runtime.TransformerFlags.SubtypeNameComparison[C]]
+          def unapply[A](A: Type[A]): Option[?<[dsls.TransformedNamesComparison]] =
+            if (A.isCtor[runtime.TransformerFlags.SubtypeNameComparison[?]])
+              Some(A.param_<[dsls.TransformedNamesComparison](0))
+            else scala.None
+        }
         val MacrosLogging: Type[runtime.TransformerFlags.MacrosLogging] =
           weakTypeTag[runtime.TransformerFlags.MacrosLogging]
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -216,6 +216,23 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
               Some(Type[r].as_?<[dsls.ImplicitTransformerPreference])
             case _ => scala.None
         }
+        object FieldNameComparison extends FieldNameComparisonModule {
+          def apply[C <: dsls.TransformedNamesComparison: Type]: Type[runtime.TransformerFlags.FieldNameComparison[C]] =
+            quoted.Type.of[runtime.TransformerFlags.FieldNameComparison[C]]
+          def unapply[A](tpe: Type[A]): Option[?<[dsls.TransformedNamesComparison]] = tpe match
+            case '[runtime.TransformerFlags.FieldNameComparison[c]] =>
+              Some(Type[c].as_?<[dsls.TransformedNamesComparison])
+            case _ => scala.None
+        }
+        object SubtypeNameComparison extends SubtypeNameComparisonModule {
+          def apply[C <: dsls.TransformedNamesComparison: Type]
+              : Type[runtime.TransformerFlags.SubtypeNameComparison[C]] =
+            quoted.Type.of[runtime.TransformerFlags.SubtypeNameComparison[C]]
+          def unapply[A](tpe: Type[A]): Option[?<[dsls.TransformedNamesComparison]] = tpe match
+            case '[runtime.TransformerFlags.SubtypeNameComparison[c]] =>
+              Some(Type[c].as_?<[dsls.TransformedNamesComparison])
+            case _ => scala.None
+        }
         val MacrosLogging: Type[runtime.TransformerFlags.MacrosLogging] =
           quoted.Type.of[runtime.TransformerFlags.MacrosLogging]
       }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -5,27 +5,15 @@ package io.scalaland.chimney.dsl
 abstract class TransformedNamesComparison { this: Singleton =>
 
   def namesMatch(fromName: String, toName: String): Boolean
-  def dropSet(name: String): String
 }
 object TransformedNamesComparison {
 
   object BeanAware extends TransformedNamesComparison {
 
-    private val getAccessor = raw"(?i)get(.)(.*)".r
-    private val isAccessor = raw"(?i)is(.)(.*)".r
-    private val setAccessor = raw"(?i)set(.)(.*)".r
-
-    override def dropSet(name: String): String = name match {
-      case setAccessor(head, tail) => head.toLowerCase + tail
-      case other                   => other
-    }
-
-    private val dropGetIs: String => String = {
-      case getAccessor(head, tail) => head.toLowerCase + tail
-      case isAccessor(head, tail)  => head.toLowerCase + tail
-      case other                   => other
-    }
-    private val normalize: String => String = dropGetIs.andThen(dropSet)
+    // While it's bad to refer to compiletime package this code should only be used by this compiletime package.
+    // Additionally, current module has to rely on chimney-macro-commons, not the other way round.
+    import io.scalaland.chimney.internal.compiletime.datatypes.ProductTypes
+    private val normalize = ProductTypes.BeanAware.dropGetIs andThen ProductTypes.BeanAware.dropSet
 
     def namesMatch(fromName: String, toName: String): Boolean =
       fromName == toName || normalize(fromName) == normalize(toName)
@@ -34,13 +22,11 @@ object TransformedNamesComparison {
   object StrictEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName == toName
-    override def dropSet(name: String): String = name
   }
 
   object CaseInsensitiveEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
-    override def dropSet(name: String): String = name
   }
 
   type FieldDefault = BeanAware.type

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -1,0 +1,33 @@
+package io.scalaland.chimney.dsl
+
+// TODO: documentation
+
+abstract class TransformedNamesComparison { this: Singleton =>
+
+  def namesMatch(fromName: String, toName: String): Boolean
+}
+object TransformedNamesComparison {
+
+  object BeanAware extends TransformedNamesComparison {
+
+    def namesMatch(fromName: String, toName: String): Boolean =
+      // TODO: move logic here, so that dsl would not have a dependency on internal.compiletime
+      io.scalaland.chimney.internal.compiletime.datatypes.ProductTypes.areNamesMatching(fromName, toName)
+  }
+
+  object StrictEquality extends TransformedNamesComparison {
+
+    def namesMatch(fromName: String, toName: String): Boolean = fromName == toName
+  }
+
+  object CaseInsensitiveEquality extends TransformedNamesComparison {
+
+    def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
+  }
+
+  type FieldDefault = BeanAware.type
+  val FieldDefault: FieldDefault = BeanAware
+
+  type SubtypeDefault = StrictEquality.type
+  val SubtypeDefault: SubtypeDefault = StrictEquality
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -8,7 +8,7 @@ abstract class TransformedNamesComparison { this: Singleton =>
 }
 object TransformedNamesComparison {
 
-  object BeanAware extends TransformedNamesComparison {
+  case object BeanAware extends TransformedNamesComparison {
 
     // While it's bad to refer to compiletime package this code should only be used by this compiletime package.
     // Additionally, current module has to rely on chimney-macro-commons, not the other way round.
@@ -19,12 +19,12 @@ object TransformedNamesComparison {
       fromName == toName || normalize(fromName) == normalize(toName)
   }
 
-  object StrictEquality extends TransformedNamesComparison {
+  case object StrictEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName == toName
   }
 
-  object CaseInsensitiveEquality extends TransformedNamesComparison {
+  case object CaseInsensitiveEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -1,13 +1,26 @@
 package io.scalaland.chimney.dsl
 
-// TODO: documentation
-
+/** Provides a way of customizing how fields/subtypes shoud get matched betwen source value and target value.
+  *
+  * @see [[https://chimney.readthedocs.io/supported-transformations/#defining-custom-name-matching-predicate]] for more details
+  *
+  * @since 1.0.0
+  */
 abstract class TransformedNamesComparison { this: Singleton =>
 
+  /** Return true if `fromName` should be considered a match for `toName`.
+    *
+    * @param fromName name of a field/subtype in the source type
+    * @param toName   name of a field/subtype in the target type
+    * @return         whether fromName should be used as a source for value in toName
+    */
   def namesMatch(fromName: String, toName: String): Boolean
 }
+
+/** @since 1.0.0 */
 object TransformedNamesComparison {
 
+  /** Matches names, dropping is/get/set prefixes and then lowercasing the first letter if it was a Bean name. */
   case object BeanAware extends TransformedNamesComparison {
 
     // While it's bad to refer to compiletime package this code should only be used by this compiletime package.
@@ -19,11 +32,13 @@ object TransformedNamesComparison {
       fromName == toName || normalize(fromName) == normalize(toName)
   }
 
+  /** Matches only the same Strings. */
   case object StrictEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName == toName
   }
 
+  /** Matches Strings ignoring upper/lower case distinction. */
   case object CaseInsensitiveEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -5,24 +5,42 @@ package io.scalaland.chimney.dsl
 abstract class TransformedNamesComparison { this: Singleton =>
 
   def namesMatch(fromName: String, toName: String): Boolean
+  def dropSet(name: String): String
 }
 object TransformedNamesComparison {
 
   object BeanAware extends TransformedNamesComparison {
 
+    private val getAccessor = raw"(?i)get(.)(.*)".r
+    private val isAccessor = raw"(?i)is(.)(.*)".r
+    private val setAccessor = raw"(?i)set(.)(.*)".r
+
+    override def dropSet(name: String): String = name match {
+      case setAccessor(head, tail) => head.toLowerCase + tail
+      case other                   => other
+    }
+
+    private val dropGetIs: String => String = {
+      case getAccessor(head, tail) => head.toLowerCase + tail
+      case isAccessor(head, tail)  => head.toLowerCase + tail
+      case other                   => other
+    }
+    private val normalize: String => String = dropGetIs.andThen(dropSet)
+
     def namesMatch(fromName: String, toName: String): Boolean =
-      // TODO: move logic here, so that dsl would not have a dependency on internal.compiletime
-      io.scalaland.chimney.internal.compiletime.datatypes.ProductTypes.areNamesMatching(fromName, toName)
+      fromName == toName || normalize(fromName) == normalize(toName)
   }
 
   object StrictEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName == toName
+    override def dropSet(name: String): String = name
   }
 
   object CaseInsensitiveEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
+    override def dropSet(name: String): String = name
   }
 
   type FieldDefault = BeanAware.type

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -200,7 +200,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
     *
     * @param namesComparison parameter specifying how names should be compared by macro
     *
-    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#customizing-field-name-matching]] for more details
     *
     * @since 1.0.0
     */
@@ -211,7 +211,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Disable any custom way of comparing if source fields' names and target fields' names are matching.
     *
-    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#customizing-field-name-matching]] for more details
     *
     * @since 1.0.0
     */
@@ -222,7 +222,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
     *
     * @param namesComparison parameter specifying how names should be compared by macro
     *
-    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#customizing-subtype-name-matching]] for more details
     *
     * @since 1.0.0
     */
@@ -233,7 +233,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Disable any custom way of comparing if source subtypes' names and target fields' names are matching.
     *
-    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#customizing-subtype-name-matching]] for more details
     *
     * @since 1.0.0
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -196,6 +196,50 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
   def disableImplicitConflictResolution: UpdateFlag[Disable[ImplicitConflictResolution[?], Flags]] =
     disableFlag[ImplicitConflictResolution[?]]
 
+  /** Enable custom way of comparing if source fields' names and target fields' names are matching.
+    *
+    * @param namesComparison parameter specifying how names should be compared by macro
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @since 1.0.0
+    */
+  def enableCustomFieldNameComparison[C <: TransformedNamesComparison & Singleton](
+      @unused namesComparison: C
+  ): UpdateFlag[Enable[FieldNameComparison[C], Flags]] =
+    enableFlag[FieldNameComparison[C]]
+
+  /** Disable any custom way of comparing if source fields' names and target fields' names are matching.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @since 1.0.0
+    */
+  def disableCustomFieldNameComparison: UpdateFlag[Disable[FieldNameComparison[?], Flags]] =
+    disableFlag[FieldNameComparison[?]]
+
+  /** Enable custom way of comparing if source subtypes' names and target fields' names are matching.
+    *
+    * @param namesComparison parameter specifying how names should be compared by macro
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @since 1.0.0
+    */
+  def enableCustomSubtypeNameComparison[C <: TransformedNamesComparison & Singleton](
+      @unused namesComparison: C
+  ): UpdateFlag[Enable[SubtypeNameComparison[C], Flags]] =
+    enableFlag[SubtypeNameComparison[C]]
+
+  /** Disable any custom way of comparing if source subtypes' names and target fields' names are matching.
+    *
+    * @see [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @since 1.0.0
+    */
+  def disableCustomSubtypeNameComparison: UpdateFlag[Disable[SubtypeNameComparison[?], Flags]] =
+    disableFlag[SubtypeNameComparison[?]]
+
   /** Enable printing the logs from the derivation process.
     *
     * @see [[https://chimney.readthedocs.io/troubleshooting/#debugging-macros]] for more details

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -181,6 +181,18 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
               dsls.ImplicitTransformerPreference,
               runtime.TransformerFlags.ImplicitConflictResolution
             ] { this: ImplicitConflictResolution.type => }
+        val FieldNameComparison: FieldNameComparisonModule
+        trait FieldNameComparisonModule
+            extends Type.Ctor1UpperBounded[
+              dsls.TransformedNamesComparison,
+              runtime.TransformerFlags.FieldNameComparison
+            ] { this: FieldNameComparison.type => }
+        val SubtypeNameComparison: SubtypeNameComparisonModule
+        trait SubtypeNameComparisonModule
+            extends Type.Ctor1UpperBounded[
+              dsls.TransformedNamesComparison,
+              runtime.TransformerFlags.SubtypeNameComparison
+            ] { this: SubtypeNameComparison.type => }
         val MacrosLogging: Type[runtime.TransformerFlags.MacrosLogging]
       }
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -19,8 +19,8 @@ private[compiletime] trait Configurations { this: Derivation =>
       optionDefaultsToNone: Boolean = false,
       partialUnwrapsOption: Boolean = true,
       implicitConflictResolution: Option[ImplicitTransformerPreference] = None,
-      fieldNameComparison: dsls.TransformedNamesComparison = dsls.TransformedNamesComparison.FieldDefault,
-      subtypeNameComparison: dsls.TransformedNamesComparison = dsls.TransformedNamesComparison.SubtypeDefault,
+      fieldNameComparison: Option[dsls.TransformedNamesComparison] = None,
+      subtypeNameComparison: Option[dsls.TransformedNamesComparison] = None,
       displayMacrosLogging: Boolean = false
   ) {
 
@@ -52,10 +52,10 @@ private[compiletime] trait Configurations { this: Derivation =>
     def setImplicitConflictResolution(preference: Option[ImplicitTransformerPreference]): TransformerFlags =
       copy(implicitConflictResolution = preference)
 
-    def setFieldNameComparison(nameComparison: dsls.TransformedNamesComparison): TransformerFlags =
+    def setFieldNameComparison(nameComparison: Option[dsls.TransformedNamesComparison]): TransformerFlags =
       copy(fieldNameComparison = nameComparison)
 
-    def setSubtypeNameComparison(nameComparison: dsls.TransformedNamesComparison): TransformerFlags =
+    def setSubtypeNameComparison(nameComparison: Option[dsls.TransformedNamesComparison]): TransformerFlags =
       copy(subtypeNameComparison = nameComparison)
 
     override def toString: String = s"TransformerFlags(${Vector(
@@ -66,6 +66,8 @@ private[compiletime] trait Configurations { this: Derivation =>
         if (beanGetters) Vector("beanGetters") else Vector.empty,
         if (optionDefaultsToNone) Vector("optionDefaultsToNone") else Vector.empty,
         implicitConflictResolution.map(r => s"ImplicitTransformerPreference=$r").toList.toVector,
+        fieldNameComparison.map(r => s"fieldNameComparison=$r").toList.toVector,
+        subtypeNameComparison.map(r => s"subtypeNameComparison=$r").toList.toVector,
         if (displayMacrosLogging) Vector("displayMacrosLogging") else Vector.empty
       ).flatten.mkString(", ")})"
   }
@@ -282,12 +284,12 @@ private[compiletime] trait Configurations { this: Derivation =>
           case ChimneyType.TransformerFlags.Flags.FieldNameComparison(c) =>
             import c.Underlying as Comparison
             extractTransformerFlags[Flags2](defaultFlags).setFieldNameComparison(
-              extractNameComparisonObject[Comparison]
+              Some(extractNameComparisonObject[Comparison])
             )
           case ChimneyType.TransformerFlags.Flags.SubtypeNameComparison(c) =>
             import c.Underlying as Comparison
-            extractTransformerFlags[Flags2](defaultFlags).setFieldNameComparison(
-              extractNameComparisonObject[Comparison]
+            extractTransformerFlags[Flags2](defaultFlags).setSubtypeNameComparison(
+              Some(extractNameComparisonObject[Comparison])
             )
           case _ =>
             extractTransformerFlags[Flags2](defaultFlags).setBoolFlag[Flag](value = true)
@@ -298,13 +300,9 @@ private[compiletime] trait Configurations { this: Derivation =>
           case ChimneyType.TransformerFlags.Flags.ImplicitConflictResolution(_) =>
             extractTransformerFlags[Flags2](defaultFlags).setImplicitConflictResolution(None)
           case ChimneyType.TransformerFlags.Flags.FieldNameComparison(_) =>
-            extractTransformerFlags[Flags2](defaultFlags).setFieldNameComparison(
-              dsls.TransformedNamesComparison.FieldDefault
-            )
+            extractTransformerFlags[Flags2](defaultFlags).setFieldNameComparison(None)
           case ChimneyType.TransformerFlags.Flags.SubtypeNameComparison(_) =>
-            extractTransformerFlags[Flags2](defaultFlags).setSubtypeNameComparison(
-              dsls.TransformedNamesComparison.SubtypeDefault
-            )
+            extractTransformerFlags[Flags2](defaultFlags).setSubtypeNameComparison(None)
           case _ =>
             extractTransformerFlags[Flags2](defaultFlags).setBoolFlag[Flag](value = false)
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -132,9 +132,6 @@ private[compiletime] trait Configurations { this: Derivation =>
     }
   }
   final protected case class DownField(nameFilter: String => Boolean) extends FieldPathUpdate
-  protected object DownField {
-    def apply(name: String): DownField = DownField(ProductType.areNamesMatching(_, name))
-  }
   protected case object KeepFieldOverrides extends FieldPathUpdate
   protected case object CleanFieldOverrides extends FieldPathUpdate
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -19,6 +19,8 @@ private[compiletime] trait Configurations { this: Derivation =>
       optionDefaultsToNone: Boolean = false,
       partialUnwrapsOption: Boolean = true,
       implicitConflictResolution: Option[ImplicitTransformerPreference] = None,
+      fieldNameComparison: dsls.TransformedNamesComparison = dsls.TransformedNamesComparison.FieldDefault,
+      subtypeNameComparison: dsls.TransformedNamesComparison = dsls.TransformedNamesComparison.SubtypeDefault,
       displayMacrosLogging: Boolean = false
   ) {
 
@@ -49,6 +51,12 @@ private[compiletime] trait Configurations { this: Derivation =>
 
     def setImplicitConflictResolution(preference: Option[ImplicitTransformerPreference]): TransformerFlags =
       copy(implicitConflictResolution = preference)
+
+    def setFieldNameComparison(nameComparison: dsls.TransformedNamesComparison): TransformerFlags =
+      copy(fieldNameComparison = nameComparison)
+
+    def setSubtypeNameComparison(nameComparison: dsls.TransformedNamesComparison): TransformerFlags =
+      copy(subtypeNameComparison = nameComparison)
 
     override def toString: String = s"TransformerFlags(${Vector(
         if (inheritedAccessors) Vector("inheritedAccessors") else Vector.empty,
@@ -274,6 +282,16 @@ private[compiletime] trait Configurations { this: Derivation =>
               reportError("Invalid ImplicitTransformerPreference type!!")
               // $COVERAGE-ON$
             }
+          case ChimneyType.TransformerFlags.Flags.FieldNameComparison(c) =>
+            import c.Underlying as Comparison
+            extractTransformerFlags[Flags2](defaultFlags).setFieldNameComparison(
+              extractNameComparisonObject[Comparison]
+            )
+          case ChimneyType.TransformerFlags.Flags.SubtypeNameComparison(c) =>
+            import c.Underlying as Comparison
+            extractTransformerFlags[Flags2](defaultFlags).setFieldNameComparison(
+              extractNameComparisonObject[Comparison]
+            )
           case _ =>
             extractTransformerFlags[Flags2](defaultFlags).setBoolFlag[Flag](value = true)
         }
@@ -282,6 +300,14 @@ private[compiletime] trait Configurations { this: Derivation =>
         Flag match {
           case ChimneyType.TransformerFlags.Flags.ImplicitConflictResolution(_) =>
             extractTransformerFlags[Flags2](defaultFlags).setImplicitConflictResolution(None)
+          case ChimneyType.TransformerFlags.Flags.FieldNameComparison(_) =>
+            extractTransformerFlags[Flags2](defaultFlags).setFieldNameComparison(
+              dsls.TransformedNamesComparison.FieldDefault
+            )
+          case ChimneyType.TransformerFlags.Flags.SubtypeNameComparison(_) =>
+            extractTransformerFlags[Flags2](defaultFlags).setSubtypeNameComparison(
+              dsls.TransformedNamesComparison.SubtypeDefault
+            )
           case _ =>
             extractTransformerFlags[Flags2](defaultFlags).setBoolFlag[Flag](value = false)
         }
@@ -371,5 +397,14 @@ private[compiletime] trait Configurations { this: Derivation =>
         reportError(s"Invalid internal Path shape: ${Type.prettyPrint[Field]}!!")
       // $COVERAGE-ON$
     }
+
+    private def extractNameComparisonObject[Comparison <: dsls.TransformedNamesComparison: Type]: Comparison =
+      // TODO: implement this based on https://github.com/MateuszKubuszok/MacroTypeclass ideas
+
+      // $COVERAGE-OFF$
+      reportError(
+        s"Invalid TransformerNamesComparison type - only global objects are allowed: ${Type.prettyPrint[Comparison]}!!"
+      )
+    // $COVERAGE-ON$
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -398,13 +398,35 @@ private[compiletime] trait Configurations { this: Derivation =>
       // $COVERAGE-ON$
     }
 
-    private def extractNameComparisonObject[Comparison <: dsls.TransformedNamesComparison: Type]: Comparison =
-      // TODO: implement this based on https://github.com/MateuszKubuszok/MacroTypeclass ideas
+    // TODO: consider moving this utils to Type and requiring <: Singleton type-bound
+    private val AnsiControlCode = "\u001b\\[([0-9]+)m".r
+    private def extractNameComparisonObject[Comparison <: dsls.TransformedNamesComparison: Type]: Comparison = {
+      // based on https://github.com/MateuszKubuszok/MacroTypeclass ideas
+      object Comparison {
+        def unapply(className: String): Option[Comparison] =
+          try
+            Option(Class.forName(className).getField("MODULE$").get(null).asInstanceOf[Comparison])
+          catch {
+            case _: Throwable => None
+          }
+      }
 
-      // $COVERAGE-OFF$
-      reportError(
-        s"Invalid TransformerNamesComparison type - only global objects are allowed: ${Type.prettyPrint[Comparison]}!!"
-      )
-    // $COVERAGE-ON$
+      // assuming this is "foo.bar.baz"...
+      val name = AnsiControlCode.replaceAllIn(Type.prettyPrint[Comparison], "")
+
+      Iterator
+        .iterate(name.replace('.', '$') + '$')(_.replaceFirst("\\$", "."))
+        .take(name.count(_ == '.') + 1) // ...then this is: "foo$bar$baz$", "foo.bar$baz$", "foo.bar.baz$"...
+        .toArray
+        .reverse // ...and this is: "foo.bar.baz$", "foo.bar$baz$", "foo$bar$baz$"
+        .collectFirst { case Comparison(value) => value } // attempts: top-level object, object in object, etc
+        .getOrElse {
+          // $COVERAGE-OFF$
+          reportError(
+            s"Invalid TransformerNamesComparison type - only global objects are allowed: ${Type.prettyPrint[Comparison]}!!"
+          )
+          // $COVERAGE-ON$
+        }
+    }
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -410,8 +410,8 @@ private[compiletime] trait Configurations { this: Derivation =>
       val name = AnsiControlCode.replaceAllIn(Type.prettyPrint[Comparison], "")
 
       Iterator
-        .iterate(name.replace('.', '$') + '$')(_.replaceFirst("\\$", "."))
-        .take(name.count(_ == '.') + 1) // ...then this is: "foo$bar$baz$", "foo.bar$baz$", "foo.bar.baz$"...
+        .iterate(name + '$')(_.reverse.replaceFirst("[.]", "\\$").reverse)
+        .take(name.count(_ == '.') + 1) // ...then this is: "foo.bar.baz$", "foo.bar$baz$", "foo$bar$baz$"...
         .toArray
         .reverse // ...and this is: "foo.bar.baz$", "foo.bar$baz$", "foo$bar$baz$"
         .collectFirst { case Comparison(value) => value } // attempts: top-level object, object in object, etc

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -418,7 +418,8 @@ private[compiletime] trait Configurations { this: Derivation =>
         .getOrElse {
           // $COVERAGE-OFF$
           reportError(
-            s"Invalid TransformerNamesComparison type - only global objects are allowed: ${Type.prettyPrint[Comparison]}!!"
+            s"Invalid TransformerNamesComparison type - only (case) objects are allowed, and only the ones defined as top-level or in top-level objects, got: ${Type
+                .prettyPrint[Comparison]}!!!"
           )
           // $COVERAGE-ON$
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer
 
-import io.scalaland.chimney.dsl.TransformerDefinitionCommons
+import io.scalaland.chimney.dsl.{TransformedNamesComparison, TransformerDefinitionCommons}
 import io.scalaland.chimney.partial
 
 private[compiletime] trait Contexts { this: Derivation =>
@@ -169,11 +169,13 @@ private[compiletime] trait Contexts { this: Derivation =>
   implicit def areFieldNamesMatching(fromName: String, toName: String)(implicit
       ctx: TransformationContext[?, ?]
   ): Boolean =
-    ctx.config.flags.fieldNameComparison.namesMatch(fromName, toName)
+    ctx.config.flags.fieldNameComparison.getOrElse(TransformedNamesComparison.FieldDefault).namesMatch(fromName, toName)
   implicit def areSubtypeNamesMatching(fromName: String, toName: String)(implicit
       ctx: TransformationContext[?, ?]
   ): Boolean =
-    ctx.config.flags.subtypeNameComparison.namesMatch(fromName, toName)
+    ctx.config.flags.subtypeNameComparison
+      .getOrElse(TransformedNamesComparison.SubtypeDefault)
+      .namesMatch(fromName, toName)
 
   // for unpacking Exprs from Context, pattern matching should be enough
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
@@ -166,5 +166,14 @@ private[compiletime] trait Contexts { this: Derivation =>
     ctx.From
   implicit final protected def ctx2ToType[From, To](implicit ctx: TransformationContext[From, To]): Type[To] = ctx.To
 
+  implicit def areFieldNamesMatching(fromName: String, toName: String)(implicit
+      ctx: TransformationContext[?, ?]
+  ): Boolean =
+    ctx.config.flags.fieldNameComparison.namesMatch(fromName, toName)
+  implicit def areSubtypeNamesMatching(fromName: String, toName: String)(implicit
+      ctx: TransformationContext[?, ?]
+  ): Boolean =
+    ctx.config.flags.subtypeNameComparison.namesMatch(fromName, toName)
+
   // for unpacking Exprs from Context, pattern matching should be enough
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -97,7 +97,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
       val verifyNoOverrideUnused = Traverse[List]
         .parTraverse(
           filterOverridesForField(fromName =>
-            !parameters.keys.exists(toName => flags.fieldNameComparison.namesMatch(fromName, toName))
+            !parameters.keys.exists(toName => areFieldNamesMatching(fromName, toName))
           ).keys.toList
         ) { fromName =>
           val tpeStr = Type.prettyPrint[To]
@@ -134,7 +134,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
             import ctorParam.Underlying as CtorParam, ctorParam.value.defaultValue
             // user might have used _.getName in modifier, to define target we know as _.setName
             // so simple .get(toName) might not be enough
-            filterOverridesForField(fromName => flags.fieldNameComparison.namesMatch(fromName, toName)).headOption
+            filterOverridesForField(fromName => areFieldNamesMatching(fromName, toName)).headOption
               .map { case (fromName, value) =>
                 useOverride[From, To, CtorParam](fromName, toName, value)
               }
@@ -143,7 +143,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                   if (usePositionBasedMatching) ctorParamToGetter.get(ctorParam)
                   else
                     fromEnabledExtractors.collectFirst {
-                      case (fromName, getter) if flags.fieldNameComparison.namesMatch(fromName, toName) =>
+                      case (fromName, getter) if areFieldNamesMatching(fromName, toName) =>
                         (fromName, toName, getter)
                     }
                 resolvedExtractor

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -5,6 +5,7 @@ import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivati
 import io.scalaland.chimney.internal.compiletime.fp.Implicits.*
 import io.scalaland.chimney.internal.compiletime.fp.Traverse
 import io.scalaland.chimney.partial
+import io.scalaland.chimney.internal.compiletime.datatypes.ProductTypes
 
 private[compiletime] trait TransformProductToProductRuleModule { this: Derivation =>
 
@@ -164,9 +165,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                       DerivationResult
                         .missingAccessor[From, To, CtorParam, Existential[TransformationExpr]](
                           toName,
-                          fromExtractors.exists { case (fromName, _) =>
-                            flags.fieldNameComparison.namesMatch(fromName, toName)
-                          }
+                          fromExtractors.exists { case (fromName, _) => areFieldNamesMatching(fromName, toName) }
                         )
                     case Product.Parameter.TargetType.SetterParameter =>
                       if (flags.beanSettersIgnoreUnmatched)
@@ -175,10 +174,8 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                         // TODO: update this for isLocal
                         DerivationResult
                           .missingJavaBeanSetterParam[From, To, CtorParam, Existential[TransformationExpr]](
-                            flags.fieldNameComparison.dropSet(toName),
-                            fromExtractors.exists { case (fromName, _) =>
-                              flags.fieldNameComparison.namesMatch(fromName, toName)
-                            }
+                            ProductTypes.BeanAware.dropSet(toName),
+                            fromExtractors.exists { case (fromName, _) => areFieldNamesMatching(fromName, toName) }
                           )
                   }
               }
@@ -329,7 +326,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               // '{ ${ derivedToElement } } // using ${ src.$name }
               deriveRecursiveTransformationExpr[ExtractedSrc, CtorParam](
                 extractedSrcExpr,
-                new DownField(ctx.config.flags.fieldNameComparison.namesMatch(_, toName))
+                new DownField(areFieldNamesMatching(_, toName))
               ).transformWith { expr =>
                 // If we derived partial.Result[$ctorParam] we are appending
                 //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))
@@ -364,7 +361,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
           // '{ ${ derivedToElement } } // using ${ src.$name }
           deriveRecursiveTransformationExpr[Getter, CtorParam](
             get(ctx.src),
-            new DownField(ctx.config.flags.fieldNameComparison.namesMatch(_, toName))
+            new DownField(areFieldNamesMatching(_, toName))
           ).transformWith { expr =>
             // If we derived partial.Result[$ctorParam] we are appending
             //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -107,7 +107,9 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
         ctx: TransformationContext[From, To]
     ): DerivationResult[Existential[ExprPromise[*, TransformationExpr[To]]]] = {
       import fromSubtype.Underlying as FromSubtype, fromSubtype.value.name as fromName
-      toElements.filter(toSubtype => enumNamesMatch(fromName, toSubtype.value.name)).toList match {
+      toElements.filter(toSubtype =>
+        ctx.config.flags.subtypeNameComparison.namesMatch(fromName, toSubtype.value.name)
+      ) match {
         // 0 matches - no coproduct with the same name
         case Nil =>
           DerivationResult
@@ -223,7 +225,5 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
             }
             .matchOn(ctx.src)
         )
-
-    private def enumNamesMatch(fromName: String, toName: String): Boolean = fromName == toName
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -107,9 +107,7 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
         ctx: TransformationContext[From, To]
     ): DerivationResult[Existential[ExprPromise[*, TransformationExpr[To]]]] = {
       import fromSubtype.Underlying as FromSubtype, fromSubtype.value.name as fromName
-      toElements.filter(toSubtype =>
-        ctx.config.flags.subtypeNameComparison.namesMatch(fromName, toSubtype.value.name)
-      ) match {
+      toElements.filter(toSubtype => areSubtypeNamesMatching(fromName, toSubtype.value.name)) match {
         // 0 matches - no coproduct with the same name
         case Nil =>
           DerivationResult

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
@@ -24,7 +24,7 @@ private[compiletime] trait TransformTypeToValueClassRuleModule {
   )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
     deriveRecursiveTransformationExpr[From, InnerTo](
       ctx.src,
-      new DownField(ctx.config.flags.fieldNameComparison.namesMatch(_, valueTo.fieldName))
+      new DownField(areFieldNamesMatching(_, valueTo.fieldName))
     ).flatMap { derivedInnerTo =>
       // We're constructing:
       // '{ new $To(${ derivedInnerTo }) }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
@@ -22,10 +22,12 @@ private[compiletime] trait TransformValueClassToValueClassRuleModule { this: Der
       valueFrom: ValueClass[From, InnerFrom],
       valueTo: ValueClass[To, InnerTo]
   )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
-    deriveRecursiveTransformationExpr[InnerFrom, InnerTo](valueFrom.unwrap(ctx.src), DownField(valueTo.fieldName))
-      .flatMap { (derivedInnerTo: TransformationExpr[InnerTo]) =>
-        // We're constructing:
-        // '{ ${ new $To(${ derivedInnerTo }) } /* using ${ src }.$from internally */ }
-        DerivationResult.expanded(derivedInnerTo.map(valueTo.wrap))
-      }
+    deriveRecursiveTransformationExpr[InnerFrom, InnerTo](
+      valueFrom.unwrap(ctx.src),
+      new DownField(ctx.config.flags.fieldNameComparison.namesMatch(_, valueTo.fieldName))
+    ).flatMap { (derivedInnerTo: TransformationExpr[InnerTo]) =>
+      // We're constructing:
+      // '{ ${ new $To(${ derivedInnerTo }) } /* using ${ src }.$from internally */ }
+      DerivationResult.expanded(derivedInnerTo.map(valueTo.wrap))
+    }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
@@ -24,7 +24,7 @@ private[compiletime] trait TransformValueClassToValueClassRuleModule { this: Der
   )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
     deriveRecursiveTransformationExpr[InnerFrom, InnerTo](
       valueFrom.unwrap(ctx.src),
-      new DownField(ctx.config.flags.fieldNameComparison.namesMatch(_, valueTo.fieldName))
+      new DownField(areFieldNamesMatching(_, valueTo.fieldName))
     ).flatMap { (derivedInnerTo: TransformationExpr[InnerTo]) =>
       // We're constructing:
       // '{ ${ new $To(${ derivedInnerTo }) } /* using ${ src }.$from internally */ }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney.internal.runtime
 
-import io.scalaland.chimney.dsl.ImplicitTransformerPreference
+import io.scalaland.chimney.dsl.{ImplicitTransformerPreference, TransformedNamesComparison}
 
 sealed abstract class TransformerFlags
 object TransformerFlags {
@@ -18,5 +18,7 @@ object TransformerFlags {
   final class OptionDefaultsToNone extends Flag
   final class PartialUnwrapsOption extends Flag
   final class ImplicitConflictResolution[R <: ImplicitTransformerPreference] extends Flag
+  final class FieldNameComparison[C <: TransformedNamesComparison] extends Flag
+  final class SubtypeNameComparison[C <: TransformedNamesComparison] extends Flag
   final class MacrosLogging extends Flag
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -1165,6 +1165,20 @@ class PartialTransformerProductSpec extends ChimneySpec {
       )
     }
 
+    test("should inform user if and why the setting cannot be read") {
+      @unused object BadNameComparison extends TransformedNamesComparison {
+
+        def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
+      }
+
+      compileErrorsFixed(
+        """Foo(Foo.Baz("test"), 1024).intoPartial[Bar].enableCustomFieldNameComparison(BadNameComparison).transform"""
+      )
+        .check(
+          "Invalid TransformerNamesComparison type - only (case) objects are allowed, and only the ones defined as top-level or in top-level objects, got: io.scalaland.chimney.PartialTransformerProductSpec.BadNameComparison!!!"
+        )
+    }
+
     test("should allow fields to be matched using user-provided predicate") {
 
       val result = Foo(Foo.Baz("test"), 1024)

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
@@ -404,6 +404,18 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
       )
     }
 
+    test("should inform user if and why the setting cannot be read") {
+      @unused object BadNameComparison extends TransformedNamesComparison {
+
+        def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
+      }
+
+      compileErrorsFixed("""(Foo.BAZ: Foo).into[Bar].enableCustomSubtypeNameComparison(BadNameComparison).transform""")
+        .check(
+          "Invalid TransformerNamesComparison type - only (case) objects are allowed, and only the ones defined as top-level or in top-level objects, got: io.scalaland.chimney.PartialTransformerSealedHierarchySpec.BadNameComparison!!!"
+        )
+    }
+
     test("should allow subtypes to be matched using user-provided predicate") {
       val result = (Foo.BAZ: Foo)
         .intoPartial[Bar]

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -612,6 +612,20 @@ class TotalTransformerProductSpec extends ChimneySpec {
       )
     }
 
+    test("should inform user if and why the setting cannot be read") {
+      @unused object BadNameComparison extends TransformedNamesComparison {
+
+        def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
+      }
+
+      compileErrorsFixed(
+        """Foo(Foo.Baz("test"), 1024).into[Bar].enableCustomFieldNameComparison(BadNameComparison).transform"""
+      )
+        .check(
+          "Invalid TransformerNamesComparison type - only (case) objects are allowed, and only the ones defined as top-level or in top-level objects, got: io.scalaland.chimney.TotalTransformerProductSpec.BadNameComparison!!!"
+        )
+    }
+
     test("should allow fields to be matched using user-provided predicate") {
 
       Foo(Foo.Baz("test"), 1024)

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -243,6 +243,18 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
       )
     }
 
+    test("should inform user if and why the setting cannot be read") {
+      @unused object BadNameComparison extends TransformedNamesComparison {
+
+        def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
+      }
+
+      compileErrorsFixed("""(Foo.BAZ: Foo).into[Bar].enableCustomSubtypeNameComparison(BadNameComparison).transform""")
+        .check(
+          "Invalid TransformerNamesComparison type - only (case) objects are allowed, and only the ones defined as top-level or in top-level objects, got: io.scalaland.chimney.TotalTransformerSealedHierarchySpec.BadNameComparison!!!"
+        )
+    }
+
     test("should allow subtypes to be matched using user-provided predicate") {
       (Foo.BAZ: Foo)
         .into[Bar]

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -199,4 +199,100 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
       )
     }
   }
+
+  group("flag .enableCustomSubtypeNameComparison") {
+
+    import fixtures.renames.Subtypes.*
+
+    test("should be disabled by default") {
+
+      compileErrorsFixed("""(Foo.BAZ: Foo).transformInto[Bar]""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Foo to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "derivation from baz: io.scalaland.chimney.fixtures.renames.Subtypes.Foo.BAZ to io.scalaland.chimney.fixtures.renames.Subtypes.Bar is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Foo.BAZ to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+
+      compileErrorsFixed("""(Foo.BAZ: Foo).into[Bar].transform""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Foo to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "derivation from baz: io.scalaland.chimney.fixtures.renames.Subtypes.Foo.BAZ to io.scalaland.chimney.fixtures.renames.Subtypes.Bar is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Foo.BAZ to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+
+      compileErrorsFixed("""(Bar.Baz: Bar).transformInto[Foo]""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Bar to io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "derivation from baz: io.scalaland.chimney.fixtures.renames.Subtypes.Bar.Baz to io.scalaland.chimney.fixtures.renames.Subtypes.Foo is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Bar.Baz to io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+
+      compileErrorsFixed("""(Bar.Baz: Bar).into[Foo].transform""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Bar to io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "derivation from baz: io.scalaland.chimney.fixtures.renames.Subtypes.Bar.Baz to io.scalaland.chimney.fixtures.renames.Subtypes.Foo is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Bar.Baz to io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+
+    test("should allow subtypes to be matched using user-provided predicate") {
+      (Foo.BAZ: Foo)
+        .into[Bar]
+        .enableCustomSubtypeNameComparison(TransformedNamesComparison.CaseInsensitiveEquality)
+        .transform ==> Bar.Baz
+
+      (Bar.Baz: Bar)
+        .into[Foo]
+        .enableCustomSubtypeNameComparison(TransformedNamesComparison.CaseInsensitiveEquality)
+        .transform ==> Foo.BAZ
+
+      locally {
+        implicit val config = TransformerConfiguration.default.enableCustomSubtypeNameComparison(
+          TransformedNamesComparison.CaseInsensitiveEquality
+        )
+
+        (Foo.BAZ: Foo).transformInto[Bar] ==> Bar.Baz
+        (Foo.BAZ: Foo).into[Bar].transform ==> Bar.Baz
+
+        (Bar.Baz: Bar).transformInto[Foo] ==> Foo.BAZ
+        (Bar.Baz: Bar).into[Foo].transform ==> Foo.BAZ
+      }
+    }
+  }
+
+  group("flag .disableCustomSubtypeNameComparison") {
+    import fixtures.renames.Subtypes.*
+
+    test("should disable globally enabled .enableCustomSubtypeNameComparison") {
+      @unused implicit val config = TransformerConfiguration.default.enableCustomSubtypeNameComparison(
+        TransformedNamesComparison.CaseInsensitiveEquality
+      )
+
+      compileErrorsFixed("""(Foo.BAZ: Foo).into[Bar].disableCustomSubtypeNameComparison.transform""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Foo to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "derivation from baz: io.scalaland.chimney.fixtures.renames.Subtypes.Foo.BAZ to io.scalaland.chimney.fixtures.renames.Subtypes.Bar is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Foo.BAZ to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+
+      compileErrorsFixed("""(Bar.Baz: Bar).into[Foo].disableCustomSubtypeNameComparison.transform""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Bar to io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "derivation from baz: io.scalaland.chimney.fixtures.renames.Subtypes.Bar.Baz to io.scalaland.chimney.fixtures.renames.Subtypes.Foo is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Bar.Baz to io.scalaland.chimney.fixtures.renames.Subtypes.Foo",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
@@ -1,0 +1,82 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.TransformedNamesComparison
+
+class TransformedNamesComparisonSpec extends ChimneySpec {
+
+  group("TransformedNamesComparison.BeanAware") {
+
+    test("should match identical names") {
+      TransformedNamesComparison.BeanAware.namesMatch("someField", "someField") ==> true
+    }
+
+    test("should allows matching fields with Java Bean getters and setters") {
+      TransformedNamesComparison.BeanAware.namesMatch("someField", "isSomeField") ==> true
+      TransformedNamesComparison.BeanAware.namesMatch("isSomeField", "someField") ==> true
+      TransformedNamesComparison.BeanAware.namesMatch("someField", "getSomeField") ==> true
+      TransformedNamesComparison.BeanAware.namesMatch("getSomeField", "someField") ==> true
+      TransformedNamesComparison.BeanAware.namesMatch("someField", "setSomeField") ==> true
+      TransformedNamesComparison.BeanAware.namesMatch("setSomeField", "someField") ==> true
+    }
+
+    test("should not match names converted with different conventions") {
+      TransformedNamesComparison.BeanAware.namesMatch("someField", "some-field") ==> false
+      TransformedNamesComparison.BeanAware.namesMatch("some-field", "someField") ==> false
+      TransformedNamesComparison.BeanAware.namesMatch("someField", "some_field") ==> false
+      TransformedNamesComparison.BeanAware.namesMatch("some_field", "someField") ==> false
+      TransformedNamesComparison.BeanAware.namesMatch("someField", "SOME_FIELD") ==> false
+      TransformedNamesComparison.BeanAware.namesMatch("SOME_FIELD", "someField") ==> false
+    }
+  }
+
+  group("TransformedNamesComparison.StrictEquality") {
+
+    test("should match identical names") {
+      TransformedNamesComparison.StrictEquality.namesMatch("someField", "someField") ==> true
+    }
+
+    test("should not match names converted with different conventions") {
+      TransformedNamesComparison.StrictEquality.namesMatch("someField", "isSomeField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("isSomeField", "someField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("someField", "getSomeField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("getSomeField", "someField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("someField", "setSomeField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("setSomeField", "someField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("someField", "some-field") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("some-field", "someField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("someField", "some_field") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("some_field", "someField") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("someField", "SOME_FIELD") ==> false
+      TransformedNamesComparison.StrictEquality.namesMatch("SOME_FIELD", "someField") ==> false
+    }
+  }
+
+  group("TransformedNamesComparison.CaseInsensitiveEquality") {
+
+    test("should match identical names") {
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "someField") ==> true
+    }
+
+    test("should match names which differ only in letter capitalisation") {
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "SomeField") ==> true
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("SomeField", "someField") ==> true
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "SOMEFIELD") ==> true
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("SOMEFIELD", "someField") ==> true
+    }
+
+    test("should not match names converted with different conventions") {
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "isSomeField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("isSomeField", "someField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "getSomeField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("getSomeField", "someField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "setSomeField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("setSomeField", "someField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "some-field") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("some-field", "someField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "some_field") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("some_field", "someField") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("someField", "SOME_FIELD") ==> false
+      TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("SOME_FIELD", "someField") ==> false
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/renames/Subtypes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/renames/Subtypes.scala
@@ -1,0 +1,14 @@
+package io.scalaland.chimney.fixtures.renames
+
+object Subtypes {
+
+  sealed trait Foo
+  object Foo {
+    case object BAZ extends Foo
+  }
+
+  sealed trait Bar
+  object Bar {
+    case object Baz extends Bar
+  }
+}

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -2801,11 +2801,11 @@ but Chimney has a specific solution for this:
     // Object is "case" for better toString output.
     case object PermissiveNamesComparison extends TransformedNamesComparison {
 
-      private val normalize(name: String): String = {
+      private def normalize(name: String): String = {
         val name2 =
           if (name.startsWith("is")) name.drop(2)
-          else (name.startsWith("get")) name.drop(3)
-          else (name.startsWith("set")) name.drop(3)
+          else if (name.startsWith("get")) name.drop(3)
+          else if (name.startsWith("set")) name.drop(3)
           else name
         name2.replaceAll("[-_]", "")
       }
@@ -2831,3 +2831,5 @@ but Chimney has a specific solution for this:
       //.enableCustomSubtypeNameComparison(your.organization.PermissiveNamesComparison)
       .transform
     ```
+
+Since this feature relied on ClassLoaders and class path lookup it, testing it with REPL may not work.


### PR DESCRIPTION
TODO:

 - [x] obtain `object` by its type in the macro (based on https://github.com/MateuszKubuszok/MacroTypeclass)
 - [x] replace each usage of `ProductTypes.areNamesEqual` with `ctx.config.flags.fieldNamesComparison`
   - [x] consider some utility which would provide global `areFieldNamesEqual` delegating to the code above
 - [x] replace each usage of `enumNamesEqual` with `ctx.config.flags.subtypeNamesComparison`
   - [x] consider some utility which would provide global `areSubtypeNamesEqual` delegating to the code above
 - [x] tests
   - [x] custom fields names matching
   - [x] custom subtypes names matching
   - [x] build-in comparators
   - [x] error messages when a comparator cannot be read
 - [x] mkdocs
   - [x] `enableFieldNamesMatching` + `disableFieldNamesMatching`
   - [x] `enableSubtypeNamesMatching` + `dsableSubtypeNamesMatching`
   - [x] `TransformedNamesComparison`
 - [x] scaladoc
   - [x] `TransformedNamesComparison`
   - [x] links to mkdocs
 