### PR TITLE
#480 Automatic Coproduct Rename from/to Protobuf GeneratedEnum

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -44,6 +44,16 @@ object TransformedNamesComparison {
     def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
   }
 
+  case object GeneratedProtobufEnumEquality extends TransformedNamesComparison {
+
+    def namesMatch(fromName: String, toName: String): Boolean = {
+      val fromNameWithoutPrefix = fromName.replace("_", "").reverse.toLowerCase
+      val toNameWithoutPrefix = toName.replace("_", "").reverse.toLowerCase
+
+      fromNameWithoutPrefix.startsWith(toNameWithoutPrefix) || toNameWithoutPrefix.startsWith(fromNameWithoutPrefix)
+    }
+  }
+
   type FieldDefault = BeanAware.type
   val FieldDefault: FieldDefault = BeanAware
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
@@ -79,4 +79,29 @@ class TransformedNamesComparisonSpec extends ChimneySpec {
       TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("SOME_FIELD", "someField") ==> false
     }
   }
+
+  group("TransformedNamesComparison.GeneratedProtobufEnumEquality") {
+
+    test("should match identical names") {
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("someField", "someField") ==> true
+    }
+
+    test("should match names which differ in capitalisation, underscores and prefix") {
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("FIELD_SOME", "some") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("SOME_FIELD", "Field") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("Field", "SOME_FIELD") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("FIELD", "some_Field") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("someField", "isSomeField") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("isSomeField", "someField") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("someField", "getSomeField") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("getSomeField", "someField") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("someField", "setSomeField") ==> true
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("setSomeField", "someField") ==> true
+    }
+
+    test("should not match names converted with different conventions") {
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("someField", "some-field") ==> false
+      TransformedNamesComparison.GeneratedProtobufEnumEquality.namesMatch("some-field", "someField") ==> false
+    }
+  }
 }


### PR DESCRIPTION
I'm not entirely happy with the `TransformedNamesComparison` because it matches too broadly. I'm open for better suggestions.

I want to achieve a comparison for the following:

```
enum Field {
  FIELD_UNSPECIFIED = 0;
  FIELD_CASE_ONE = 1;
  FIELD_CASE_TWO = 2;
}
```

From/To

```
enum Field:
  case One, Two
```