### PR TITLE
More nested-path functionalities

### DIFF
--- a/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/BasicHuge.scala
+++ b/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/BasicHuge.scala
@@ -13,5 +13,4 @@ class BasicHuge extends CommonBenchmarkSettings {
   @Benchmark
   def hugeByHand: HugeOutput =
     doHugeByHand(samples.hugeSample)
-
 }

--- a/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/fixtures.scala
+++ b/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/fixtures.scala
@@ -104,10 +104,10 @@ object fixtures {
       }
 
       object nonFunhappy {
-        def validateA(a: Int): Int = throw new Exception("a not nice")
+        def validateA(a: Int): Int = sys.error("a not nice")
         def validateB(b: Double): Double = b
-        def validateC(c: String): String = throw new Exception("c not pretty")
-        def validateD(d: Option[String]): Option[String] = throw new Exception("I don't like this d")
+        def validateC(c: String): String = sys.error("c not pretty")
+        def validateD(d: Option[String]): Option[String] = sys.error("I don't like this d")
       }
 
       object happy {

--- a/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/fixtures.scala
+++ b/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/fixtures.scala
@@ -104,10 +104,10 @@ object fixtures {
       }
 
       object nonFunhappy {
-        def validateA(a: Int): Int = sys.error("a not nice")
+        def validateA(a: Int): Int = throw new Exception("a not nice")
         def validateB(b: Double): Double = b
-        def validateC(c: String): String = sys.error("c not pretty")
-        def validateD(d: Option[String]): Option[String] = sys.error("I don't like this d")
+        def validateC(c: String): String = throw new Exception("c not pretty")
+        def validateD(d: Option[String]): Option[String] = throw new Exception("I don't like this d")
       }
 
       object happy {

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -49,7 +49,7 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
     def matchOn[From: Type, To: Type](src: Expr[From], cases: List[PatternMatchCase[To]]): Expr[To] = {
       val casesTrees = cases.map { case PatternMatchCase(someFrom, usage, fromName) =>
         import someFrom.Underlying as SomeFrom
-        val markUsed = Expr.suppressUnused(c.Expr[someFrom.Underlying](q"$fromName"))
+        val markUsed = Expr.suppressUnused(c.Expr[SomeFrom](q"$fromName"))
         cq"""$fromName : $SomeFrom => { $markUsed; $usage }"""
       }
       c.Expr[To](q"$src match { case ..$casesTrees }")

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -132,16 +132,13 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
 
     def asInstanceOf[A: Type, B: Type](expr: Expr[A]): Expr[B] = c.Expr[B](q"$expr.asInstanceOf[${Type[B]}]")
 
-    def upcast[A: Type, B: Type](expr: Expr[A]): Expr[B] = {
-      val wideningChecked = expr.widenExpr[B]
-      if (Type[A] =:= Type[B]) wideningChecked
-      else c.Expr[B](q"($expr : ${Type[B]})")
-    }
+    def upcast[A: Type, B: Type](expr: Expr[A]): Expr[B] =
+      if (Type[A] =:= Type[B]) expr.asInstanceOf[Expr[B]] // types are identical in practice, we can just cast
+      else c.Expr[B](q"(${expr.widenExpr[B]} : ${Type[B]})") // check A <:< B AND add a syntax to force upcasting
 
     def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] =
       // In Scala 2.12 suppressing two variables at once resulted in "_ is already defined as value _" error
-      if (scala.util.Properties.versionNumberString < "2.13")
-        c.Expr[Unit](q"_root_.scala.Predef.locally { val _ = $expr }")
+      if (isScala212) c.Expr[Unit](q"_root_.scala.Predef.locally { val _ = $expr }")
       else c.Expr[Unit](q"val _ = $expr")
 
     def prettyPrint[A](expr: Expr[A]): String =

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -14,6 +14,8 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     def Int(value: Int): Expr[Int] = c.Expr[Int](q"$value")
     def String(value: String): Expr[String] = c.Expr[String](q"$value")
 
+    def Tuple2[A: Type, B: Type](a: Expr[A], b: Expr[B]): Expr[(A, B)] = c.Expr[(A, B)](q"($a, $b)")
+
     object Function1 extends Function1Module {
       def apply[A: Type, B: Type](fn: Expr[A => B])(a: Expr[A]): Expr[B] = c.Expr[B](q"$fn.apply($a)")
     }
@@ -49,8 +51,8 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
       val None: Expr[scala.None.type] = c.Expr[scala.None.type](q"_root_.scala.None")
       def map[A: Type, B: Type](opt: Expr[Option[A]])(f: Expr[A => B]): Expr[Option[B]] =
         c.Expr[Option[B]](q"$opt.map[${Type[B]}]($f)")
-      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(onSome: Expr[A => B]): Expr[B] =
-        c.Expr[B](q"$opt.fold[${Type[B]}]($onNone)($onSome)")
+      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(matchingSome: Expr[A => B]): Expr[B] =
+        c.Expr[B](q"$opt.fold[${Type[B]}]($onNone)($matchingSome)")
       def orElse[A: Type](opt1: Expr[Option[A]], opt2: Expr[Option[A]]): Expr[Option[A]] =
         c.Expr[Option[A]](q"$opt1.orElse[${Type[A]}]($opt2)")
       def getOrElse[A: Type](opt: Expr[Option[A]])(orElse: Expr[A]): Expr[A] =

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -51,8 +51,8 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
       val None: Expr[scala.None.type] = c.Expr[scala.None.type](q"_root_.scala.None")
       def map[A: Type, B: Type](opt: Expr[Option[A]])(f: Expr[A => B]): Expr[Option[B]] =
         c.Expr[Option[B]](q"$opt.map[${Type[B]}]($f)")
-      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(matchingSome: Expr[A => B]): Expr[B] =
-        c.Expr[B](q"$opt.fold[${Type[B]}]($onNone)($matchingSome)")
+      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(onSome: Expr[A => B]): Expr[B] =
+        c.Expr[B](q"$opt.fold[${Type[B]}]($onNone)($onSome)")
       def orElse[A: Type](opt1: Expr[Option[A]], opt2: Expr[Option[A]]): Expr[Option[A]] =
         c.Expr[Option[A]](q"$opt1.orElse[${Type[A]}]($opt2)")
       def getOrElse[A: Type](opt: Expr[Option[A]])(orElse: Expr[A]): Expr[A] =

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -93,10 +93,15 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
     object Option extends OptionModule {
       def apply[A: Type]: Type[Option[A]] = weakTypeTag[Option[A]]
       def unapply[A](A: Type[A]): Option[??] =
-        if (A <:< None) Some(ExistentialType(Nothing))
-        else if (A.isCtor[Option[?]]) Some(A.param(0))
+        if (A <:< None) scala.Some(ExistentialType(Nothing))
+        else if (A.isCtor[Option[?]]) scala.Some(A.param(0))
         else scala.None
-
+      object Some extends SomeModule {
+        def apply[A: Type]: Type[Some[A]] = weakTypeTag[Some[A]]
+        def unapply[A](A: Type[A]): Option[??] =
+          if (A.isCtor[Some[?]]) scala.Some(A.param(0))
+          else scala.None
+      }
       val None: Type[scala.None.type] = weakTypeTag[scala.None.type]
     }
 

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -44,7 +44,7 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
         subtypes
           .map { case (name, subtypeA: ?<[A]) =>
             subtypeA.mapK[Enum.Element[A, *]] { implicit Subtype: Type[subtypeA.Underlying] => _ =>
-              Enum.Element(name = name, upcast = _.upcastExpr[A])
+              Enum.Element(name = name, upcast = _.upcastToExprOf[A])
             }
           }
           // with GADT we can have subtypes that shouldn't appear in pattern matching

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -29,7 +29,7 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
           val inner = fromUntyped(returnTypeOf(A, getter)).as_??
           import inner.Underlying as Inner
           assert(
-            Argument =:= Inner,
+            Argument <:< Inner,
             s"Wrapper/AnyVal ${Type.prettyPrint[A]} only property's type (${Type
                 .prettyPrint(Argument)}) was expected to be the same as only constructor argument's type (${Type
                 .prettyPrint(Inner)})"

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -117,26 +117,26 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
         val body = Block(
           List(
             ValDef(fromName, Some(Ref(bindName))), // not a Term, so we cannot use Expr.block
-            Expr.suppressUnused(Ref(fromName).asExprOf[someFrom.Underlying]).asTerm
+            Expr.suppressUnused(Ref(fromName).asExprOf[SomeFrom]).asTerm
           ),
           usage.asTerm
         )
 
-        if TypeRepr.of[someFrom.Underlying].typeSymbol.flags.is(Flags.Enum | Flags.JavaStatic) then
+        if TypeRepr.of[SomeFrom].typeSymbol.flags.is(Flags.Enum | Flags.JavaStatic) then
           // Scala 3's enums' parameterless cases are vals with type erased, so w have to match them by value
           // case arg @ Enum.Value => ...
-          CaseDef(Bind(bindName, Ident(TypeRepr.of[someFrom.Underlying].typeSymbol.termRef)), None, body)
-        else if TypeRepr.of[someFrom.Underlying].typeSymbol.flags.is(Flags.Module) then
+          CaseDef(Bind(bindName, Ident(TypeRepr.of[SomeFrom].typeSymbol.termRef)), None, body)
+        else if TypeRepr.of[SomeFrom].typeSymbol.flags.is(Flags.Module) then
           // case objects are also matched by value but the tree for them is generated in a slightly different way
           // case arg @ Enum.Value => ...
           CaseDef(
-            Bind(bindName, Ident(TypeRepr.of[someFrom.Underlying].typeSymbol.companionModule.termRef)),
+            Bind(bindName, Ident(TypeRepr.of[SomeFrom].typeSymbol.companionModule.termRef)),
             None,
             body
           )
         else
           // case arg : Enum.Value => ...
-          CaseDef(Bind(bindName, Typed(Wildcard(), TypeTree.of[someFrom.Underlying])), None, body)
+          CaseDef(Bind(bindName, Typed(Wildcard(), TypeTree.of[SomeFrom])), None, body)
       }
     ).asExprOf[To]
   }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -59,8 +59,8 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
       def map[A: Type, B: Type](opt: Expr[Option[A]])(f: Expr[A => B]): Expr[Option[B]] = '{
         ${ resetOwner(opt) }.map(${ f })
       }
-      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(matchingSome: Expr[A => B]): Expr[B] =
-        '{ ${ resetOwner(opt) }.fold(${ onNone })(${ matchingSome }) }
+      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(onSome: Expr[A => B]): Expr[B] =
+        '{ ${ resetOwner(opt) }.fold(${ onNone })(${ onSome }) }
       def orElse[A: Type](opt1: Expr[Option[A]], opt2: Expr[Option[A]]): Expr[Option[A]] =
         '{ ${ opt1 }.orElse(${ opt2 }) }
       def getOrElse[A: Type](opt: Expr[Option[A]])(orElse: Expr[A]): Expr[A] =

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -132,11 +132,9 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
 
     def asInstanceOf[A: Type, B: Type](expr: Expr[A]): Expr[B] = '{ ${ resetOwner(expr) }.asInstanceOf[B] }
 
-    def upcast[A: Type, B: Type](expr: Expr[A]): Expr[B] = {
-      val wideningChecked = expr.widenExpr[B]
-      if Type[A] =:= Type[B] then wideningChecked
-      else asInstanceOf[A, B](expr)
-    }
+    def upcast[A: Type, B: Type](expr: Expr[A]): Expr[B] =
+      if Type[A] =:= Type[B] then expr.asExprOf[B] // types are identical in practice, we can just cast
+      else expr.widenExpr[B] // check that A <:< B but without upcasting (Scala 3 should get away without it)
 
     def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] = '{ val _ = ${ expr } }
 

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -25,6 +25,8 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     def Int(value: Int): Expr[Int] = scala.quoted.Expr(value)
     def String(value: String): Expr[String] = scala.quoted.Expr(value)
 
+    def Tuple2[A: Type, B: Type](a: Expr[A], b: Expr[B]): Expr[(A, B)] = '{ (${ a }, ${ b }) }
+
     object Function1 extends Function1Module {
       def apply[A: Type, B: Type](fn: Expr[A => B])(a: Expr[A]): Expr[B] = '{
         ${ resetOwner(fn) }.apply(${ resetOwner(a) })
@@ -57,8 +59,8 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
       def map[A: Type, B: Type](opt: Expr[Option[A]])(f: Expr[A => B]): Expr[Option[B]] = '{
         ${ resetOwner(opt) }.map(${ f })
       }
-      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(onSome: Expr[A => B]): Expr[B] =
-        '{ ${ resetOwner(opt) }.fold(${ onNone })(${ onSome }) }
+      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(matchingSome: Expr[A => B]): Expr[B] =
+        '{ ${ resetOwner(opt) }.fold(${ onNone })(${ matchingSome }) }
       def orElse[A: Type](opt1: Expr[Option[A]], opt2: Expr[Option[A]]): Expr[Option[A]] =
         '{ ${ opt1 }.orElse(${ opt2 }) }
       def getOrElse[A: Type](opt: Expr[Option[A]])(orElse: Expr[A]): Expr[A] =

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -126,11 +126,18 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
     }
 
     object Option extends OptionModule {
-
       def apply[A: Type]: Type[Option[A]] = quoted.Type.of[Option[A]]
       def unapply[A](A: Type[A]): Option[??] = A match {
-        case '[Option[inner]] => Some(Type[inner].as_??)
+        case '[Option[inner]] => scala.Some(Type[inner].as_??)
         case _                => scala.None
+      }
+
+      object Some extends SomeModule {
+        def apply[A: Type]: Type[Some[A]] = quoted.Type.of[Some[A]]
+        def unapply[A](A: Type[A]): Option[??] = A match {
+          case '[Some[inner]] => scala.Some(Type[inner].as_??)
+          case _              => scala.None
+        }
       }
 
       val None: Type[scala.None.type] = quoted.Type.of[scala.None.type]

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -40,7 +40,7 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
         subtypes
           .map { case (name, subtypeA: ?<[A]) =>
             subtypeA.mapK[Enum.Element[A, *]] { implicit Subtype: Type[subtypeA.Underlying] => _ =>
-              Enum.Element[A, subtypeA.Underlying](name = name, upcast = _.upcastExpr[A])
+              Enum.Element[A, subtypeA.Underlying](name = name, upcast = _.upcastToExprOf[A])
             }
           }
           // with GADT we can have subtypes that shouldn't appear in pattern matching

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -30,7 +30,7 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
           val inner = returnTypeOf[Any](A, getter).as_??
           import inner.Underlying as Inner
           assert(
-            Argument =:= Inner,
+            Argument <:< Inner,
             s"Wrapper/AnyVal ${Type.prettyPrint[A]} only property's type (${Type
                 .prettyPrint(Argument)}) was expected to be the same as only constructor argument's type (${Type
                 .prettyPrint(Inner)})"

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -156,10 +156,10 @@ private[compiletime] trait Exprs { this: Definitions =>
         Type[A] <:< Type[B],
         s"Upcasting can only be done to type proved to be super type! Failed ${Type.prettyPrint[A]} <:< ${Type.prettyPrint[B]} check"
       )
-      expr.asInstanceOf[Expr[B]]
+      expr.asInstanceOf[Expr[B]] // same as expr.asExprOf[B] on Scala 3 but without expr.isExprOf[B] type checking
     }
 
-    /** Upcasts `Expr[A]` to `Expr[B]` in the emitted code: '{ (${ expr }) : B } */
+    /** Upcasts `Expr[A]` to `Expr[B]` in the emitted code: '{ (${ expr }) : B } (unless it's unnecessary) */
     def upcastExpr[B: Type]: Expr[B] = Expr.upcast[A, B](expr)
 
     def as_?? : ExistentialExpr = ExistentialExpr(expr)

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -16,6 +16,8 @@ private[compiletime] trait Exprs { this: Definitions =>
     def Int(value: Int): Expr[Int]
     def String(value: String): Expr[String]
 
+    def Tuple2[A: Type, B: Type](a: Expr[A], b: Expr[B]): Expr[(A, B)]
+
     val Function1: Function1Module
     trait Function1Module { this: Function1.type =>
       def apply[A: Type, B: Type](fn: Expr[A => B])(a: Expr[A]): Expr[B]
@@ -194,8 +196,8 @@ private[compiletime] trait Exprs { this: Definitions =>
 
   implicit final protected class EitherExprOps[L: Type, R: Type](private val eitherExpr: Expr[Either[L, R]]) {
 
-    def fold[B: Type](onLeft: Expr[L => B])(onRight: Expr[R => B]): Expr[B] =
-      Expr.Either.fold(eitherExpr)(onLeft)(onRight)
+    def fold[B: Type](matchingLeft: Expr[L => B])(matchingRight: Expr[R => B]): Expr[B] =
+      Expr.Either.fold(eitherExpr)(matchingLeft)(matchingRight)
   }
 
   implicit final protected class LeftExprOps[L: Type, R: Type](private val leftExpr: Expr[Left[L, R]]) {

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -57,7 +57,7 @@ private[compiletime] trait Exprs { this: Definitions =>
       def empty[A: Type]: Expr[Option[A]]
       val None: Expr[scala.None.type]
       def map[A: Type, B: Type](opt: Expr[Option[A]])(f: Expr[A => B]): Expr[Option[B]]
-      def fold[A: Type, B: Type](opt: Expr[Option[A]])(none: Expr[B])(f: Expr[A => B]): Expr[B]
+      def fold[A: Type, B: Type](opt: Expr[Option[A]])(onNone: Expr[B])(onSome: Expr[A => B]): Expr[B]
       def orElse[A: Type](opt1: Expr[Option[A]], opt2: Expr[Option[A]]): Expr[Option[A]]
       def getOrElse[A: Type](opt: Expr[Option[A]])(orElse: Expr[A]): Expr[A]
       def get[A: Type](opt: Expr[Option[A]]): Expr[A]

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
@@ -80,6 +80,8 @@ private[compiletime] trait Types { this: Existentials =>
 
     val Option: OptionModule
     trait OptionModule extends Ctor1[Option] { this: Option.type =>
+      val Some: SomeModule
+      trait SomeModule extends Ctor1[Some] { this: Some.type => }
       val None: Type[scala.None.type]
     }
 
@@ -130,6 +132,7 @@ private[compiletime] trait Types { this: Existentials =>
       implicit def ArrayType[A: Type]: Type[Array[A]] = Array[A]
 
       implicit def OptionType[A: Type]: Type[Option[A]] = Option[A]
+      implicit def SomeType[A: Type]: Type[Some[A]] = Option.Some[A]
       implicit val NoneType: Type[None.type] = Option.None
 
       implicit def EitherType[L: Type, R: Type]: Type[Either[L, R]] = Either[L, R]

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/IterableOrArrays.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/IterableOrArrays.scala
@@ -25,53 +25,53 @@ trait IterableOrArrays { this: Definitions =>
     def unapply[M](implicit tpe: Type[M]): Option[Existential[IterableOrArray[M, *]]] = tpe match {
       case Type.Map(k, v) =>
         import k.Underlying as K, v.Underlying as V
-        val a = ExistentialType[(k.Underlying, v.Underlying)]
+        val a = ExistentialType[(K, V)]
         import a.Underlying as Inner
         Some(
-          Existential[IterableOrArray[M, *], a.Underlying](
-            new IterableOrArray[M, a.Underlying] {
+          Existential[IterableOrArray[M, *], Inner](
+            new IterableOrArray[M, Inner] {
 
-              def iterator(m: Expr[M]): Expr[Iterator[a.Underlying]] =
-                m.widenExpr[Iterable[a.Underlying]].iterator
+              def iterator(m: Expr[M]): Expr[Iterator[Inner]] =
+                m.widenExpr[Iterable[Inner]].iterator
 
-              def map[B: Type](m: Expr[M])(f: Expr[a.Underlying => B]): ExistentialExpr =
-                ExistentialExpr.withoutType(m.widenExpr[Iterable[a.Underlying]].map(f))
+              def map[B: Type](m: Expr[M])(f: Expr[Inner => B]): ExistentialExpr =
+                ExistentialExpr.withoutType(m.widenExpr[Iterable[Inner]].map(f))
 
-              def to[C: Type](m: Expr[M])(factory: Expr[Factory[a.Underlying, C]]): Expr[C] =
-                m.widenExpr[Iterable[a.Underlying]].to(factory)
+              def to[C: Type](m: Expr[M])(factory: Expr[Factory[Inner, C]]): Expr[C] =
+                m.widenExpr[Iterable[Inner]].to(factory)
             }
           )
         )
       case Type.Iterable(a) =>
         import a.Underlying as Inner
         Some(
-          Existential[IterableOrArray[M, *], a.Underlying](
-            new IterableOrArray[M, a.Underlying] {
+          Existential[IterableOrArray[M, *], Inner](
+            new IterableOrArray[M, Inner] {
 
-              def iterator(m: Expr[M]): Expr[Iterator[a.Underlying]] =
-                m.widenExpr[Iterable[a.Underlying]].iterator
+              def iterator(m: Expr[M]): Expr[Iterator[Inner]] =
+                m.widenExpr[Iterable[Inner]].iterator
 
-              def map[B: Type](m: Expr[M])(f: Expr[a.Underlying => B]): ExistentialExpr =
-                ExistentialExpr.withoutType(m.widenExpr[Iterable[a.Underlying]].map(f))
+              def map[B: Type](m: Expr[M])(f: Expr[Inner => B]): ExistentialExpr =
+                ExistentialExpr.withoutType(m.widenExpr[Iterable[Inner]].map(f))
 
-              def to[C: Type](m: Expr[M])(factory: Expr[Factory[a.Underlying, C]]): Expr[C] =
-                m.widenExpr[Iterable[a.Underlying]].to(factory)
+              def to[C: Type](m: Expr[M])(factory: Expr[Factory[Inner, C]]): Expr[C] =
+                m.widenExpr[Iterable[Inner]].to(factory)
             }
           )
         )
       case Type.Array(a) =>
         import a.Underlying as Inner
         Some(
-          Existential[IterableOrArray[M, *], a.Underlying](
-            new IterableOrArray[M, a.Underlying] {
-              def iterator(m: Expr[M]): Expr[Iterator[a.Underlying]] =
-                m.widenExpr[Array[a.Underlying]].iterator
+          Existential[IterableOrArray[M, *], Inner](
+            new IterableOrArray[M, Inner] {
+              def iterator(m: Expr[M]): Expr[Iterator[Inner]] =
+                m.widenExpr[Array[Inner]].iterator
 
-              def map[B: Type](m: Expr[M])(f: Expr[a.Underlying => B]): ExistentialExpr =
-                ExistentialExpr.withoutType(m.widenExpr[Array[a.Underlying]].map(f))
+              def map[B: Type](m: Expr[M])(f: Expr[Inner => B]): ExistentialExpr =
+                ExistentialExpr.withoutType(m.widenExpr[Array[Inner]].map(f))
 
-              def to[C: Type](m: Expr[M])(factory: Expr[Factory[a.Underlying, C]]): Expr[C] =
-                m.widenExpr[Array[a.Underlying]].to(factory)
+              def to[C: Type](m: Expr[M])(factory: Expr[Factory[Inner, C]]): Expr[C] =
+                m.widenExpr[Array[Inner]].to(factory)
             }
           )
         )

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/IterableOrArrays.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/IterableOrArrays.scala
@@ -32,13 +32,13 @@ trait IterableOrArrays { this: Definitions =>
             new IterableOrArray[M, Inner] {
 
               def iterator(m: Expr[M]): Expr[Iterator[Inner]] =
-                m.widenExpr[Iterable[Inner]].iterator
+                m.upcastToExprOf[Iterable[Inner]].iterator
 
               def map[B: Type](m: Expr[M])(f: Expr[Inner => B]): ExistentialExpr =
-                ExistentialExpr.withoutType(m.widenExpr[Iterable[Inner]].map(f))
+                ExistentialExpr.withoutType(m.upcastToExprOf[Iterable[Inner]].map(f))
 
               def to[C: Type](m: Expr[M])(factory: Expr[Factory[Inner, C]]): Expr[C] =
-                m.widenExpr[Iterable[Inner]].to(factory)
+                m.upcastToExprOf[Iterable[Inner]].to(factory)
             }
           )
         )
@@ -49,13 +49,13 @@ trait IterableOrArrays { this: Definitions =>
             new IterableOrArray[M, Inner] {
 
               def iterator(m: Expr[M]): Expr[Iterator[Inner]] =
-                m.widenExpr[Iterable[Inner]].iterator
+                m.upcastToExprOf[Iterable[Inner]].iterator
 
               def map[B: Type](m: Expr[M])(f: Expr[Inner => B]): ExistentialExpr =
-                ExistentialExpr.withoutType(m.widenExpr[Iterable[Inner]].map(f))
+                ExistentialExpr.withoutType(m.upcastToExprOf[Iterable[Inner]].map(f))
 
               def to[C: Type](m: Expr[M])(factory: Expr[Factory[Inner, C]]): Expr[C] =
-                m.widenExpr[Iterable[Inner]].to(factory)
+                m.upcastToExprOf[Iterable[Inner]].to(factory)
             }
           )
         )
@@ -65,13 +65,13 @@ trait IterableOrArrays { this: Definitions =>
           Existential[IterableOrArray[M, *], Inner](
             new IterableOrArray[M, Inner] {
               def iterator(m: Expr[M]): Expr[Iterator[Inner]] =
-                m.widenExpr[Array[Inner]].iterator
+                m.upcastToExprOf[Array[Inner]].iterator
 
               def map[B: Type](m: Expr[M])(f: Expr[Inner => B]): ExistentialExpr =
-                ExistentialExpr.withoutType(m.widenExpr[Array[Inner]].map(f))
+                ExistentialExpr.withoutType(m.upcastToExprOf[Array[Inner]].map(f))
 
               def to[C: Type](m: Expr[M])(factory: Expr[Factory[Inner, C]]): Expr[C] =
-                m.widenExpr[Array[Inner]].to(factory)
+                m.upcastToExprOf[Array[Inner]].to(factory)
             }
           )
         )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
@@ -34,8 +34,14 @@ package object dsl {
   implicit def TryPartialTransformerOps[A](`try`: Try[A]): syntax.TryPartialTransformerOps[A] =
     syntax.TryPartialTransformerOps(`try`)
 
-  implicit def TransformationPathOps[A](a: A): syntax.TransformationPathOps[A] =
-    syntax.TransformationPathOps(a)
+  implicit def TransformationMatchingPathOps[A](a: A): syntax.TransformationMatchingPathOps[A] =
+    syntax.TransformationMatchingPathOps(a)
+
+  implicit def TransformationCollectionPathOps[C[_], A](a: C[A]): syntax.TransformationCollectionPathOps[C, A] =
+    syntax.TransformationCollectionPathOps(a)
+
+  implicit def TransformationMapPathOps[M[_, _], K, V](a: M[K, V]): syntax.TransformationMapPathOps[M, K, V] =
+    syntax.TransformationMapPathOps(a)
 
   // Extension methods in dsl.* summon TypeClass.AutoDerived while extension methods in syntax.* summon TypeClass.
   // This help us preserve legacy behavior in dsl code while keeping stricter separation in auto/syntax imports.

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/package.scala
@@ -34,6 +34,9 @@ package object dsl {
   implicit def TryPartialTransformerOps[A](`try`: Try[A]): syntax.TryPartialTransformerOps[A] =
     syntax.TryPartialTransformerOps(`try`)
 
+  implicit def TransformationPathOps[A](a: A): syntax.TransformationPathOps[A] =
+    syntax.TransformationPathOps(a)
+
   // Extension methods in dsl.* summon TypeClass.AutoDerived while extension methods in syntax.* summon TypeClass.
   // This help us preserve legacy behavior in dsl code while keeping stricter separation in auto/syntax imports.
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -38,11 +38,11 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             val fixedInit = fixJavaEnums(init)
             import name.Underlying as Name, fixedInit.Underlying as FixedInit
             Path.Select[FixedInit, Name].as_?<[runtime.Path]
-          case Path.Match(init, subtype) =>
+          case Path.Matching(init, subtype) =>
             val fixedSubtype = fixJavaEnum(subtype)
             val fixedInit = fixJavaEnums(init)
             import fixedSubtype.Underlying as FixedSubtype, fixedInit.Underlying as FixedInit
-            Path.Match[FixedInit, FixedSubtype].as_?<[runtime.Path]
+            Path.Matching[FixedInit, FixedSubtype].as_?<[runtime.Path]
           case _ => reportError(s"Expected valid runtime.Path, got ${Type.prettyPrint(path.Underlying)}")
         }
     }
@@ -340,32 +340,32 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           if (A.isCtor[runtime.Path.Select[?, ?]]) Some(A.param_<[runtime.Path](0) -> A.param_<[String](1))
           else scala.None
       }
-      object Match extends MatchModule {
-        def apply[Init <: runtime.Path: Type, Subtype: Type]: Type[runtime.Path.Match[Init, Subtype]] =
-          weakTypeTag[runtime.Path.Match[Init, Subtype]]
+      object Matching extends MatchingModule {
+        def apply[Init <: runtime.Path: Type, Subtype: Type]: Type[runtime.Path.Matching[Init, Subtype]] =
+          weakTypeTag[runtime.Path.Matching[Init, Subtype]]
         def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ??)] =
-          if (A.isCtor[runtime.Path.Match[?, ?]]) Some(A.param_<[runtime.Path](0) -> A.param(1))
+          if (A.isCtor[runtime.Path.Matching[?, ?]]) Some(A.param_<[runtime.Path](0) -> A.param(1))
           else scala.None
       }
-      object EachItem extends EachItemModule {
-        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachItem[Init]] =
-          weakTypeTag[runtime.Path.EachItem[Init]]
+      object EveryItem extends EveryItemModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EveryItem[Init]] =
+          weakTypeTag[runtime.Path.EveryItem[Init]]
         def unapply[A](A: Type[A]): Option[?<[runtime.Path]] =
-          if (A.isCtor[runtime.Path.EachItem[?]]) Some(A.param_<[runtime.Path](0))
+          if (A.isCtor[runtime.Path.EveryItem[?]]) Some(A.param_<[runtime.Path](0))
           else scala.None
       }
-      object EachMapKey extends EachMapKeyModule {
-        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapKey[Init]] =
-          weakTypeTag[runtime.Path.EachMapKey[Init]]
+      object EveryMapKey extends EveryMapKeyModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EveryMapKey[Init]] =
+          weakTypeTag[runtime.Path.EveryMapKey[Init]]
         def unapply[A](A: Type[A]): Option[?<[runtime.Path]] =
-          if (A.isCtor[runtime.Path.EachMapKey[?]]) Some(A.param_<[runtime.Path](0))
+          if (A.isCtor[runtime.Path.EveryMapKey[?]]) Some(A.param_<[runtime.Path](0))
           else scala.None
       }
-      object EachMapValue extends EachMapValueModule {
-        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapValue[Init]] =
-          weakTypeTag[runtime.Path.EachMapValue[Init]]
+      object EveryMapValue extends EveryMapValueModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EveryMapValue[Init]] =
+          weakTypeTag[runtime.Path.EveryMapValue[Init]]
         def unapply[A](A: Type[A]): Option[?<[runtime.Path]] =
-          if (A.isCtor[runtime.Path.EachMapValue[?]]) Some(A.param_<[runtime.Path](0))
+          if (A.isCtor[runtime.Path.EveryMapValue[?]]) Some(A.param_<[runtime.Path](0))
           else scala.None
       }
     }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -347,6 +347,27 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           if (A.isCtor[runtime.Path.Match[?, ?]]) Some(A.param_<[runtime.Path](0) -> A.param(1))
           else scala.None
       }
+      object EachItem extends EachItemModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachItem[Init]] =
+          weakTypeTag[runtime.Path.EachItem[Init]]
+        def unapply[A](A: Type[A]): Option[?<[runtime.Path]] =
+          if (A.isCtor[runtime.Path.EachItem[?]]) Some(A.param_<[runtime.Path](0))
+          else scala.None
+      }
+      object EachMapKey extends EachMapKeyModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapKey[Init]] =
+          weakTypeTag[runtime.Path.EachMapKey[Init]]
+        def unapply[A](A: Type[A]): Option[?<[runtime.Path]] =
+          if (A.isCtor[runtime.Path.EachMapKey[?]]) Some(A.param_<[runtime.Path](0))
+          else scala.None
+      }
+      object EachMapValue extends EachMapValueModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapValue[Init]] =
+          weakTypeTag[runtime.Path.EachMapValue[Init]]
+        def unapply[A](A: Type[A]): Option[?<[runtime.Path]] =
+          if (A.isCtor[runtime.Path.EachMapValue[?]]) Some(A.param_<[runtime.Path](0))
+          else scala.None
+      }
     }
   }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -43,6 +43,18 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             val fixedInit = fixJavaEnums(init)
             import fixedSubtype.Underlying as FixedSubtype, fixedInit.Underlying as FixedInit
             Path.Matching[FixedInit, FixedSubtype].as_?<[runtime.Path]
+          case Path.EveryItem(init) =>
+            val fixedInit = fixJavaEnums(init)
+            import fixedInit.Underlying as FixedInit
+            Path.EveryItem[FixedInit].as_?<[runtime.Path]
+          case Path.EveryMapKey(init) =>
+            val fixedInit = fixJavaEnums(init)
+            import fixedInit.Underlying as FixedInit
+            Path.EveryMapKey[FixedInit].as_?<[runtime.Path]
+          case Path.EveryMapValue(init) =>
+            val fixedInit = fixJavaEnums(init)
+            import fixedInit.Underlying as FixedInit
+            Path.EveryMapValue[FixedInit].as_?<[runtime.Path]
           case _ => reportError(s"Expected valid runtime.Path, got ${Type.prettyPrint(path.Underlying)}")
         }
     }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -91,7 +91,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       .asInstanceOfExpr[PartialTransformerDefinition[
         From,
         To,
-        CaseComputed[Path.Match[Path.Root, FixedSubtype], Overrides],
+        CaseComputed[Path.Matching[Path.Root, FixedSubtype], Overrides],
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
@@ -108,7 +108,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       .asInstanceOfExpr[PartialTransformerDefinition[
         From,
         To,
-        CaseComputedPartial[Path.Match[Path.Root, FixedSubtype], Overrides],
+        CaseComputedPartial[Path.Matching[Path.Root, FixedSubtype], Overrides],
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -92,7 +92,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       .asInstanceOfExpr[PartialTransformerInto[
         From,
         To,
-        CaseComputed[Path.Match[Path.Root, FixedSubtype], Overrides],
+        CaseComputed[Path.Matching[Path.Root, FixedSubtype], Overrides],
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
@@ -109,7 +109,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       .asInstanceOfExpr[PartialTransformerInto[
         From,
         To,
-        CaseComputedPartial[Path.Match[Path.Root, FixedSubtype], Overrides],
+        CaseComputedPartial[Path.Matching[Path.Root, FixedSubtype], Overrides],
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -64,7 +64,7 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       .asInstanceOfExpr[TransformerDefinition[
         From,
         To,
-        CaseComputed[Path.Match[Path.Root, FixedSubtype], Overrides],
+        CaseComputed[Path.Matching[Path.Root, FixedSubtype], Overrides],
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -61,7 +61,12 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
   ](f: Tree): Tree = new ApplyFixedCoproductType {
     def apply[FixedSubtype: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
-      .asInstanceOfExpr[TransformerInto[From, To, CaseComputed[Path.Match[Path.Root, FixedSubtype], Overrides], Flags]]
+      .asInstanceOfExpr[TransformerInto[
+        From,
+        To,
+        CaseComputed[Path.Matching[Path.Root, FixedSubtype], Overrides],
+        Flags
+      ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
 
   def withConstructorImpl[

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -184,10 +184,10 @@ private[chimney] trait DslMacroUtils {
       s"Invalid selector expression: $selectorTree"
 
     private def arbitraryFunctionNotAllowed(selectorTree: Tree): String =
-      s"Invalid selector expression - only vals, and nullary defs allowed: $selectorTree\n${showRaw(selectorTree)}"
+      s"The path expression has to be a single chain of calls on the original input, operation other than value extraction: $selectorTree\n${showRaw(selectorTree)}"
 
     private def ignoringInputNotAllowed(selectorTree: Tree): String =
-      s"Invalid selector expression - only input value can be extracted from: $selectorTree"
+      s"The path expression has to be a single chain of calls on the original input, got external identifier: $selectorTree"
   }
 
   private trait ExistentialCtor {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
@@ -182,7 +182,7 @@ package object syntax {
   }
 
   // TODO: docs
-  implicit final class TransformationPathOps[A](@unused private val a: A) extends AnyVal {
+  implicit final class TransformationMatchingPathOps[A](@unused private val a: A) extends AnyVal {
 
     def matching[B <: A]: B =
       sys.error(".matching should be only called within Chimney DSL")
@@ -195,14 +195,20 @@ package object syntax {
 
     def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV =
       sys.error(".matchingRight should be only called within Chimney DSL")
+  }
 
-    def everyItem[I](implicit @unused ev: IsCollection.Of[A, I]): I =
+  implicit final class TransformationCollectionPathOps[C[_], I](@unused private val cc: C[I]) extends AnyVal {
+
+    def everyItem(implicit @unused ev: IsCollection.Of[C[I], I]): I =
       sys.error(".everyItem should be only called within Chimney DSL")
+  }
 
-    def everyMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
+  implicit final class TransformationMapPathOps[M[_, _], K, V](@unused private val cc: M[K, V]) extends AnyVal {
+
+    def everyMapKey(implicit @unused ev: IsMap.Of[M[K, V], K, V]): K =
       sys.error(".everyMapKey should be only called within Chimney DSL")
 
-    def everyMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
+    def everyMapValue(implicit @unused ev: IsMap.Of[M[K, V], K, V]): V =
       sys.error(".everyMapValue should be only called within Chimney DSL")
   }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
@@ -183,33 +183,110 @@ package object syntax {
 
   // $COVERAGE-OFF$methods used only within macro-erased expressions
 
-  // TODO: docs
+  /** Allows subtype matching when selecting path to override in Chimney DSL.
+    *
+    * @tparam A type to match
+    *
+    * @since 1.0.0
+    */
   implicit final class TransformationMatchingPathOps[A](@unused private val a: A) extends AnyVal {
 
+    /** Allows paths like `_.adt.matching[Subtype].field` when selecting the target fields to override in Chimney DSL.
+      *
+      * It can only be used within `.withField*` methods where the macros reads it and erases it from the final code!
+      *
+      * @tparam B subtype for which override should be provided
+      * @return   stubs value of selected subtype
+      *
+      * @since 1.0.0
+      */
     @compileTimeOnly(".matching should be only called within Chimney DSL")
     def matching[B <: A]: B = sys.error("")
 
+    /** Allows paths like `_.optional.matchingSome.field` when selecting the target fields to override in Chimney DSL.
+      *
+      * It can only be used within `.withField*` methods where the macros reads it and erases it from the final code!
+      *
+      * @return stubs a value extracted from `Some`
+      *
+      * @since 1.0.0
+      */
     @compileTimeOnly(".matchingSome should be only called within Chimney DSL")
     def matchingSome[SV, S](implicit @unused ev: IsOption.Of[A, SV, S]): SV = sys.error("")
 
+    /** Allows paths like `_.either.matchingLeft` when selecting the target fields to override in Chimney DSL.
+      *
+      * It can only be used within `.withField*` methods where the macros reads it and erases it from the final code!
+      *
+      * @return stubs a value extracted from `Left`
+      *
+      * @since 1.0.0
+      */
     @compileTimeOnly(".matchingLeft should be only called within Chimney DSL")
     def matchingLeft[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): LV = sys.error("")
 
+    /** Allows paths like `_.either.matchingRight.field` when selecting the target fields to override in Chimney DSL.
+      *
+      * It can only be used within `.withField*` methods where the macros reads it and erases it from the final code!
+      *
+      * @return stubs a value extracted from `Right`
+      *
+      * @since 1.0.0
+      */
     @compileTimeOnly(".matchingRight should be only called within Chimney DSL")
     def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV = sys.error("")
   }
 
+  /** Allow item extraction when selecting path to override in Chimney DSL.
+    *
+    * @tparam C type of the collection
+    * @tparam I type of items in the collection
+    *
+    * @since 1.0.0
+    */
   implicit final class TransformationCollectionPathOps[C[_], I](@unused private val cc: C[I]) extends AnyVal {
 
+    /** Allows paths like `_.collection.everyItem.field` when selecting the target fields to override in Chimney DSL.
+      *
+      * It can only be used within `.withField*` methods where the macros reads it and erases it from the final code!
+      *
+      * @return stubs an item extracted from the collection
+      *
+      * @since 1.0.0
+      */
     @compileTimeOnly(".everyItem should be only called within Chimney DSL")
     def everyItem(implicit @unused ev: IsCollection.Of[C[I], I]): I = sys.error("")
   }
 
+  /** Allow key/value extraction from maps when selecting path to override in Chimney DSL.
+    *
+    * @tparam M type of the map
+    * @tparam K type of keys in the map
+    * @tparam V type of values in the map
+    *
+    * @since 1.0.0
+    */
   implicit final class TransformationMapPathOps[M[_, _], K, V](@unused private val cc: M[K, V]) extends AnyVal {
 
+    /** Allows paths like `_.map.everyMapKey.field` when selecting the target fields to override in Chimney DSL.
+      *
+      * It can only be used within `.withField*` methods where the macros reads it and erases it from the final code!
+      *
+      * @return stubs a key extracted from the map
+      *
+      * @since 1.0.0
+      */
     @compileTimeOnly(".everyMapKey should be only called within Chimney DSL")
     def everyMapKey(implicit @unused ev: IsMap.Of[M[K, V], K, V]): K = sys.error("")
 
+    /** Allows paths like `_.map.everyMapValue.field` when selecting the target fields to override in Chimney DSL.
+      *
+      * It can only be used within `.withField*` methods where the macros reads it and erases it from the final code!
+      *
+      * @return stubs a value extracted from the map
+      *
+      * @since 1.0.0
+      */
     @compileTimeOnly(".everyMapValue should be only called within Chimney DSL")
     def everyMapValue(implicit @unused ev: IsMap.Of[M[K, V], K, V]): V = sys.error("")
   }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
@@ -184,25 +184,25 @@ package object syntax {
   // TODO: docs
   implicit final class TransformationPathOps[A](@unused private val a: A) extends AnyVal {
 
-    def onSubtype[B <: A]: B =
-      sys.error(".onSubtype should be only called within Chimney DSL")
+    def matching[B <: A]: B =
+      sys.error(".matching should be only called within Chimney DSL")
 
-    def onSome[B](implicit @unused ev: IsOption.Of[A, B]): B =
-      sys.error(".onSome should be only called within Chimney DSL")
+    def matchingSome[SV, S](implicit @unused ev: IsOption.Of[A, SV, S]): SV =
+      sys.error(".matchingSome should be only called within Chimney DSL")
 
-    def onLeft[L, R](implicit @unused ev: IsEither.Of[A, L, R]): L =
-      sys.error(".onLeft should be only called within Chimney DSL")
+    def matchingLeft[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): LV =
+      sys.error(".matchingLeft should be only called within Chimney DSL")
 
-    def onRight[L, R](implicit @unused ev: IsEither.Of[A, L, R]): R =
-      sys.error(".onRight should be only called within Chimney DSL")
+    def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV =
+      sys.error(".matchingRight should be only called within Chimney DSL")
 
-    def eachItem[B](implicit @unused ev: IsCollection.Of[A, B]): B =
-      sys.error(".eachItem should be only called within Chimney DSL")
+    def everyItem[I](implicit @unused ev: IsCollection.Of[A, I]): I =
+      sys.error(".everyItem should be only called within Chimney DSL")
 
-    def eachMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
-      sys.error(".eachMapKey should be only called within Chimney DSL")
+    def everyMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
+      sys.error(".everyMapKey should be only called within Chimney DSL")
 
-    def eachMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
-      sys.error(".eachMapValue should be only called within Chimney DSL")
+    def everyMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
+      sys.error(".everyMapValue should be only called within Chimney DSL")
   }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
@@ -1,5 +1,8 @@
 package io.scalaland.chimney
 
+import io.scalaland.chimney.internal.runtime.{IsCollection, IsEither, IsMap, IsOption}
+
+import scala.annotation.unused
 import scala.util.Try
 
 /** Imports only extension methods for summoning and using Transformer, PartialTransformer or Patcher
@@ -176,5 +179,30 @@ package object syntax {
       */
     def toPartialResult: partial.Result[A] =
       partial.Result.fromTry(`try`)
+  }
+
+  // TODO: docs
+  implicit final class TransformationPathOps[A](@unused private val a: A) extends AnyVal {
+
+    def onSubtype[B <: A]: B =
+      sys.error(".onSubtype should be only called within Chimney DSL")
+
+    def onSome[B](implicit @unused ev: IsOption.Of[A, B]): B =
+      sys.error(".onSome should be only called within Chimney DSL")
+
+    def onLeft[L, R](implicit @unused ev: IsEither.Of[A, L, R]): L =
+      sys.error(".onLeft should be only called within Chimney DSL")
+
+    def onRight[L, R](implicit @unused ev: IsEither.Of[A, L, R]): R =
+      sys.error(".onRight should be only called within Chimney DSL")
+
+    def eachItem[B](implicit @unused ev: IsCollection.Of[A, B]): B =
+      sys.error(".eachItem should be only called within Chimney DSL")
+
+    def eachMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
+      sys.error(".eachMapKey should be only called within Chimney DSL")
+
+    def eachMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
+      sys.error(".eachMapValue should be only called within Chimney DSL")
   }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/syntax/package.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney
 
 import io.scalaland.chimney.internal.runtime.{IsCollection, IsEither, IsMap, IsOption}
 
-import scala.annotation.unused
+import scala.annotation.{compileTimeOnly, unused}
 import scala.util.Try
 
 /** Imports only extension methods for summoning and using Transformer, PartialTransformer or Patcher
@@ -181,34 +181,38 @@ package object syntax {
       partial.Result.fromTry(`try`)
   }
 
+  // $COVERAGE-OFF$methods used only within macro-erased expressions
+
   // TODO: docs
   implicit final class TransformationMatchingPathOps[A](@unused private val a: A) extends AnyVal {
 
-    def matching[B <: A]: B =
-      sys.error(".matching should be only called within Chimney DSL")
+    @compileTimeOnly(".matching should be only called within Chimney DSL")
+    def matching[B <: A]: B = sys.error("")
 
-    def matchingSome[SV, S](implicit @unused ev: IsOption.Of[A, SV, S]): SV =
-      sys.error(".matchingSome should be only called within Chimney DSL")
+    @compileTimeOnly(".matchingSome should be only called within Chimney DSL")
+    def matchingSome[SV, S](implicit @unused ev: IsOption.Of[A, SV, S]): SV = sys.error("")
 
-    def matchingLeft[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): LV =
-      sys.error(".matchingLeft should be only called within Chimney DSL")
+    @compileTimeOnly(".matchingLeft should be only called within Chimney DSL")
+    def matchingLeft[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): LV = sys.error("")
 
-    def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV =
-      sys.error(".matchingRight should be only called within Chimney DSL")
+    @compileTimeOnly(".matchingRight should be only called within Chimney DSL")
+    def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV = sys.error("")
   }
 
   implicit final class TransformationCollectionPathOps[C[_], I](@unused private val cc: C[I]) extends AnyVal {
 
-    def everyItem(implicit @unused ev: IsCollection.Of[C[I], I]): I =
-      sys.error(".everyItem should be only called within Chimney DSL")
+    @compileTimeOnly(".everyItem should be only called within Chimney DSL")
+    def everyItem(implicit @unused ev: IsCollection.Of[C[I], I]): I = sys.error("")
   }
 
   implicit final class TransformationMapPathOps[M[_, _], K, V](@unused private val cc: M[K, V]) extends AnyVal {
 
-    def everyMapKey(implicit @unused ev: IsMap.Of[M[K, V], K, V]): K =
-      sys.error(".everyMapKey should be only called within Chimney DSL")
+    @compileTimeOnly(".everyMapKey should be only called within Chimney DSL")
+    def everyMapKey(implicit @unused ev: IsMap.Of[M[K, V], K, V]): K = sys.error("")
 
-    def everyMapValue(implicit @unused ev: IsMap.Of[M[K, V], K, V]): V =
-      sys.error(".everyMapValue should be only called within Chimney DSL")
+    @compileTimeOnly(".everyMapValue should be only called within Chimney DSL")
+    def everyMapValue(implicit @unused ev: IsMap.Of[M[K, V], K, V]): V = sys.error("")
   }
+
+  // $COVERAGE-ON$
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
@@ -6,13 +6,13 @@ import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacro
 
 export io.scalaland.chimney.inlined.{into, intoPartial, using}
 export io.scalaland.chimney.syntax.{
-  eachItem,
-  eachMapKey,
-  eachMapValue,
-  onLeft,
-  onRight,
-  onSome,
-  onSubtype,
+  everyItem,
+  everyMapKey,
+  everyMapValue,
+  matching,
+  matchingLeft,
+  matchingRight,
+  matchingSome,
   toPartialResult,
   toPartialResultOrString
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
@@ -5,7 +5,17 @@ import io.scalaland.chimney.internal.compiletime.derivation.transformer.Transfor
 import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacros
 
 export io.scalaland.chimney.inlined.{into, intoPartial, using}
-export io.scalaland.chimney.syntax.{toPartialResult, toPartialResultOrString}
+export io.scalaland.chimney.syntax.{
+  eachItem,
+  eachMapKey,
+  eachMapValue,
+  onLeft,
+  onRight,
+  onSome,
+  onSubtype,
+  toPartialResult,
+  toPartialResultOrString
+}
 
 // Extension methods in dsl.* summon TypeClass.AutoDerived while extension methods in syntax.* summon TypeClass.
 // This help us preserve legacy behavior in dsl code while keeping stricter separation in auto/syntax imports.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -311,35 +311,35 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             Some((Type[init].as_?<[runtime.Path], Type[fieldName].as_?<[String]))
           case _ => scala.None
       }
-      object Match extends MatchModule {
-        def apply[Init <: runtime.Path: Type, Subtype: Type]: Type[runtime.Path.Match[Init, Subtype]] =
-          quoted.Type.of[runtime.Path.Match[Init, Subtype]]
+      object Matching extends MatchingModule {
+        def apply[Init <: runtime.Path: Type, Subtype: Type]: Type[runtime.Path.Matching[Init, Subtype]] =
+          quoted.Type.of[runtime.Path.Matching[Init, Subtype]]
         def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ??)] = tpe match
-          case '[runtime.Path.Match[init, subtype]] =>
+          case '[runtime.Path.Matching[init, subtype]] =>
             Some((Type[init].as_?<[runtime.Path], Type[subtype].as_??))
           case _ => scala.None
       }
-      object EachItem extends EachItemModule {
-        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachItem[Init]] =
-          quoted.Type.of[runtime.Path.EachItem[Init]]
+      object EveryItem extends EveryItemModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EveryItem[Init]] =
+          quoted.Type.of[runtime.Path.EveryItem[Init]]
         def unapply[A](tpe: Type[A]): Option[?<[runtime.Path]] = tpe match
-          case '[runtime.Path.EachItem[init]] =>
+          case '[runtime.Path.EveryItem[init]] =>
             Some(Type[init].as_?<[runtime.Path])
           case _ => scala.None
       }
-      object EachMapKey extends EachMapKeyModule {
-        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapKey[Init]] =
-          quoted.Type.of[runtime.Path.EachMapKey[Init]]
+      object EveryMapKey extends EveryMapKeyModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EveryMapKey[Init]] =
+          quoted.Type.of[runtime.Path.EveryMapKey[Init]]
         def unapply[A](tpe: Type[A]): Option[?<[runtime.Path]] = tpe match
-          case '[runtime.Path.EachMapKey[init]] =>
+          case '[runtime.Path.EveryMapKey[init]] =>
             Some(Type[init].as_?<[runtime.Path])
           case _ => scala.None
       }
-      object EachMapValue extends EachMapValueModule {
-        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapValue[Init]] =
-          quoted.Type.of[runtime.Path.EachMapValue[Init]]
+      object EveryMapValue extends EveryMapValueModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EveryMapValue[Init]] =
+          quoted.Type.of[runtime.Path.EveryMapValue[Init]]
         def unapply[A](tpe: Type[A]): Option[?<[runtime.Path]] = tpe match
-          case '[runtime.Path.EachMapValue[init]] =>
+          case '[runtime.Path.EveryMapValue[init]] =>
             Some(Type[init].as_?<[runtime.Path])
           case _ => scala.None
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -319,6 +319,30 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             Some((Type[init].as_?<[runtime.Path], Type[subtype].as_??))
           case _ => scala.None
       }
+      object EachItem extends EachItemModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachItem[Init]] =
+          quoted.Type.of[runtime.Path.EachItem[Init]]
+        def unapply[A](tpe: Type[A]): Option[?<[runtime.Path]] = tpe match
+          case '[runtime.Path.EachItem[init]] =>
+            Some(Type[init].as_?<[runtime.Path])
+          case _ => scala.None
+      }
+      object EachMapKey extends EachMapKeyModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapKey[Init]] =
+          quoted.Type.of[runtime.Path.EachMapKey[Init]]
+        def unapply[A](tpe: Type[A]): Option[?<[runtime.Path]] = tpe match
+          case '[runtime.Path.EachMapKey[init]] =>
+            Some(Type[init].as_?<[runtime.Path])
+          case _ => scala.None
+      }
+      object EachMapValue extends EachMapValueModule {
+        def apply[Init <: runtime.Path: Type]: Type[runtime.Path.EachMapValue[Init]] =
+          quoted.Type.of[runtime.Path.EachMapValue[Init]]
+        def unapply[A](tpe: Type[A]): Option[?<[runtime.Path]] = tpe match
+          case '[runtime.Path.EachMapValue[init]] =>
+            Some(Type[init].as_?<[runtime.Path])
+          case _ => scala.None
+      }
     }
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -152,7 +152,12 @@ object PartialTransformerDefinitionMacros {
     '{
       WithRuntimeDataStore
         .update($td, $f)
-        .asInstanceOf[PartialTransformerDefinition[From, To, CaseComputed[Path.Match[Path.Root, Subtype], Tail], Flags]]
+        .asInstanceOf[PartialTransformerDefinition[
+          From,
+          To,
+          CaseComputed[Path.Matching[Path.Root, Subtype], Tail],
+          Flags
+        ]]
     }
 
   def withCoproductInstancePartial[
@@ -171,7 +176,7 @@ object PartialTransformerDefinitionMacros {
         .asInstanceOf[PartialTransformerDefinition[
           From,
           To,
-          CaseComputedPartial[Path.Match[Path.Root, Subtype], Tail],
+          CaseComputedPartial[Path.Matching[Path.Root, Subtype], Tail],
           Flags
         ]]
     }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -142,7 +142,7 @@ object PartialTransformerIntoMacros {
     '{
       WithRuntimeDataStore
         .update($ti, $f)
-        .asInstanceOf[PartialTransformerInto[From, To, CaseComputed[Path.Match[Path.Root, Subtype], Tail], Flags]]
+        .asInstanceOf[PartialTransformerInto[From, To, CaseComputed[Path.Matching[Path.Root, Subtype], Tail], Flags]]
     }
 
   def withCoproductInstancePartialImpl[
@@ -161,7 +161,7 @@ object PartialTransformerIntoMacros {
         .asInstanceOf[PartialTransformerInto[
           From,
           To,
-          CaseComputedPartial[Path.Match[Path.Root, Subtype], Tail],
+          CaseComputedPartial[Path.Matching[Path.Root, Subtype], Tail],
           Flags
         ]]
     }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -100,7 +100,7 @@ object TransformerDefinitionMacros {
     '{
       WithRuntimeDataStore
         .update($td, $f)
-        .asInstanceOf[TransformerDefinition[From, To, CaseComputed[Path.Match[Path.Root, Subtype], Tail], Flags]]
+        .asInstanceOf[TransformerDefinition[From, To, CaseComputed[Path.Matching[Path.Root, Subtype], Tail], Flags]]
     }
 
   def withConstructorImpl[

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -96,7 +96,7 @@ object TransformerIntoMacros {
     '{
       WithRuntimeDataStore
         .update($ti, $f)
-        .asInstanceOf[TransformerInto[From, To, CaseComputed[Path.Match[Path.Root, Subtype], Tail], Flags]]
+        .asInstanceOf[TransformerInto[From, To, CaseComputed[Path.Matching[Path.Root, Subtype], Tail], Flags]]
     }
 
   def withConstructorImpl[

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -155,7 +155,7 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
               }
             }
           // matches `.everyItem`
-          case Apply(TypeApply(Apply(TypeApply(Ident("everyItem"), _), List(t2)), _), List(IsCollectionOf(_, _))) =>
+          case Apply(Apply(TypeApply(Ident("everyItem"), _), List(t2)), List(IsCollectionOf(_, _))) =>
             unpackSelects(t2).map { init =>
               import init.Underlying as Init
               new ExistentialPath {
@@ -164,7 +164,7 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
               }
             }
           // matches `.everyMapKey`
-          case Apply(TypeApply(Apply(TypeApply(Ident("everyMapKey"), _), List(t2)), _), List(IsMapOf(_, _, _))) =>
+          case Apply(Apply(TypeApply(Ident("everyMapKey"), _), List(t2)), List(IsMapOf(_, _, _))) =>
             unpackSelects(t2).map { init =>
               import init.Underlying as Init
               new ExistentialPath {
@@ -173,7 +173,7 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
               }
             }
           // matches `.everyMapValue`
-          case Apply(TypeApply(Apply(TypeApply(Ident("everyMapValue"), _), List(t2)), _), List(IsMapOf(_, _, _))) =>
+          case Apply(Apply(TypeApply(Ident("everyMapValue"), _), List(t2)), List(IsMapOf(_, _, _))) =>
             unpackSelects(t2).map { init =>
               import init.Underlying as Init
               new ExistentialPath {
@@ -191,7 +191,6 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
     }
 
     private def invalidSelectorErrorMessage(t: Tree): String =
-      println(t.show(using Printer.TreeStructure))
       s"Invalid selector expression: ${t.show(using Printer.TreeAnsiCode)}"
 
     private def arbitraryFunctionNotAllowed(t: Tree): String =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -194,10 +194,11 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
       s"Invalid selector expression: ${t.show(using Printer.TreeAnsiCode)}"
 
     private def arbitraryFunctionNotAllowed(t: Tree): String =
-      s"Invalid selector expression - only vals, and nullary defs allowed: ${t.show(using Printer.TreeAnsiCode)}"
+      s"The path expression has to be a single chain of calls on the original input, operation other than value extraction: ${t
+          .show(using Printer.TreeAnsiCode)}"
 
     private def ignoringInputNotAllowed(t: Tree): String =
-      s"Invalid selector expression - only input value can be extracted from: ${t.show(using Printer.TreeAnsiCode)}"
+      s"The path expression has to be a single chain of calls on the original input, got external identifier: ${t.show(using Printer.TreeAnsiCode)}"
   }
 
   private trait ExistentialCtor {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
@@ -175,26 +175,27 @@ extension [T](`try`: Try[T]) {
     partial.Result.fromTry(`try`)
 }
 
+// TODO docs
 extension [A](@unused a: A) {
 
-  def onSubtype[B <: A]: B =
-    sys.error(".onSubtype should be only called within Chimney DSL")
+  def matching[B <: A]: B =
+    sys.error(".matching should be only called within Chimney DSL")
 
-  def onSome[B](implicit @unused ev: IsOption.Of[A, B]): B =
-    sys.error(".onSome should be only called within Chimney DSL")
+  def matchingSome[SV, S](implicit @unused ev: IsOption.Of[A, SV, S]): SV =
+    sys.error(".matchingSome should be only called within Chimney DSL")
 
-  def onLeft[L, R](implicit @unused ev: IsEither.Of[A, L, R]): L =
-    sys.error(".onLeft should be only called within Chimney DSL")
+  def matchingLeft[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): LV =
+    sys.error(".matchingLeft should be only called within Chimney DSL")
 
-  def onRight[L, R](implicit @unused ev: IsEither.Of[A, L, R]): R =
-    sys.error(".onRight should be only called within Chimney DSL")
+  def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV =
+    sys.error(".matchingRight should be only called within Chimney DSL")
 
-  def eachItem[B](implicit @unused ev: IsCollection.Of[A, B]): B =
-    sys.error(".eachItem should be only called within Chimney DSL")
+  def everyItem[I](implicit @unused ev: IsCollection.Of[A, I]): I =
+    sys.error(".everyItem should be only called within Chimney DSL")
 
-  def eachMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
-    sys.error(".eachMapKey should be only called within Chimney DSL")
+  def everyMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
+    sys.error(".everyMapKey should be only called within Chimney DSL")
 
-  def eachMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
-    sys.error(".eachMapValue should be only called within Chimney DSL")
+  def everyMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
+    sys.error(".everyMapValue should be only called within Chimney DSL")
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.syntax
 import io.scalaland.chimney.{partial, PartialTransformer, Patcher, Transformer}
 import io.scalaland.chimney.internal.runtime.{IsCollection, IsEither, IsMap, IsOption}
 
-import scala.annotation.unused
+import scala.annotation.{compileTimeOnly, unused}
 import scala.util.Try
 
 // Extension methods in dsl.* summon TypeClass.AutoDerived while extension methods in syntax.* summon TypeClass.
@@ -175,27 +175,36 @@ extension [T](`try`: Try[T]) {
     partial.Result.fromTry(`try`)
 }
 
+// $COVERAGE-OFF$methods used only within macro-erased expressions
+
 // TODO docs
 extension [A](@unused a: A) {
 
-  def matching[B <: A]: B =
-    sys.error(".matching should be only called within Chimney DSL")
+  inline def matching[B <: A]: B = compiletime.error(".matching should be only called within Chimney DSL")
 
-  def matchingSome[SV, S](implicit @unused ev: IsOption.Of[A, SV, S]): SV =
-    sys.error(".matchingSome should be only called within Chimney DSL")
+  inline def matchingSome[SV, S](implicit @unused ev: IsOption.Of[A, SV, S]): SV =
+    compiletime.error(".matchingSome should be only called within Chimney DSL")
 
-  def matchingLeft[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): LV =
-    sys.error(".matchingLeft should be only called within Chimney DSL")
+  inline def matchingLeft[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): LV =
+    compiletime.error(".matchingLeft should be only called within Chimney DSL")
 
-  def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV =
-    sys.error(".matchingRight should be only called within Chimney DSL")
-
-  def everyItem[I](implicit @unused ev: IsCollection.Of[A, I]): I =
-    sys.error(".everyItem should be only called within Chimney DSL")
-
-  def everyMapKey[K, V](implicit @unused ev: IsMap.Of[A, K, V]): K =
-    sys.error(".everyMapKey should be only called within Chimney DSL")
-
-  def everyMapValue[K, V](implicit @unused ev: IsMap.Of[A, K, V]): V =
-    sys.error(".everyMapValue should be only called within Chimney DSL")
+  inline def matchingRight[LV, RV, L, R](implicit @unused ev: IsEither.Of[A, LV, RV, L, R]): RV =
+    compiletime.error(".matchingRight should be only called within Chimney DSL")
 }
+
+extension [C[_], I](@unused cc: C[I]) {
+
+  inline def everyItem(implicit @unused ev: IsCollection.Of[C[I], I]): I =
+    compiletime.error(".everyItem should be only called within Chimney DSL")
+}
+
+extension [M[_, _], K, V](@unused cc: M[K, V]) {
+
+  inline def everyMapKey(implicit @unused ev: IsMap.Of[M[K, V], K, V]): K =
+    compiletime.error(".everyMapKey should be only called within Chimney DSL")
+
+  inline def everyMapValue(implicit @unused ev: IsMap.Of[M[K, V], K, V]): V =
+    compiletime.error(".everyMapValue should be only called within Chimney DSL")
+}
+
+// $COVERAGE-ON$

--- a/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
@@ -193,9 +193,9 @@ extension [A](@unused a: A) {
   def everyItem[I](implicit @unused ev: IsCollection.Of[A, I]): I =
     sys.error(".everyItem should be only called within Chimney DSL")
 
-  def everyMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
+  def everyMapKey[K, V](implicit @unused ev: IsMap.Of[A, K, V]): K =
     sys.error(".everyMapKey should be only called within Chimney DSL")
 
-  def everyMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
+  def everyMapValue[K, V](implicit @unused ev: IsMap.Of[A, K, V]): V =
     sys.error(".everyMapValue should be only called within Chimney DSL")
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
@@ -1,7 +1,9 @@
 package io.scalaland.chimney.syntax
 
 import io.scalaland.chimney.{partial, PartialTransformer, Patcher, Transformer}
+import io.scalaland.chimney.internal.runtime.{IsCollection, IsEither, IsMap, IsOption}
 
+import scala.annotation.unused
 import scala.util.Try
 
 // Extension methods in dsl.* summon TypeClass.AutoDerived while extension methods in syntax.* summon TypeClass.
@@ -171,4 +173,28 @@ extension [T](`try`: Try[T]) {
     */
   transparent inline def toPartialResult: partial.Result[T] =
     partial.Result.fromTry(`try`)
+}
+
+extension [A](@unused a: A) {
+
+  def onSubtype[B <: A]: B =
+    sys.error(".onSubtype should be only called within Chimney DSL")
+
+  def onSome[B](implicit @unused ev: IsOption.Of[A, B]): B =
+    sys.error(".onSome should be only called within Chimney DSL")
+
+  def onLeft[L, R](implicit @unused ev: IsEither.Of[A, L, R]): L =
+    sys.error(".onLeft should be only called within Chimney DSL")
+
+  def onRight[L, R](implicit @unused ev: IsEither.Of[A, L, R]): R =
+    sys.error(".onRight should be only called within Chimney DSL")
+
+  def eachItem[B](implicit @unused ev: IsCollection.Of[A, B]): B =
+    sys.error(".eachItem should be only called within Chimney DSL")
+
+  def eachMapKey[K, V](implicit @unused ev: IsMap.Of[K, V, A]): K =
+    sys.error(".eachMapKey should be only called within Chimney DSL")
+
+  def eachMapValue[K, V](implicit @unused ev: IsMap.Of[K, V, A]): V =
+    sys.error(".eachMapValue should be only called within Chimney DSL")
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -246,6 +246,24 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             Any,
             runtime.Path.Match
           ] { this: Match.type => }
+      val EachItem: EachItemModule
+      trait EachItemModule
+          extends Type.Ctor1UpperBounded[
+            runtime.Path,
+            runtime.Path.EachItem
+          ] { this: EachItem.type => }
+      val EachMapKey: EachMapKeyModule
+      trait EachMapKeyModule
+          extends Type.Ctor1UpperBounded[
+            runtime.Path,
+            runtime.Path.EachMapKey
+          ] { this: EachMapKey.type => }
+      val EachMapValue: EachMapValueModule
+      trait EachMapValueModule
+          extends Type.Ctor1UpperBounded[
+            runtime.Path,
+            runtime.Path.EachMapValue
+          ] { this: EachMapValue.type => }
     }
 
     // You can `import ChimneyType.Implicits.*` in your shared code to avoid providing types manually, while avoiding conflicts

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -239,31 +239,31 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             String,
             runtime.Path.Select
           ] { this: Select.type => }
-      val Match: MatchModule
-      trait MatchModule
+      val Matching: MatchingModule
+      trait MatchingModule
           extends Type.Ctor2UpperBounded[
             runtime.Path,
             Any,
-            runtime.Path.Match
-          ] { this: Match.type => }
-      val EachItem: EachItemModule
-      trait EachItemModule
+            runtime.Path.Matching
+          ] { this: Matching.type => }
+      val EveryItem: EveryItemModule
+      trait EveryItemModule
           extends Type.Ctor1UpperBounded[
             runtime.Path,
-            runtime.Path.EachItem
-          ] { this: EachItem.type => }
-      val EachMapKey: EachMapKeyModule
-      trait EachMapKeyModule
+            runtime.Path.EveryItem
+          ] { this: EveryItem.type => }
+      val EveryMapKey: EveryMapKeyModule
+      trait EveryMapKeyModule
           extends Type.Ctor1UpperBounded[
             runtime.Path,
-            runtime.Path.EachMapKey
-          ] { this: EachMapKey.type => }
-      val EachMapValue: EachMapValueModule
-      trait EachMapValueModule
+            runtime.Path.EveryMapKey
+          ] { this: EveryMapKey.type => }
+      val EveryMapValue: EveryMapValueModule
+      trait EveryMapValueModule
           extends Type.Ctor1UpperBounded[
             runtime.Path,
-            runtime.Path.EachMapValue
-          ] { this: EachMapValue.type => }
+            runtime.Path.EveryMapValue
+          ] { this: EveryMapValue.type => }
     }
 
     // You can `import ChimneyType.Implicits.*` in your shared code to avoid providing types manually, while avoiding conflicts

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
@@ -100,7 +100,9 @@ private[compiletime] trait Derivation
                 patchGetter.value.get(ctx.patch).asInstanceOfExpr[Option[GetterInner]]
               )
                 .map { (transformedExpr: Expr[Option[TargetInner]]) =>
-                  Some(transformedExpr.orElse(targetGetter.value.get(ctx.obj).upcastExpr[Option[TargetInner]]).as_??)
+                  Some(
+                    transformedExpr.orElse(targetGetter.value.get(ctx.obj).upcastToExprOf[Option[TargetInner]]).as_??
+                  )
                 }
             case _ =>
               assertionFailed(
@@ -121,7 +123,7 @@ private[compiletime] trait Derivation
                   import inner.Underlying as Inner, targetGetter.Underlying as TargetGetter
                   PrependDefinitionsTo
                     .prependVal[Option[Inner]](
-                      patchGetter.value.get(ctx.patch).upcastExpr[Option[Inner]],
+                      patchGetter.value.get(ctx.patch).upcastToExprOf[Option[Inner]],
                       ExprPromise.NameGenerationStrategy.FromPrefix(patchFieldName)
                     )
                     .traverse { (option: Expr[Option[Inner]]) =>
@@ -129,7 +131,7 @@ private[compiletime] trait Derivation
                         src = option.get
                       ).map { (transformedExpr: Expr[TargetParam]) =>
                         Expr.ifElse(option.isDefined)(transformedExpr)(
-                          targetGetter.value.get(ctx.obj).widenExpr[TargetParam]
+                          targetGetter.value.get(ctx.obj).upcastToExprOf[TargetParam]
                         )
                       }
                     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -88,6 +88,10 @@ private[compiletime] trait Configurations { this: Derivation =>
     import Path.Segment.*
     def select(name: String): Path = new Path(segments :+ Select(name))
     def `match`[Tpe: Type]: Path = new Path(segments :+ Match(Type[Tpe].as_??))
+    // TODO: implement these
+    def eachItem: Path = Path.clean
+    def eachMapKey: Path = Path.clean
+    def eachMapValue: Path = Path.clean
 
     @scala.annotation.tailrec
     def drop(prefix: Path)(implicit ctx: TransformationContext[?, ?]): Option[Path] = (prefix, this) match {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -150,7 +150,7 @@ private[compiletime] trait Configurations { this: Derivation =>
           case _           => false
         }
 
-        override def toString: String = s".whenSubtype[${Type.prettyPrint(tpe.Underlying)}]"
+        override def toString: String = s".onSubtype[${Type.prettyPrint(tpe.Underlying)}]"
       }
       case object EachItem extends Segment {
         override def toString: String = ".eachItem"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -266,8 +266,13 @@ private[compiletime] trait Configurations { this: Derivation =>
             // Constructor is always matched at "_" Path, and dropped only when going inward
             case _: TransformerOverride.ForConstructor => false
           }
-          newPath <- path.drop(toPath)
+          newPath <- path.drop(toPath).to(Vector)
           if !(newPath == Path.Root && alwaysDropOnRoot)
+//          newPathWorkaround <- newPath match {
+//            case Path.AtSubtype(_, tail) => Vector(newPath, tail)
+//            case _                       => Vector(newPath)
+//          }
+//        } yield newPathWorkaround -> runtimeOverride,
         } yield newPath -> runtimeOverride,
         preventImplicitSummoningForTypes = None
       )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -39,14 +39,14 @@ private[compiletime] trait Derivation
   /** Intended use case: recursive derivation within rules */
   final protected def deriveRecursiveTransformationExpr[NewFrom: Type, NewTo: Type](
       newSrc: Expr[NewFrom],
-      followTo: Path = Path.clean
+      followTo: Path
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] =
     deriveRecursiveTransformationExprUpdatingRules[NewFrom, NewTo](newSrc, followTo)(identity)
 
   /** Intended use case: recursive derivation within rules which should remove some rules from consideration */
   final protected def deriveRecursiveTransformationExprUpdatingRules[NewFrom: Type, NewTo: Type](
       newSrc: Expr[NewFrom],
-      followTo: Path = Path.clean
+      followTo: Path
   )(
       updateRules: List[Rule] => List[Rule]
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
@@ -28,24 +28,24 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
         ctx: TransformationContext[From, To]
     ): DerivationResult[Rule.ExpansionResult[To]] =
       deriveRecursiveTransformationExpr[FromL, ToL](
-        ctx.src.upcastExpr[Left[FromL, FromR]].value,
+        ctx.src.upcastToExprOf[Left[FromL, FromR]].value,
         Path.Root.matching[Left[ToL, ToR]]
       ).flatMap { (derivedToL: TransformationExpr[ToL]) =>
         // We're constructing:
         // '{ Left( ${ derivedToL } ) /* from ${ src }.value */ }
-        DerivationResult.expanded(derivedToL.map(Expr.Either.Left[ToL, ToR](_).upcastExpr[To]))
+        DerivationResult.expanded(derivedToL.map(Expr.Either.Left[ToL, ToR](_).upcastToExprOf[To]))
       }
 
     private def mapRight[From, To, FromL: Type, FromR: Type, ToL: Type, ToR: Type](implicit
         ctx: TransformationContext[From, To]
     ): DerivationResult[Rule.ExpansionResult[To]] =
       deriveRecursiveTransformationExpr[FromR, ToR](
-        ctx.src.upcastExpr[Right[FromL, FromR]].value,
+        ctx.src.upcastToExprOf[Right[FromL, FromR]].value,
         Path.Root.matching[Right[ToL, ToR]]
       ).flatMap { (derivedToR: TransformationExpr[ToR]) =>
         // We're constructing:
         // '{ Right( ${ derivedToR } ) /* from ${ src }.value */ }
-        DerivationResult.expanded(derivedToR.map(Expr.Either.Right[ToL, ToR](_).upcastExpr[To]))
+        DerivationResult.expanded(derivedToR.map(Expr.Either.Right[ToL, ToR](_).upcastToExprOf[To]))
       }
 
     private def mapEither[From, To, FromL: Type, FromR: Type, ToL: Type, ToR: Type](implicit
@@ -64,9 +64,9 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
         }
 
       val inLeft =
-        (expr: Expr[ToL]) => Expr.Either.Left[ToL, ToR](expr).upcastExpr[To]
+        (expr: Expr[ToL]) => Expr.Either.Left[ToL, ToR](expr).upcastToExprOf[To]
       val inRight =
-        (expr: Expr[ToR]) => Expr.Either.Right[ToL, ToR](expr).upcastExpr[To]
+        (expr: Expr[ToR]) => Expr.Either.Right[ToL, ToR](expr).upcastToExprOf[To]
 
       toLeftResult
         .map2(toRightResult) {
@@ -81,7 +81,7 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
                 // }
                 TransformationExpr.fromTotal(
                   ctx.src
-                    .upcastExpr[Either[FromL, FromR]]
+                    .upcastToExprOf[Either[FromL, FromR]]
                     .fold[To](
                       totalToLeft.map(inLeft).fulfilAsLambda
                     )(
@@ -97,7 +97,7 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
                 // }
                 TransformationExpr.fromPartial(
                   ctx.src
-                    .upcastExpr[Either[FromL, FromR]]
+                    .upcastToExprOf[Either[FromL, FromR]]
                     .fold[partial.Result[To]](
                       toLeft.map(_.ensurePartial.map[To](Expr.Function1.instance(inLeft))).fulfilAsLambda
                     )(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
@@ -29,7 +29,7 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
     ): DerivationResult[Rule.ExpansionResult[To]] =
       deriveRecursiveTransformationExpr[FromL, ToL](
         ctx.src.upcastExpr[Left[FromL, FromR]].value,
-        Path.Root.`match`[Left[ToL, ToR]]
+        Path.Root.matching[Left[ToL, ToR]]
       ).flatMap { (derivedToL: TransformationExpr[ToL]) =>
         // We're constructing:
         // '{ Left( ${ derivedToL } ) /* from ${ src }.value */ }
@@ -41,7 +41,7 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
     ): DerivationResult[Rule.ExpansionResult[To]] =
       deriveRecursiveTransformationExpr[FromR, ToR](
         ctx.src.upcastExpr[Right[FromL, FromR]].value,
-        Path.Root.`match`[Right[ToL, ToR]]
+        Path.Root.matching[Right[ToL, ToR]]
       ).flatMap { (derivedToR: TransformationExpr[ToR]) =>
         // We're constructing:
         // '{ Right( ${ derivedToR } ) /* from ${ src }.value */ }
@@ -54,13 +54,13 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
       val toLeftResult = ExprPromise
         .promise[FromL](ExprPromise.NameGenerationStrategy.FromPrefix("left"))
         .traverse { (leftExpr: Expr[FromL]) =>
-          deriveRecursiveTransformationExpr[FromL, ToL](leftExpr, Path.Root.`match`[Left[ToL, ToR]])
+          deriveRecursiveTransformationExpr[FromL, ToL](leftExpr, Path.Root.matching[Left[ToL, ToR]])
         }
 
       val toRightResult = ExprPromise
         .promise[FromR](ExprPromise.NameGenerationStrategy.FromPrefix("right"))
         .traverse { (rightExpr: Expr[FromR]) =>
-          deriveRecursiveTransformationExpr[FromR, ToR](rightExpr, Path.Root.`match`[Right[ToL, ToR]])
+          deriveRecursiveTransformationExpr[FromR, ToR](rightExpr, Path.Root.matching[Right[ToL, ToR]])
         }
 
       val inLeft =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
@@ -28,7 +28,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
         ctx: TransformationContext[From, To]
     ): DerivationResult[Rule.ExpansionResult[To]] =
       deriveRecursiveTransformationExpr[FromL, ToL](
-        ctx.src.upcastExpr[Left[FromL, FromR]].value
+        ctx.src.upcastExpr[Left[FromL, FromR]].value,
+        Path.Root.`match`[Left[ToL, ToR]]
       ).flatMap { (derivedToL: TransformationExpr[ToL]) =>
         // We're constructing:
         // '{ Left( ${ derivedToL } ) /* from ${ src }.value */ }
@@ -39,7 +40,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
         ctx: TransformationContext[From, To]
     ): DerivationResult[Rule.ExpansionResult[To]] =
       deriveRecursiveTransformationExpr[FromR, ToR](
-        ctx.src.upcastExpr[Right[FromL, FromR]].value
+        ctx.src.upcastExpr[Right[FromL, FromR]].value,
+        Path.Root.`match`[Right[ToL, ToR]]
       ).flatMap { (derivedToR: TransformationExpr[ToR]) =>
         // We're constructing:
         // '{ Right( ${ derivedToR } ) /* from ${ src }.value */ }
@@ -52,13 +54,13 @@ private[compiletime] trait TransformEitherToEitherRuleModule { this: Derivation 
       val toLeftResult = ExprPromise
         .promise[FromL](ExprPromise.NameGenerationStrategy.FromPrefix("left"))
         .traverse { (leftExpr: Expr[FromL]) =>
-          deriveRecursiveTransformationExpr[FromL, ToL](leftExpr)
+          deriveRecursiveTransformationExpr[FromL, ToL](leftExpr, Path.Root.`match`[Left[ToL, ToR]])
         }
 
       val toRightResult = ExprPromise
         .promise[FromR](ExprPromise.NameGenerationStrategy.FromPrefix("right"))
         .traverse { (rightExpr: Expr[FromR]) =>
-          deriveRecursiveTransformationExpr[FromR, ToR](rightExpr)
+          deriveRecursiveTransformationExpr[FromR, ToR](rightExpr, Path.Root.`match`[Right[ToL, ToR]])
         }
 
       val inLeft =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -68,10 +68,10 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
                 .fulfilAsLambda2(toValueP) { case ((keyResult, key), valueResult) =>
                   ChimneyExpr.PartialResult.product(
                     keyResult.prependErrorPath(
-                      ChimneyExpr.PathElement.MapKey(key.upcastExpr[Any]).upcastExpr[partial.PathElement]
+                      ChimneyExpr.PathElement.MapKey(key.upcastExpr[Any]).widenExpr[partial.PathElement]
                     ),
                     valueResult.prependErrorPath(
-                      ChimneyExpr.PathElement.MapValue(key.upcastExpr[Any]).upcastExpr[partial.PathElement]
+                      ChimneyExpr.PathElement.MapValue(key.upcastExpr[Any]).widenExpr[partial.PathElement]
                     ),
                     failFast
                   )
@@ -142,7 +142,7 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
                           ExprPromise.promise[Int](ExprPromise.NameGenerationStrategy.FromPrefix("idx"))
                         ) { (result: Expr[partial.Result[InnerTo]], idx: Expr[Int]) =>
                           result.prependErrorPath(
-                            ChimneyExpr.PathElement.Index(idx).upcastExpr[partial.PathElement]
+                            ChimneyExpr.PathElement.Index(idx).widenExpr[partial.PathElement]
                           )
                         }
                         .tupled,

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -39,12 +39,12 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
       val toKeyResult = ExprPromise
         .promise[FromK](ExprPromise.NameGenerationStrategy.FromPrefix("key"))
         .traverse { key =>
-          deriveRecursiveTransformationExpr[FromK, ToK](key).map(_.ensurePartial -> key)
+          deriveRecursiveTransformationExpr[FromK, ToK](key, Path.Root.eachMapKey).map(_.ensurePartial -> key)
         }
       val toValueResult = ExprPromise
         .promise[FromV](ExprPromise.NameGenerationStrategy.FromPrefix("value"))
         .traverse { value =>
-          deriveRecursiveTransformationExpr[FromV, ToV](value).map(_.ensurePartial)
+          deriveRecursiveTransformationExpr[FromV, ToV](value, Path.Root.eachMapValue).map(_.ensurePartial)
         }
 
       toKeyResult.parTuple(toValueResult).parTuple(toIorA.factory).flatMap { case ((toKeyP, toValueP), factory) =>
@@ -91,7 +91,7 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
       ExprPromise
         .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromExpr(ctx.src))
         .traverse { (newFromSrc: Expr[InnerFrom]) =>
-          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromSrc)
+          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromSrc, Path.Root.eachItem)
         }
         .flatMap { (to2P: ExprPromise[InnerFrom, TransformationExpr[InnerTo]]) =>
           to2P.foldTransformationExpr { (totalP: ExprPromise[InnerFrom, Expr[InnerTo]]) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -63,22 +63,22 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
         DerivationResult.expandedPartial(
           ChimneyExpr.PartialResult
             .traverse[To, (FromK, FromV), (ToK, ToV)](
-              ctx.src.widenExpr[Map[FromK, FromV]].iterator,
+              ctx.src.upcastToExprOf[Map[FromK, FromV]].iterator,
               toKeyP
                 .fulfilAsLambda2(toValueP) { case ((keyResult, key), valueResult) =>
                   ChimneyExpr.PartialResult.product(
                     keyResult.prependErrorPath(
-                      ChimneyExpr.PathElement.MapKey(key.upcastExpr[Any]).widenExpr[partial.PathElement]
+                      ChimneyExpr.PathElement.MapKey(key.upcastToExprOf[Any]).upcastToExprOf[partial.PathElement]
                     ),
                     valueResult.prependErrorPath(
-                      ChimneyExpr.PathElement.MapValue(key.upcastExpr[Any]).widenExpr[partial.PathElement]
+                      ChimneyExpr.PathElement.MapValue(key.upcastToExprOf[Any]).upcastToExprOf[partial.PathElement]
                     ),
                     failFast
                   )
                 }
                 .tupled,
               failFast,
-              factory.widenExpr[Factory[(ToK, ToV), To]]
+              factory.upcastToExprOf[Factory[(ToK, ToV), To]]
             )
         )
       }
@@ -105,14 +105,14 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
                 // We're constructing:
                 // '{ ${ src }.to(Factory[$To, $InnerTo]) }
                 DerivationResult.expandedTotal(
-                  fromIorA.to[To](ctx.src)(factory.upcastExpr[Factory[InnerFrom, To]])
+                  fromIorA.to[To](ctx.src)(factory.upcastToExprOf[Factory[InnerFrom, To]])
                 )
               }
             } else if (mappedFrom.Underlying =:= Type[To]) {
               // We're constructing:
               // '{ ${ src }.map(from2 => ${ derivedInnerTo }) }
               import mappedFrom.{Underlying, value as expr}
-              DerivationResult.expandedTotal(expr.upcastExpr[To])
+              DerivationResult.expandedTotal(expr.upcastToExprOf[To])
             } else {
               // We're constructing
               // '{ ${ src }.iterator.map(from2 => ${ derivedInnerTo }).to(Factory[$To, $InnerTo]) }
@@ -142,7 +142,7 @@ private[compiletime] trait TransformIterableToIterableRuleModule { this: Derivat
                           ExprPromise.promise[Int](ExprPromise.NameGenerationStrategy.FromPrefix("idx"))
                         ) { (result: Expr[partial.Result[InnerTo]], idx: Expr[Int]) =>
                           result.prependErrorPath(
-                            ChimneyExpr.PathElement.Index(idx).widenExpr[partial.PathElement]
+                            ChimneyExpr.PathElement.Index(idx).upcastToExprOf[partial.PathElement]
                           )
                         }
                         .tupled,

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformMapToMapRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformMapToMapRuleModule.scala
@@ -17,7 +17,9 @@ private[compiletime] trait TransformMapToMapRuleModule { this: Derivation with T
         case (TransformationContext.ForTotal(_), Type.Map(fromK, fromV), Type.Map(toK, toV))
             if !ctx.config.areOverridesEmpty =>
           import fromK.Underlying as FromK, fromV.Underlying as FromV, toK.Underlying as ToK, toV.Underlying as ToV
-          mapMapForTotalTransformers[From, To, FromK, FromV, ToK, ToV](ctx.src.upcastExpr[Map[FromK, FromV]].iterator)
+          mapMapForTotalTransformers[From, To, FromK, FromV, ToK, ToV](
+            ctx.src.upcastToExprOf[Map[FromK, FromV]].iterator
+          )
         case (TransformationContext.ForTotal(_), IterableOrArray(from2), Type.Map(toK, toV))
             if !ctx.config.areOverridesEmpty =>
           // val Type.Tuple2(fromK, fromV) = from2: @unchecked
@@ -25,12 +27,12 @@ private[compiletime] trait TransformMapToMapRuleModule { this: Derivation with T
           import from2.{Underlying as InnerFrom, value as fromIorA}, fromK.Underlying as FromK,
             fromV.Underlying as FromV, toK.Underlying as ToK, toV.Underlying as ToV
           mapMapForTotalTransformers[From, To, FromK, FromV, ToK, ToV](
-            fromIorA.iterator(ctx.src).upcastExpr[Iterator[(FromK, FromV)]]
+            fromIorA.iterator(ctx.src).upcastToExprOf[Iterator[(FromK, FromV)]]
           )
         case (TransformationContext.ForPartial(_, failFast), Type.Map(fromK, fromV), Type.Map(toK, toV)) =>
           import fromK.Underlying as FromK, fromV.Underlying as FromV, toK.Underlying as ToK, toV.Underlying as ToV
           mapMapForPartialTransformers[From, To, FromK, FromV, ToK, ToV](
-            ctx.src.upcastExpr[Map[FromK, FromV]].iterator,
+            ctx.src.upcastToExprOf[Map[FromK, FromV]].iterator,
             failFast,
             isConversionFromMap = true
           )
@@ -40,7 +42,7 @@ private[compiletime] trait TransformMapToMapRuleModule { this: Derivation with T
           import from2.{Underlying as InnerFrom, value as fromIorA}, fromK.Underlying as FromK,
             fromV.Underlying as FromV, toK.Underlying as ToK, toV.Underlying as ToV
           mapMapForPartialTransformers[From, To, FromK, FromV, ToK, ToV](
-            fromIorA.iterator(ctx.src).upcastExpr[Iterator[(FromK, FromV)]],
+            fromIorA.iterator(ctx.src).upcastToExprOf[Iterator[(FromK, FromV)]],
             failFast,
             isConversionFromMap = false
           )
@@ -133,10 +135,10 @@ private[compiletime] trait TransformMapToMapRuleModule { this: Derivation with T
                   .fulfilAsLambda2(toValueP) { case ((keyResult, key), valueResult) =>
                     ChimneyExpr.PartialResult.product(
                       keyResult.prependErrorPath(
-                        ChimneyExpr.PathElement.MapKey(key.upcastExpr[Any]).widenExpr[partial.PathElement]
+                        ChimneyExpr.PathElement.MapKey(key.upcastToExprOf[Any]).upcastToExprOf[partial.PathElement]
                       ),
                       valueResult.prependErrorPath(
-                        ChimneyExpr.PathElement.MapValue(key.upcastExpr[Any]).widenExpr[partial.PathElement]
+                        ChimneyExpr.PathElement.MapValue(key.upcastToExprOf[Any]).upcastToExprOf[partial.PathElement]
                       ),
                       failFast
                     )
@@ -177,22 +179,22 @@ private[compiletime] trait TransformMapToMapRuleModule { this: Derivation with T
                     import _1.{Underlying as From_1, value as getter_1}, _2.{Underlying as From_2, value as getter_2}
                     ChimneyExpr.PartialResult.product(
                       toKeyP
-                        .fulfilAsVal(getter_1.get(pairExpr).upcastExpr[FromK])
+                        .fulfilAsVal(getter_1.get(pairExpr).upcastToExprOf[FromK])
                         .use(_._1) // "key" (here: _1 value) is not needed
                         .prependErrorPath(
-                          ChimneyExpr.PathElement.Accessor(Expr.String("_1")).widenExpr[partial.PathElement]
+                          ChimneyExpr.PathElement.Accessor(Expr.String("_1")).upcastToExprOf[partial.PathElement]
                         )
                         .prependErrorPath(
-                          ChimneyExpr.PathElement.Index(indexExpr).widenExpr[partial.PathElement]
+                          ChimneyExpr.PathElement.Index(indexExpr).upcastToExprOf[partial.PathElement]
                         ),
                       toValueP
-                        .fulfilAsVal(getter_2.get(pairExpr).upcastExpr[FromV])
+                        .fulfilAsVal(getter_2.get(pairExpr).upcastToExprOf[FromV])
                         .closeBlockAsExprOf[partial.Result[ToV]]
                         .prependErrorPath(
-                          ChimneyExpr.PathElement.Accessor(Expr.String("_2")).widenExpr[partial.PathElement]
+                          ChimneyExpr.PathElement.Accessor(Expr.String("_2")).upcastToExprOf[partial.PathElement]
                         )
                         .prependErrorPath(
-                          ChimneyExpr.PathElement.Index(indexExpr).widenExpr[partial.PathElement]
+                          ChimneyExpr.PathElement.Index(indexExpr).upcastToExprOf[partial.PathElement]
                         ),
                       failFast
                     )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformMapToMapRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformMapToMapRuleModule.scala
@@ -34,12 +34,12 @@ private[compiletime] trait TransformMapToMapRuleModule { this: Derivation with T
       val toKeyResult = ExprPromise
         .promise[FromK](ExprPromise.NameGenerationStrategy.FromPrefix("key"))
         .traverse { key =>
-          deriveRecursiveTransformationExpr[FromK, ToK](key).map(_.ensurePartial -> key)
+          deriveRecursiveTransformationExpr[FromK, ToK](key, Path.Root.eachMapKey).map(_.ensurePartial -> key)
         }
       val toValueResult = ExprPromise
         .promise[FromV](ExprPromise.NameGenerationStrategy.FromPrefix("value"))
         .traverse { value =>
-          deriveRecursiveTransformationExpr[FromV, ToV](value).map(_.ensurePartial)
+          deriveRecursiveTransformationExpr[FromV, ToV](value, Path.Root.eachMapValue).map(_.ensurePartial)
         }
 
       val factoryResult = DerivationResult.summonImplicit[Factory[(ToK, ToV), To]]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -29,7 +29,7 @@ private[compiletime] trait TransformOptionToOptionRuleModule { this: Derivation 
       ExprPromise
         .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromType)
         .traverse { (newFromExpr: Expr[InnerFrom]) =>
-          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromExpr)
+          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromExpr, Path.Root.`match`[Some[InnerTo]])
         }
         .flatMap { (derivedToExprPromise: ExprPromise[InnerFrom, TransformationExpr[InnerTo]]) =>
           derivedToExprPromise.foldTransformationExpr { (totalP: ExprPromise[InnerFrom, Expr[InnerTo]]) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -37,9 +37,9 @@ private[compiletime] trait TransformOptionToOptionRuleModule { this: Derivation 
             // '{ ${ src }.map(innerFrom: $InnerFrom => ${ derivedInnerTo }) }
             DerivationResult.expandedTotal(
               ctx.src
-                .upcastExpr[Option[InnerFrom]]
+                .upcastToExprOf[Option[InnerFrom]]
                 .map(totalP.fulfilAsLambda[InnerTo])
-                .upcastExpr[To]
+                .upcastToExprOf[To]
             )
           } { (partialP: ExprPromise[InnerFrom, Expr[partial.Result[InnerTo]]]) =>
             // We're constructing:
@@ -48,11 +48,11 @@ private[compiletime] trait TransformOptionToOptionRuleModule { this: Derivation 
             // }
             DerivationResult.expandedPartial(
               ctx.src
-                .upcastExpr[Option[InnerFrom]]
+                .upcastToExprOf[Option[InnerFrom]]
                 .fold(
                   ChimneyExpr.PartialResult
                     .Value(Expr.Option.None)
-                    .upcastExpr[partial.Result[Option[InnerTo]]]
+                    .upcastToExprOf[partial.Result[Option[InnerTo]]]
                 )(
                   partialP
                     .map { (derivedResultTo2: Expr[partial.Result[InnerTo]]) =>
@@ -62,7 +62,7 @@ private[compiletime] trait TransformOptionToOptionRuleModule { this: Derivation 
                     }
                     .fulfilAsLambda[partial.Result[Option[InnerTo]]]
                 )
-                .upcastExpr[partial.Result[To]]
+                .upcastToExprOf[partial.Result[To]]
             )
           }
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -29,7 +29,7 @@ private[compiletime] trait TransformOptionToOptionRuleModule { this: Derivation 
       ExprPromise
         .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromType)
         .traverse { (newFromExpr: Expr[InnerFrom]) =>
-          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromExpr, Path.Root.`match`[Some[InnerTo]])
+          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromExpr, Path.Root.matching[Some[InnerTo]])
         }
         .flatMap { (derivedToExprPromise: ExprPromise[InnerFrom, TransformationExpr[InnerTo]]) =>
           derivedToExprPromise.foldTransformationExpr { (totalP: ExprPromise[InnerFrom, Expr[InnerTo]]) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
@@ -41,7 +41,7 @@ private[compiletime] trait TransformPartialOptionToNonOptionRuleModule { this: D
           //   ${ derivedResultTo } // wrap if needed
           // }.getOrElse(partial.Result.empty)
           ctx.src
-            .upcastExpr[Option[InnerFrom]]
+            .upcastToExprOf[Option[InnerFrom]]
             .map(Expr.Function1.instance[InnerFrom, partial.Result[To]] { (from2Expr: Expr[InnerFrom]) =>
               await(deriveRecursiveTransformationExpr[InnerFrom, To](from2Expr, Path.Root)).ensurePartial
             })

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
@@ -43,7 +43,7 @@ private[compiletime] trait TransformPartialOptionToNonOptionRuleModule { this: D
           ctx.src
             .upcastExpr[Option[InnerFrom]]
             .map(Expr.Function1.instance[InnerFrom, partial.Result[To]] { (from2Expr: Expr[InnerFrom]) =>
-              await(deriveRecursiveTransformationExpr[InnerFrom, To](from2Expr)).ensurePartial
+              await(deriveRecursiveTransformationExpr[InnerFrom, To](from2Expr, Path.Root)).ensurePartial
             })
             .getOrElse(ChimneyExpr.PartialResult.fromEmpty[To])
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -682,6 +682,9 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
       path match {
         case Path.AtField(name, path2) => appendPath[A](appendPath[A](expr, name), path2)
         case Path.AtSubtype(_, path2)  => appendPath[A](expr, path2)
+        case Path.AtItem(path2)        => appendPath[A](expr, path2) // TODO: ?
+        case Path.AtMapKey(path2)      => appendPath[A](expr, path2) // TODO: ?
+        case Path.AtMapValue(path2)    => appendPath[A](expr, path2) // TODO: ?
         case _                         => expr
       }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -293,7 +293,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               .runtimeDataStore(runtimeDataIdx)
               .asInstanceOfExpr[partial.Result[CtorParam]]
               .prependErrorPath(
-                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastExpr[partial.PathElement]
+                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).widenExpr[partial.PathElement]
               )
           )
         )
@@ -327,7 +327,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                   .prependErrorPath(
                     ChimneyExpr.PathElement
                       .Accessor(Expr.String(fromName))
-                      .upcastExpr[partial.PathElement]
+                      .widenExpr[partial.PathElement]
                   )
               )
             )
@@ -347,7 +347,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               .asInstanceOfExpr[OriginalFrom => partial.Result[CtorParam]]
               .apply(originalSrc)
               .prependErrorPath(
-                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastExpr[partial.PathElement]
+                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).widenExpr[partial.PathElement]
               )
           )
         )
@@ -692,7 +692,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
           partialE.prependErrorPath(
             ChimneyExpr.PathElement
               .Accessor(Expr.String(path))
-              .upcastExpr[partial.PathElement]
+              .widenExpr[partial.PathElement]
           )
         )
       )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -293,7 +293,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               .runtimeDataStore(runtimeDataIdx)
               .asInstanceOfExpr[partial.Result[CtorParam]]
               .prependErrorPath(
-                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).widenExpr[partial.PathElement]
+                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastToExprOf[partial.PathElement]
               )
           )
         )
@@ -327,7 +327,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                   .prependErrorPath(
                     ChimneyExpr.PathElement
                       .Accessor(Expr.String(fromName))
-                      .widenExpr[partial.PathElement]
+                      .upcastToExprOf[partial.PathElement]
                   )
               )
             )
@@ -347,7 +347,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               .asInstanceOfExpr[OriginalFrom => partial.Result[CtorParam]]
               .apply(originalSrc)
               .prependErrorPath(
-                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).widenExpr[partial.PathElement]
+                ChimneyExpr.PathElement.Accessor(Expr.String(fromName)).upcastToExprOf[partial.PathElement]
               )
           )
         )
@@ -461,7 +461,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               // We're constructing:
               // '{ None }
               DerivationResult.existential[TransformationExpr, CtorParam](
-                TransformationExpr.fromTotal(value.upcastExpr[CtorParam])
+                TransformationExpr.fromTotal(value.upcastToExprOf[CtorParam])
               )
             )
 
@@ -471,7 +471,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
             // We're constructing:
             // '{ () }
             DerivationResult.existential[TransformationExpr, CtorParam](
-              TransformationExpr.fromTotal(value.upcastExpr[CtorParam])
+              TransformationExpr.fromTotal(value.upcastToExprOf[CtorParam])
             )
           }
         }
@@ -651,9 +651,9 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                                 }
                               )
                             )
-                            .upcastExpr[partial.Result[To]]
+                            .upcastToExprOf[partial.Result[To]]
                         } {
-                          allerrors.upcastExpr[partial.Result[To]]
+                          allerrors.upcastToExprOf[partial.Result[To]]
                         }
                       )
                     }
@@ -692,7 +692,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
           partialE.prependErrorPath(
             ChimneyExpr.PathElement
               .Accessor(Expr.String(path))
-              .widenExpr[partial.PathElement]
+              .upcastToExprOf[partial.PathElement]
           )
         )
       )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -681,11 +681,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
     private def appendPath[A: Type](expr: TransformationExpr[A], path: Path): TransformationExpr[A] =
       path match {
         case Path.AtField(name, path2) => appendPath[A](appendPath[A](expr, name), path2)
-        case Path.AtSubtype(_, path2)  => appendPath[A](expr, path2)
-        case Path.AtItem(path2)        => appendPath[A](expr, path2) // TODO: ?
-        case Path.AtMapKey(path2)      => appendPath[A](expr, path2) // TODO: ?
-        case Path.AtMapValue(path2)    => appendPath[A](expr, path2) // TODO: ?
-        case _                         => expr
+        case _                         => expr // Path.Root - other values are not possible in from Path for renames
       }
 
     // If we derived partial.Result[$ctorParam] we are appending

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -127,7 +127,7 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
               lazy val fromSubtypeIntoToSubtype =
                 deriveRecursiveTransformationExpr[FromSubtype, ToSubtype](
                   fromSubtypeExpr,
-                  Path.Root.`match`[ToSubtype]
+                  Path.Root.matching[ToSubtype]
                 ).map(_.map(toUpcast))
               // We're constructing:
               // case fromSubtypeExpr: $fromSubtype => ${ derivedToSubtype } } // or ${ derivedResultToSubtype }; using fromSubtypeExpr.value

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSubtypesRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSubtypesRuleModule.scala
@@ -18,6 +18,6 @@ private[compiletime] trait TransformSubtypesRuleModule { this: Derivation =>
     ): DerivationResult[Rule.ExpansionResult[To]] =
       // We're constructing:
       // '{ ${ src } : $To } }
-      DerivationResult.expandedTotal(ctx.src.upcastExpr[To])
+      DerivationResult.expandedTotal(ctx.src.upcastToExprOf[To])
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
@@ -23,10 +23,7 @@ private[compiletime] trait TransformValueClassToTypeRuleModule {
     )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       // We're constructing:
       // '{ ${ derivedTo } /* using ${ src }.from internally */ }
-      deriveRecursiveTransformationExpr[InnerFrom, To](
-        valueFrom.unwrap(ctx.src),
-        followTo = Path.Root
-      )
+      deriveRecursiveTransformationExpr[InnerFrom, To](valueFrom.unwrap(ctx.src), Path.Root)
         .flatMap(DerivationResult.expanded)
         // fall back to case classes expansion; see https://github.com/scalalandio/chimney/issues/297 for more info
         .orElse(TransformProductToProductRule.expand(ctx))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformationRules.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformationRules.scala
@@ -109,7 +109,7 @@ private[compiletime] trait TransformationRules { this: Derivation =>
     }
     final def ensurePartial: Expr[partial.Result[A]] = fold { expr =>
       implicit val A: Type[A] = Expr.typeOf(expr)
-      ChimneyExpr.PartialResult.Value(expr).upcastExpr[partial.Result[A]]
+      ChimneyExpr.PartialResult.Value(expr).upcastToExprOf[partial.Result[A]]
     }(identity)
 
     def prettyPrint: String = fold(Expr.prettyPrint)(Expr.prettyPrint)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
@@ -1,0 +1,17 @@
+package io.scalaland.chimney.internal.runtime
+
+import scala.annotation.unused
+
+sealed trait IsCollection[C] {
+  type Item
+}
+object IsCollection {
+  type Of[C, A] = IsCollection[C] { type Item = A }
+
+  private object Impl extends IsCollection[Nothing]
+
+  // build-in Chimney support for collections assumes that they are BOTH Iterable and have a Factory
+  implicit def scalaCollectionIsCollection[A, C <: Iterable[A]](implicit
+      @unused ev: scala.collection.compat.Factory[A, C]
+  ): IsCollection.Of[C, A] = Impl.asInstanceOf[IsCollection.Of[C, A]]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.internal.runtime
 
 import scala.annotation.unused
 
+// TODO @implicitNotFound
 sealed trait IsCollection[C] {
   type Item
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
@@ -1,12 +1,17 @@
 package io.scalaland.chimney.internal.runtime
 
-import scala.annotation.unused
+import scala.annotation.{implicitNotFound, unused}
 
-// TODO @implicitNotFound
+@implicitNotFound(
+  "Expected collection (type extending scala.Iterable which has scala.collection.compat.Factory instance), got ${C}"
+)
 sealed trait IsCollection[C] {
   type Item
 }
 object IsCollection {
+  @implicitNotFound(
+    "Expected collection (type extending scala.Iterable which has scala.collection.compat.Factory instance), got ${C}"
+  )
   type Of[C, A] = IsCollection[C] { type Item = A }
 
   private object Impl extends IsCollection[Nothing]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
@@ -2,6 +2,12 @@ package io.scalaland.chimney.internal.runtime
 
 import scala.annotation.{implicitNotFound, unused}
 
+// $COVERAGE-OFF$evidence used only within macro-erased expressions
+
+/** Allow us to provide `.everyItem` extension method only for the types where macros would actually handle it.
+  *
+  * @since 1.0.0
+  */
 @implicitNotFound(
   "Expected collection (type extending scala.Iterable which has scala.collection.compat.Factory instance), got ${C}"
 )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
@@ -8,13 +8,18 @@ import scala.annotation.{implicitNotFound, unused}
 sealed trait IsCollection[C] {
   type Item
 }
-object IsCollection {
+object IsCollection extends IsCollection1 {
   @implicitNotFound(
     "Expected collection (type extending scala.Iterable which has scala.collection.compat.Factory instance), got ${C}"
   )
   type Of[C, A] = IsCollection[C] { type Item = A }
 
-  private object Impl extends IsCollection[Nothing]
+  protected object Impl extends IsCollection[Nothing]
+
+  // build-in Chimney support for Arrays is always provided
+  implicit def arrayIsCollection[A]: IsCollection.Of[Array[A], A] = Impl.asInstanceOf[IsCollection.Of[Array[A], A]]
+}
+private[runtime] trait IsCollection1 { this: IsCollection.type =>
 
   // build-in Chimney support for collections assumes that they are BOTH Iterable and have a Factory
   implicit def scalaCollectionIsCollection[A, C <: Iterable[A]](implicit

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
@@ -1,0 +1,14 @@
+package io.scalaland.chimney.internal.runtime
+
+sealed trait IsEither[E] {
+  type Left
+  type Right
+}
+object IsEither {
+
+  type Of[E, L, R] = IsEither[E] { type Left = L; type Right = R }
+
+  private object Impl extends IsEither[Nothing]
+
+  implicit def eitherOsEither[L, R, E <: Left[L, R]]: IsEither.Of[E, L, R] = Impl.asInstanceOf[IsEither.Of[E, L, R]]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
@@ -2,6 +2,13 @@ package io.scalaland.chimney.internal.runtime
 
 import scala.annotation.implicitNotFound
 
+// $COVERAGE-OFF$evidence used only within macro-erased expressions
+
+/** Allow us to provide `.matchingLeft` and `.matchingRight` extension methods only for the types where macros would
+  * actually handle it.
+  *
+  * @since 1.0.0
+  */
 @implicitNotFound("Expected Either (type extending scala.Either), got ${E}")
 sealed trait IsEither[E] {
   type LeftValue

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
@@ -1,6 +1,8 @@
 package io.scalaland.chimney.internal.runtime
 
-// TODO @implicitNotFound
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Expected Either (type extending scala.Either), got ${E}")
 sealed trait IsEither[E] {
   type LeftValue
   type RightValue
@@ -8,6 +10,7 @@ sealed trait IsEither[E] {
   type Right
 }
 object IsEither {
+  @implicitNotFound("Expected Either (type extending scala.Either), got ${E}")
   type Of[E, LV, RV, L, R] = IsEither[E] { type LeftValue = LV; type RightValue = RV; type Left = L; type Right = R }
 
   private object Impl extends IsEither[Nothing]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
@@ -1,14 +1,17 @@
 package io.scalaland.chimney.internal.runtime
 
+// TODO @implicitNotFound
 sealed trait IsEither[E] {
+  type LeftValue
+  type RightValue
   type Left
   type Right
 }
 object IsEither {
-
-  type Of[E, L, R] = IsEither[E] { type Left = L; type Right = R }
+  type Of[E, LV, RV, L, R] = IsEither[E] { type LeftValue = LV; type RightValue = RV; type Left = L; type Right = R }
 
   private object Impl extends IsEither[Nothing]
 
-  implicit def eitherOsEither[L, R, E <: Left[L, R]]: IsEither.Of[E, L, R] = Impl.asInstanceOf[IsEither.Of[E, L, R]]
+  implicit def eitherOsEither[LV, RV, E <: Either[LV, RV]]: IsEither.Of[E, LV, RV, Left[LV, RV], Right[LV, RV]] =
+    Impl.asInstanceOf[IsEither.Of[E, LV, RV, Left[LV, RV], Right[LV, RV]]]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsEither.scala
@@ -12,6 +12,12 @@ object IsEither {
 
   private object Impl extends IsEither[Nothing]
 
-  implicit def eitherOsEither[LV, RV, E <: Either[LV, RV]]: IsEither.Of[E, LV, RV, Left[LV, RV], Right[LV, RV]] =
-    Impl.asInstanceOf[IsEither.Of[E, LV, RV, Left[LV, RV], Right[LV, RV]]]
+  implicit def eitherIsEither[LV, RV]: IsEither.Of[Either[LV, RV], LV, RV, Left[LV, RV], Right[LV, RV]] =
+    Impl.asInstanceOf[IsEither.Of[Either[LV, RV], LV, RV, Left[LV, RV], Right[LV, RV]]]
+
+  implicit def leftIsEither[LV, RV]: IsEither.Of[Left[LV, RV], LV, RV, Left[LV, RV], Right[LV, RV]] =
+    Impl.asInstanceOf[IsEither.Of[Left[LV, RV], LV, RV, Left[LV, RV], Right[LV, RV]]]
+
+  implicit def rightIsEither[LV, RV]: IsEither.Of[Right[LV, RV], LV, RV, Left[LV, RV], Right[LV, RV]] =
+    Impl.asInstanceOf[IsEither.Of[Right[LV, RV], LV, RV, Left[LV, RV], Right[LV, RV]]]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
@@ -14,5 +14,5 @@ object IsMap {
   // build-in Chimney support for maps assumes that they are BOTH Map and have a Factory
   implicit def scalaMapIsMap[K, V, M <: Map[K, V]](implicit
       @unused ev: scala.collection.compat.Factory[(K, V), M]
-  ): IsMap.Of[K, V, M] = Impl.asInstanceOf[IsMap.Of[K, V, M]]
+  ): IsMap.Of[M, K, V] = Impl.asInstanceOf[IsMap.Of[M, K, V]]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
@@ -1,0 +1,17 @@
+package io.scalaland.chimney.internal.runtime
+import scala.annotation.unused
+
+sealed trait IsMap[M] {
+  type Key
+  type Value
+}
+object IsMap {
+  type Of[M, K, V] = IsMap[M] { type Key = K; type Value = V }
+
+  private object Impl extends IsMap[Nothing]
+
+  // build-in Chimney support for maps assumes that they are BOTH Map and have a Factory
+  implicit def scalaMapIsMap[K, V, M <: Map[K, V]](implicit
+      @unused ev: scala.collection.compat.Factory[(K, V), M]
+  ): IsMap.Of[K, V, M] = Impl.asInstanceOf[IsMap.Of[K, V, M]]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney.internal.runtime
 import scala.annotation.unused
 
+// TODO @implicitNotFound
 sealed trait IsMap[M] {
   type Key
   type Value

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
@@ -2,6 +2,13 @@ package io.scalaland.chimney.internal.runtime
 
 import scala.annotation.{implicitNotFound, unused}
 
+// $COVERAGE-OFF$evidence used only within macro-erased expressions
+
+/** Allow us to provide `.everyMapKey` and `.everyMapValue` extension methods only for the types where macros would
+  * actually handle it.
+  *
+  * @since 1.0.0
+  */
 @implicitNotFound(
   "Expected map (type extending scala.collection.immutable.Map which has scala.collection.compat.Factory instance), got ${M}"
 )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsMap.scala
@@ -1,12 +1,18 @@
 package io.scalaland.chimney.internal.runtime
-import scala.annotation.unused
 
-// TODO @implicitNotFound
+import scala.annotation.{implicitNotFound, unused}
+
+@implicitNotFound(
+  "Expected map (type extending scala.collection.immutable.Map which has scala.collection.compat.Factory instance), got ${M}"
+)
 sealed trait IsMap[M] {
   type Key
   type Value
 }
 object IsMap {
+  @implicitNotFound(
+    "Expected map (type extending scala.collection.immutable.Map which has scala.collection.compat.Factory instance), got ${M}"
+  )
   type Of[M, K, V] = IsMap[M] { type Key = K; type Value = V }
 
   private object Impl extends IsMap[Nothing]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
@@ -1,12 +1,14 @@
 package io.scalaland.chimney.internal.runtime
 
-// TODO: @implicitNotFound
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Expected Option (type extending scala.Option), got ${O}")
 sealed trait IsOption[O] {
   type SomeValue
   type Some
 }
 object IsOption {
-
+  @implicitNotFound("Expected Option (type extending scala.Option), got ${O}")
   type Of[O, SV, S] = IsOption[O] { type SomeValue = SV; type Some = S }
 
   private object Impl extends IsOption[Nothing]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
@@ -11,6 +11,9 @@ object IsOption {
 
   private object Impl extends IsOption[Nothing]
 
-  implicit def optionIsOption[A, O <: Option[A]]: IsOption.Of[O, A, Some[A]] =
-    Impl.asInstanceOf[IsOption.Of[O, A, Some[A]]]
+  implicit def optionIsOption[A]: IsOption.Of[Option[A], A, Some[A]] =
+    Impl.asInstanceOf[IsOption.Of[Option[A], A, Some[A]]]
+
+  implicit def someIsOption[A]: IsOption.Of[Some[A], A, Some[A]] =
+    Impl.asInstanceOf[IsOption.Of[Some[A], A, Some[A]]]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
@@ -1,13 +1,16 @@
 package io.scalaland.chimney.internal.runtime
 
+// TODO: @implicitNotFound
 sealed trait IsOption[O] {
-  type Value
+  type SomeValue
+  type Some
 }
 object IsOption {
 
-  type Of[O, A] = IsOption[O] { type Value = A }
+  type Of[O, SV, S] = IsOption[O] { type SomeValue = SV; type Some = S }
 
   private object Impl extends IsOption[Nothing]
 
-  implicit def optionIsOption[A, O <: Option[A]]: IsOption.Of[O, A] = Impl.asInstanceOf[IsOption.Of[O, A]]
+  implicit def optionIsOption[A, O <: Option[A]]: IsOption.Of[O, A, Some[A]] =
+    Impl.asInstanceOf[IsOption.Of[O, A, Some[A]]]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
@@ -2,6 +2,12 @@ package io.scalaland.chimney.internal.runtime
 
 import scala.annotation.implicitNotFound
 
+// $COVERAGE-OFF$evidence used only within macro-erased expressions
+
+/** Allow us to provide `.matchingSome` extension method only for the types where macros would actually handle it.
+  *
+  * @since 1.0.0
+  */
 @implicitNotFound("Expected Option (type extending scala.Option), got ${O}")
 sealed trait IsOption[O] {
   type SomeValue

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsOption.scala
@@ -1,0 +1,13 @@
+package io.scalaland.chimney.internal.runtime
+
+sealed trait IsOption[O] {
+  type Value
+}
+object IsOption {
+
+  type Of[O, A] = IsOption[O] { type Value = A }
+
+  private object Impl extends IsOption[Nothing]
+
+  implicit def optionIsOption[A, O <: Option[A]]: IsOption.Of[O, A] = Impl.asInstanceOf[IsOption.Of[O, A]]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
@@ -5,4 +5,7 @@ object Path {
   final class Root extends Path
   final class Select[Init <: Path, FieldName <: String] extends Path
   final class Match[Init <: Path, Subtype] extends Path
+  final class EachItem[Init <: Path] extends Path
+  final class EachMapKey[Init <: Path] extends Path
+  final class EachMapValue[Init <: Path] extends Path
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
@@ -4,8 +4,8 @@ sealed abstract class Path
 object Path {
   final class Root extends Path
   final class Select[Init <: Path, FieldName <: String] extends Path
-  final class Match[Init <: Path, Subtype] extends Path
-  final class EachItem[Init <: Path] extends Path
-  final class EachMapKey[Init <: Path] extends Path
-  final class EachMapValue[Init <: Path] extends Path
+  final class Matching[Init <: Path, Subtype] extends Path
+  final class EveryItem[Init <: Path] extends Path
+  final class EveryMapKey[Init <: Path] extends Path
+  final class EveryMapValue[Init <: Path] extends Path
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -373,7 +373,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
 
       val result7 = Person("John", 10, 140)
         .intoPartial[User]
-        .withFieldComputed(_.age, _ => throw new Exception("error happened"))
+        .withFieldComputed(_.age, _ => sys.error("error happened"))
         .transform
       result7.asOption ==> None
       result7.asEither.isLeft ==> true

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -89,7 +89,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
       import products.{Foo, Bar, HaveY}
 
       compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.y + "abc", "pi").transform""").check(
-        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
       )
 
       compileErrorsFixed(
@@ -242,7 +242,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
           .transform
         """
       ).check(
-        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
       )
 
       compileErrorsFixed(
@@ -420,7 +420,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
         Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.y + "abc", _.toString).transform
         """
       ).check(
-        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
       )
 
       compileErrorsFixed(
@@ -601,7 +601,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
         Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.y + "abc", _ => ???).transform
         """
       ).check(
-        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
       )
 
       compileErrorsFixed(
@@ -817,7 +817,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
         User(1, "Kuba", Some(28)).intoPartial[UserPL].withFieldRenamed(_.age + "ABC", _.toString).transform
         """
       ).check(
-        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
       )
 
       compileErrorsFixed(

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -89,7 +89,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
       import products.{Foo, Bar, HaveY}
 
       compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.y + "abc", "pi").transform""").check(
-        "Invalid selector expression"
+        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
       )
 
       compileErrorsFixed(
@@ -97,7 +97,22 @@ class PartialTransformerProductSpec extends ChimneySpec {
         val haveY = HaveY("")
         Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(cc => haveY.y, "pi").transform
         """
-      ).check("Invalid selector expression")
+      ).check("The path expression has to be a single chain of calls on the original input, got external identifier:")
+
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.matching, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.matchingSome, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.matchingLeft, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.matchingRight, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.everyItem, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.everyMapKey, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConst(_.everyMapValue, "pi").transform""")
+        .arePresent()
     }
 
     test("should provide a value for selected target case class field when selector is valid") {
@@ -226,7 +241,9 @@ class PartialTransformerProductSpec extends ChimneySpec {
           .withFieldConstPartial(_.y + "abc", partial.Result.fromValue("pi"))
           .transform
         """
-      ).check("Invalid selector expression")
+      ).check(
+        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+      )
 
       compileErrorsFixed(
         """
@@ -236,7 +253,27 @@ class PartialTransformerProductSpec extends ChimneySpec {
           .withFieldConstPartial(cc => haveY.y, partial.Result.fromValue("pi"))
           .transform
         """
-      ).check("Invalid selector expression")
+      ).check("The path expression has to be a single chain of calls on the original input, got external identifier:")
+
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConstPartial(_.matching, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed(
+        """Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConstPartial(_.matchingSome, "pi").transform"""
+      ).arePresent()
+      compileErrorsFixed(
+        """Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConstPartial(_.matchingLeft, "pi").transform"""
+      ).arePresent()
+      compileErrorsFixed(
+        """Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConstPartial(_.matchingRight, "pi").transform"""
+      ).arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConstPartial(_.everyItem, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed(
+        """Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConstPartial(_.everyMapKey, "pi").transform"""
+      ).arePresent()
+      compileErrorsFixed(
+        """Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldConstPartial(_.everyMapValue, "pi").transform"""
+      ).arePresent()
     }
 
     test("should provide a value for selected target case class field when selector is valid") {
@@ -380,22 +417,54 @@ class PartialTransformerProductSpec extends ChimneySpec {
 
       compileErrorsFixed(
         """
-        Bar(3, (3.14, 3.14))
-          .intoPartial[Foo]
-          .withFieldComputed(_.y + "abc", _.toString)
-          .transform
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.y + "abc", _.toString).transform
         """
-      ).check("Invalid selector expression")
+      ).check(
+        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+      )
 
       compileErrorsFixed(
         """
         val haveY = HaveY("")
-        Bar(3, (3.14, 3.14))
-          .intoPartial[Foo]
-          .withFieldComputed(cc => haveY.y, _.toString)
-          .transform
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(cc => haveY.y, _.toString).transform
         """
-      ).check("Invalid selector expression")
+      ).check("The path expression has to be a single chain of calls on the original input, got external identifier:")
+
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.matching, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.matchingSome, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.matchingLeft, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.matchingRight, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.everyItem, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.everyMapKey, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.everyMapValue, _.toString).transform
+        """
+      ).arePresent()
     }
 
     test("should provide a value for selected target case class field when selector is valid") {
@@ -529,16 +598,54 @@ class PartialTransformerProductSpec extends ChimneySpec {
 
       compileErrorsFixed(
         """
-        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(_.y + "abc", _.toString).transform
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.y + "abc", _ => ???).transform
         """
-      ).check("Invalid selector expression")
+      ).check(
+        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+      )
 
       compileErrorsFixed(
         """
         val haveY = HaveY("")
-        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputed(cc => haveY.y, _.toString).transform
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(cc => haveY.y, _ => ???).transform
         """
-      ).check("Invalid selector expression")
+      ).check("The path expression has to be a single chain of calls on the original input, got external identifier:")
+
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.matching, _ => ???).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.matchingSome, _ => ???).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.matchingLeft, _ => ???).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.matchingRight, _ => ???).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.everyItem, _ => ???).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.everyMapKey, _ => ???).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldComputedPartial(_.everyMapValue, _ => ???).transform
+        """
+      ).arePresent()
     }
 
     test("should provide a value for selected target case class field when selector is valid") {
@@ -709,16 +816,52 @@ class PartialTransformerProductSpec extends ChimneySpec {
         """
         User(1, "Kuba", Some(28)).intoPartial[UserPL].withFieldRenamed(_.age + "ABC", _.toString).transform
         """
-      ).arePresent()
+      ).check(
+        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+      )
 
       compileErrorsFixed(
         """
         val str = "string"
         User(1, "Kuba", Some(28)).intoPartial[UserPL].withFieldRenamed(u => str, _.toString).transform
         """
-      ).check(
-        "Invalid selector expression"
-      )
+      ).check("The path expression has to be a single chain of calls on the original input, got external identifier:")
+
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldRenamed(_.matching, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldRenamed(_.matchingSome, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldRenamed(_.matchingLeft, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldRenamed(_.matchingRight, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldRenamed(_.everyItem, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldRenamed(_.everyMapKey, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).intoPartial[Foo].withFieldRenamed(_.everyMapValue, _.toString).transform
+        """
+      ).arePresent()
     }
 
     test(

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
@@ -384,7 +384,7 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
     ArrayBuffer("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]]
-      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value", "(2)" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value", "(1)._2" -> "empty value")
     Map("x" -> "10", "y" -> "z")
       .transformIntoPartial[List[(Int, Int)]]
       .asErrorPathMessageStrings ==> Iterable(
@@ -395,7 +395,7 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
     ArrayBuffer("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]](failFast = true)
-      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value")
     Map("x" -> "10", "y" -> "z")
       .transformIntoPartial[List[(Int, Int)]](failFast = true)
       .asErrorPathMessageStrings ==> Iterable("keys(x)" -> "empty value")
@@ -436,14 +436,14 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
     Array("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]]
-      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value", "(2)" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value", "(1)._2" -> "empty value")
     Map("x" -> "10", "y" -> "20")
       .transformIntoPartial[Array[(Int, String)]]
       .asErrorPathMessageStrings ==> Iterable("keys(x)" -> "empty value", "keys(y)" -> "empty value")
 
     Array("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]](failFast = true)
-      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value")
     Map("x" -> "10", "y" -> "20")
       .transformIntoPartial[Array[(Int, String)]](failFast = true)
       .asErrorPathMessageStrings ==> Iterable("keys(x)" -> "empty value")

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
@@ -384,7 +384,7 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
     ArrayBuffer("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]]
-      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value", "(1)._2" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value", "(2)" -> "empty value")
     Map("x" -> "10", "y" -> "z")
       .transformIntoPartial[List[(Int, Int)]]
       .asErrorPathMessageStrings ==> Iterable(
@@ -395,7 +395,7 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
     ArrayBuffer("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]](failFast = true)
-      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value")
     Map("x" -> "10", "y" -> "z")
       .transformIntoPartial[List[(Int, Int)]](failFast = true)
       .asErrorPathMessageStrings ==> Iterable("keys(x)" -> "empty value")
@@ -436,14 +436,14 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
     Array("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]]
-      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value", "(1)._2" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value", "(2)" -> "empty value")
     Map("x" -> "10", "y" -> "20")
       .transformIntoPartial[Array[(Int, String)]]
       .asErrorPathMessageStrings ==> Iterable("keys(x)" -> "empty value", "keys(y)" -> "empty value")
 
     Array("1" -> "x", "2" -> "y")
       .transformIntoPartial[Map[String, Int]](failFast = true)
-      .asErrorPathMessageStrings ==> Iterable("(0)._2" -> "empty value")
+      .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value")
     Map("x" -> "10", "y" -> "20")
       .transformIntoPartial[Array[(Int, String)]](failFast = true)
       .asErrorPathMessageStrings ==> Iterable("keys(x)" -> "empty value")

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
@@ -318,6 +318,30 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
       .asErrorPathMessageStrings ==> Iterable("(1)" -> "empty value")
   }
 
+  test("transform into sequential type with an override") {
+    import TotalTransformerStdLibTypesSpec.*
+
+    Iterable(Foo("a")).intoPartial[Seq[Bar]].withFieldConst(_.everyItem.value, "override").transform.asOption ==>
+      Some(Seq(Bar("override")))
+    Iterable(Foo("a")).intoPartial[List[Bar]].withFieldConst(_.everyItem.value, "override").transform.asOption ==> Some(
+      List(Bar("override"))
+    )
+    Iterable(Foo("a"))
+      .intoPartial[Vector[Bar]]
+      .withFieldConst(_.everyItem.value, "override")
+      .transform
+      .asOption ==> Some(Vector(Bar("override")))
+    Iterable(Foo("a")).intoPartial[Set[Bar]].withFieldConst(_.everyItem.value, "override").transform.asOption ==> Some(
+      Set(Bar("override"))
+    )
+    Iterable(Foo("a"))
+      .intoPartial[Array[Bar]]
+      .withFieldConst(_.everyItem.value, "override")
+      .transform
+      .asOption
+      .get ==> Array(Bar("override"))
+  }
+
   test("transform Map-type to Map-type, using Total Transformer for inner type transformation") {
     implicit val intPrinter: Transformer[Int, String] = _.toString
 
@@ -447,6 +471,17 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
     Map("x" -> "10", "y" -> "20")
       .transformIntoPartial[Array[(Int, String)]](failFast = true)
       .asErrorPathMessageStrings ==> Iterable("keys(x)" -> "empty value")
+  }
+
+  test("transform into map type with an override") {
+    import TotalTransformerStdLibTypesSpec.*
+
+    Iterable(Foo("a") -> Foo("b"))
+      .intoPartial[Map[Bar, Bar]]
+      .withFieldConst(_.everyMapKey.value, "ov1")
+      .withFieldConst(_.everyMapValue.value, "ov2")
+      .transform
+      .asOption ==> Some(Map(Bar("ov1") -> Bar("ov2")))
   }
 
   group("flag .enableOptionDefaultsToNone") {

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -50,7 +50,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
       import products.{Foo, Bar, HaveY}
 
       compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.y + "abc", "pi").transform""").check(
-        "Invalid selector expression"
+        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
       )
 
       compileErrorsFixed(
@@ -58,7 +58,20 @@ class TotalTransformerProductSpec extends ChimneySpec {
         val haveY = HaveY("")
         Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(cc => haveY.y, "pi").transform
         """
-      ).check("Invalid selector expression")
+      ).check("The path expression has to be a single chain of calls on the original input, got external identifier:")
+
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.matching, "pi").transform""").arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.matchingSome, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.matchingLeft, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.matchingRight, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.everyItem, "pi").transform""").arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.everyMapKey, "pi").transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.everyMapValue, "pi").transform""")
+        .arePresent()
     }
 
     test("should provide a value for selected target case class field when selector is valid") {
@@ -134,14 +147,31 @@ class TotalTransformerProductSpec extends ChimneySpec {
       import products.{Foo, Bar, HaveY}
 
       compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.y + "abc", _.toString).transform""")
-        .check("Invalid selector expression")
+        .check(
+          "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        )
 
       compileErrorsFixed(
         """
         val haveY = HaveY("")
         Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(cc => haveY.y, _.toString).transform
         """
-      ).check("Invalid selector expression")
+      ).check("The path expression has to be a single chain of calls on the original input, got external identifier:")
+
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.matching, _.toString).transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.matchingSome, _.toString).transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.matchingLeft, _.toString).transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.matchingRight, _.toString).transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.everyItem, _.toString).transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.everyMapKey, _.toString).transform""")
+        .arePresent()
+      compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.everyMapValue, _.toString).transform""")
+        .arePresent()
     }
 
     test("should provide a value for selected target case class field when selector is valid") {
@@ -242,7 +272,9 @@ class TotalTransformerProductSpec extends ChimneySpec {
 
       compileErrorsFixed(
         """User(1, "Kuba", Some(28)).into[UserPL].withFieldRenamed(_.age + "ABC", _.toString).transform"""
-      ).arePresent()
+      ).check(
+        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+      )
 
       compileErrorsFixed(
         """
@@ -250,8 +282,44 @@ class TotalTransformerProductSpec extends ChimneySpec {
         User(1, "Kuba", Some(28)).into[UserPL].withFieldRenamed(u => str, _.toString).transform
         """
       ).check(
-        "Invalid selector expression"
+        "The path expression has to be a single chain of calls on the original input, got external identifier:"
       )
+
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).into[Foo].withFieldRenamed(_.matching, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).into[Foo].withFieldRenamed(_.matchingSome, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).into[Foo].withFieldRenamed(_.matchingLeft, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).into[Foo].withFieldRenamed(_.matchingRight, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).into[Foo].withFieldRenamed(_.everyItem, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).into[Foo].withFieldRenamed(_.everyMapKey, _.toString).transform
+        """
+      ).arePresent()
+      compileErrorsFixed(
+        """
+        Bar(3, (3.14, 3.14)).into[Foo].withFieldRenamed(_.everyMapValue, _.toString).transform
+        """
+      ).arePresent()
     }
 
     test(

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -157,6 +157,41 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .into[NestedProduct[User]]
         .withFieldComputed(_.value.age, _.getValue.age * 2)
         .transform ==> NestedProduct(User("John", 20, 140))
+
+      NestedComplex(
+        Some(Person("John", 10, 140)),
+        Right(Person("John", 10, 140)),
+        List(Person("John", 10, 140)),
+        scala.collection.immutable.ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
+      ).into[NestedComplex[User]]
+        .withFieldComputed(_.option.matchingSome.age, _ => 15)
+        .withFieldComputed(_.either.matchingLeft.age, _ => 20)
+        .withFieldComputed(_.either.matchingRight.age, _ => 30)
+        .withFieldComputed(_.collection.everyItem.age, _ => 40)
+        .withFieldComputed(_.map.everyMapKey.age, _ => 50)
+        .withFieldComputed(_.map.everyMapValue.age, _ => 60)
+        .transform ==> NestedComplex(
+        Some(User("John", 15, 140)),
+        Right(User("John", 30, 140)),
+        List(User("John", 40, 140)),
+        scala.collection.immutable.ListMap(User("John", 50, 140) -> User("John", 60, 140))
+      )
+
+      NestedComplex(
+        Some(Person("John", 10, 140)),
+        Right(Person("John", 10, 140)),
+        List(Person("John", 10, 140)),
+        scala.collection.immutable.ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
+      ).into[NestedComplex[User]]
+        .withFieldComputed(_.option.matching[Some[User]].value.age, _ => 15)
+        .withFieldComputed(_.either.matching[Left[User, User]].value.age, _ => 20)
+        .withFieldComputed(_.either.matching[Right[User, User]].value.age, _ => 30)
+        .transform ==> NestedComplex(
+        Some(User("John", 15, 140)),
+        Right(User("John", 30, 140)),
+        List(User("John", 10, 140)),
+        scala.collection.immutable.ListMap(User("John", 10, 140) -> User("John", 10, 140))
+      )
     }
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -177,21 +177,11 @@ class TotalTransformerProductSpec extends ChimneySpec {
         scala.collection.immutable.ListMap(User("John", 50, 140) -> User("John", 60, 140))
       )
 
-      NestedComplex(
-        Some(Person("John", 10, 140)),
-        Right(Person("John", 10, 140)),
-        List(Person("John", 10, 140)),
-        scala.collection.immutable.ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
-      ).into[NestedComplex[User]]
-        .withFieldComputed(_.option.matching[Some[User]].value.age, _ => 15)
-        .withFieldComputed(_.either.matching[Left[User, User]].value.age, _ => 20)
-        .withFieldComputed(_.either.matching[Right[User, User]].value.age, _ => 30)
-        .transform ==> NestedComplex(
-        Some(User("John", 15, 140)),
-        Right(User("John", 30, 140)),
-        List(User("John", 10, 140)),
-        scala.collection.immutable.ListMap(User("John", 10, 140) -> User("John", 10, 140))
-      )
+      List[NestedADT[Person]](NestedADT.Foo(Person("John", 10, 140)), NestedADT.Bar(Person("John", 10, 140)))
+        .into[Vector[NestedADT[User]]]
+        .withFieldComputed(_.everyItem.matching[NestedADT.Foo[User]].foo.age, _ => 20)
+        .withFieldComputed(_.everyItem.matching[NestedADT.Bar[User]].bar.age, _ => 30)
+        .transform ==> Vector(NestedADT.Foo(User("John", 20, 140)), NestedADT.Bar(User("John", 30, 140)))
     }
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -158,13 +158,17 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .withFieldComputed(_.value.age, _.getValue.age * 2)
         .transform ==> NestedProduct(User("John", 20, 140))
 
+      val _ = implicitly[io.scalaland.chimney.internal.runtime.IsOption[Option[User]]]
       NestedComplex(
         Some(Person("John", 10, 140)),
         Right(Person("John", 10, 140)),
         List(Person("John", 10, 140)),
         scala.collection.immutable.ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
       ).into[NestedComplex[User]]
-        .withFieldComputed(_.option.matchingSome.age, _ => 15)
+        .withFieldComputed(
+          _.option.matchingSome(io.scalaland.chimney.internal.runtime.IsOption.optionIsOption).age,
+          _ => 15
+        )
         .withFieldComputed(_.either.matchingLeft.age, _ => 20)
         .withFieldComputed(_.either.matchingRight.age, _ => 30)
         .withFieldComputed(_.collection.everyItem.age, _ => 40)

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 
 import scala.annotation.unused
+import scala.collection.immutable.ListMap
 
 class TotalTransformerProductSpec extends ChimneySpec {
 
@@ -158,17 +159,13 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .withFieldComputed(_.value.age, _.getValue.age * 2)
         .transform ==> NestedProduct(User("John", 20, 140))
 
-      val _ = implicitly[io.scalaland.chimney.internal.runtime.IsOption[Option[User]]]
       NestedComplex(
         Some(Person("John", 10, 140)),
         Right(Person("John", 10, 140)),
         List(Person("John", 10, 140)),
-        scala.collection.immutable.ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
+        ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
       ).into[NestedComplex[User]]
-        .withFieldComputed(
-          _.option.matchingSome(io.scalaland.chimney.internal.runtime.IsOption.optionIsOption).age,
-          _ => 15
-        )
+        .withFieldComputed(_.option.matchingSome.age, _ => 15)
         .withFieldComputed(_.either.matchingLeft.age, _ => 20)
         .withFieldComputed(_.either.matchingRight.age, _ => 30)
         .withFieldComputed(_.collection.everyItem.age, _ => 40)
@@ -178,7 +175,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
         Some(User("John", 15, 140)),
         Right(User("John", 30, 140)),
         List(User("John", 40, 140)),
-        scala.collection.immutable.ListMap(User("John", 50, 140) -> User("John", 60, 140))
+        ListMap(User("John", 50, 140) -> User("John", 60, 140))
       )
 
       List[NestedADT[Person]](NestedADT.Foo(Person("John", 10, 140)), NestedADT.Bar(Person("John", 10, 140)))

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -98,6 +98,33 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .into[NestedProduct[User]]
         .withFieldConst(_.value.age, 20)
         .transform ==> NestedProduct(User("John", 20, 140))
+
+      NestedComplex(
+        Person("John", 10, 140),
+        Some(Person("John", 10, 140)),
+        Right(Person("John", 10, 140)),
+        List(Person("John", 10, 140)),
+        ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
+      ).into[NestedComplex[User]]
+        .withFieldConst(_.option.matchingSome.age, 15)
+        .withFieldConst(_.either.matchingLeft.age, 20)
+        .withFieldConst(_.either.matchingRight.age, 30)
+        .withFieldConst(_.collection.everyItem.age, 40)
+        .withFieldConst(_.map.everyMapKey.age, 50)
+        .withFieldConst(_.map.everyMapValue.age, 60)
+        .transform ==> NestedComplex(
+        User("John", 10, 140),
+        Some(User("John", 15, 140)),
+        Right(User("John", 30, 140)),
+        List(User("John", 40, 140)),
+        ListMap(User("John", 50, 140) -> User("John", 60, 140))
+      )
+
+      List[NestedADT[Person]](NestedADT.Foo(Person("John", 10, 140)), NestedADT.Bar(Person("John", 10, 140)))
+        .into[Vector[NestedADT[User]]]
+        .withFieldConst(_.everyItem.matching[NestedADT.Foo[User]].foo.age, 20)
+        .withFieldConst(_.everyItem.matching[NestedADT.Bar[User]].bar.age, 30)
+        .transform ==> Vector(NestedADT.Foo(User("John", 20, 140)), NestedADT.Bar(User("John", 30, 140)))
     }
   }
 
@@ -160,18 +187,20 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .transform ==> NestedProduct(User("John", 20, 140))
 
       NestedComplex(
+        Person("John", 10, 140),
         Some(Person("John", 10, 140)),
         Right(Person("John", 10, 140)),
         List(Person("John", 10, 140)),
         ListMap(Person("John", 10, 140) -> Person("John", 10, 140))
       ).into[NestedComplex[User]]
-        .withFieldComputed(_.option.matchingSome.age, _ => 15)
-        .withFieldComputed(_.either.matchingLeft.age, _ => 20)
-        .withFieldComputed(_.either.matchingRight.age, _ => 30)
-        .withFieldComputed(_.collection.everyItem.age, _ => 40)
-        .withFieldComputed(_.map.everyMapKey.age, _ => 50)
-        .withFieldComputed(_.map.everyMapValue.age, _ => 60)
+        .withFieldComputed(_.option.matchingSome.age, _.id.age + 5)
+        .withFieldComputed(_.either.matchingLeft.age, _.id.age * 2)
+        .withFieldComputed(_.either.matchingRight.age, _.id.age * 3)
+        .withFieldComputed(_.collection.everyItem.age, _.id.age * 4)
+        .withFieldComputed(_.map.everyMapKey.age, _.id.age * 5)
+        .withFieldComputed(_.map.everyMapValue.age, _.id.age * 6)
         .transform ==> NestedComplex(
+        User("John", 10, 140),
         Some(User("John", 15, 140)),
         Right(User("John", 30, 140)),
         List(User("John", 40, 140)),
@@ -255,6 +284,35 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .withFieldRenamed(_.getValue.name, _.value.imie)
         .withFieldRenamed(_.getValue.age, _.value.wiek)
         .transform ==> NestedProduct(UserPLStd(1, "Kuba", Some(28)))
+
+      NestedComplex(
+        UserStrict(1, "Kuba", 28),
+        Some(UserStrict(2, "Kuba", 28)),
+        Right(UserStrict(3, "Kuba", 28)),
+        List(UserStrict(4, "Kuba", 28)),
+        ListMap(UserStrict(5, "Kuba", 28) -> UserStrict(6, "Kuba", 28))
+      ).into[NestedComplex[UserPLStrict]]
+        .withFieldRenamed(_.id.name, _.id.imie)
+        .withFieldRenamed(_.id.age, _.id.wiek)
+        .withFieldRenamed(_.id.name, _.option.matchingSome.imie)
+        .withFieldRenamed(_.id.age, _.option.matchingSome.wiek)
+        .withFieldRenamed(_.id.name, _.either.matchingLeft.imie)
+        .withFieldRenamed(_.id.age, _.either.matchingLeft.wiek)
+        .withFieldRenamed(_.id.name, _.either.matchingRight.imie)
+        .withFieldRenamed(_.id.age, _.either.matchingRight.wiek)
+        .withFieldRenamed(_.id.name, _.collection.everyItem.imie)
+        .withFieldRenamed(_.id.age, _.collection.everyItem.wiek)
+        .withFieldRenamed(_.id.name, _.map.everyMapKey.imie)
+        .withFieldRenamed(_.id.age, _.map.everyMapKey.wiek)
+        .withFieldRenamed(_.id.name, _.map.everyMapValue.imie)
+        .withFieldRenamed(_.id.age, _.map.everyMapValue.wiek)
+        .transform ==> NestedComplex(
+        UserPLStrict(1, "Kuba", 28),
+        Some(UserPLStrict(2, "Kuba", 28)),
+        Right(UserPLStrict(3, "Kuba", 28)),
+        List(UserPLStrict(4, "Kuba", 28)),
+        ListMap(UserPLStrict(5, "Kuba", 28) -> UserPLStrict(6, "Kuba", 28))
+      )
     }
 
     test(

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -50,7 +50,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
       import products.{Foo, Bar, HaveY}
 
       compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldConst(_.y + "abc", "pi").transform""").check(
-        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
       )
 
       compileErrorsFixed(
@@ -148,7 +148,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
 
       compileErrorsFixed("""Bar(3, (3.14, 3.14)).into[Foo].withFieldComputed(_.y + "abc", _.toString).transform""")
         .check(
-          "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+          "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
         )
 
       compileErrorsFixed(
@@ -273,7 +273,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
       compileErrorsFixed(
         """User(1, "Kuba", Some(28)).into[UserPL].withFieldRenamed(_.age + "ABC", _.toString).transform"""
       ).check(
-        "The path expression has to be a single chain of calls on the original input, operation other than value extraction:"
+        "The path expression has to be a single chain of calls on the original input, got operation other than value extraction:"
       )
 
       compileErrorsFixed(

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
@@ -115,6 +115,18 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
     Seq(Bar("x"), Bar("y")).transformInto[Array[Foo]] ==> Array(Foo("x"), Foo("y"))
   }
 
+  test("transform into sequential type with an override") {
+    Iterable(Foo("a")).into[Seq[Bar]].withFieldConst(_.everyItem.value, "override").transform ==> Seq(Bar("override"))
+    Iterable(Foo("a")).into[List[Bar]].withFieldConst(_.everyItem.value, "override").transform ==> List(Bar("override"))
+    Iterable(Foo("a")).into[Vector[Bar]].withFieldConst(_.everyItem.value, "override").transform ==> Vector(
+      Bar("override")
+    )
+    Iterable(Foo("a")).into[Set[Bar]].withFieldConst(_.everyItem.value, "override").transform ==> Set(Bar("override"))
+    Iterable(Foo("a")).into[Array[Bar]].withFieldConst(_.everyItem.value, "override").transform ==> Array(
+      Bar("override")
+    )
+  }
+
   test("transform from Map-type to Map-type") {
     Map("test" -> Foo("a")).transformInto[Map[String, Bar]] ==> Map("test" -> Bar("a"))
     Map("test" -> "a").transformInto[Map[String, String]] ==> Map("test" -> "a")
@@ -134,6 +146,14 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
       Map(Bar("10") -> Foo("20"), Bar("20") -> Foo("40"))
     Map(Foo("10") -> Bar("20"), Foo("20") -> Bar("40")).transformInto[Array[(Bar, Foo)]] ==>
       Array(Bar("10") -> Foo("20"), Bar("20") -> Foo("40"))
+  }
+
+  test("transform into map type with an override") {
+    Iterable(Foo("a") -> Foo("b"))
+      .into[Map[Bar, Bar]]
+      .withFieldConst(_.everyMapKey.value, "ov1")
+      .withFieldConst(_.everyMapValue.value, "ov2")
+      .transform ==> Map(Bar("ov1") -> Bar("ov2"))
   }
 
   group("flag .enableOptionDefaultsToNone") {

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/nestedpath/nested.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/nestedpath/nested.scala
@@ -28,6 +28,7 @@ object NestedJavaBean {
 }
 
 case class NestedComplex[A](
+    id: A,
     option: Option[A],
     either: Either[A, A],
     collection: List[A],

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/nestedpath/nested.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/nestedpath/nested.scala
@@ -33,3 +33,9 @@ case class NestedComplex[A](
     collection: List[A],
     map: ListMap[A, A]
 )
+
+sealed trait NestedADT[A]
+object NestedADT {
+  case class Foo[A](foo: A) extends NestedADT[A]
+  case class Bar[A](bar: A) extends NestedADT[A]
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/nestedpath/nested.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/nestedpath/nested.scala
@@ -1,5 +1,7 @@
 package io.scalaland.chimney.fixtures.nestedpath
 
+import scala.collection.immutable.ListMap
+
 case class NestedProduct[A](value: A)
 
 class NestedValueClass[A](val value: A) extends AnyVal
@@ -24,3 +26,10 @@ object NestedJavaBean {
     jb
   }
 }
+
+case class NestedComplex[A](
+    option: Option[A],
+    either: Either[A, A],
+    collection: List[A],
+    map: ListMap[A, A]
+)

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
@@ -48,6 +48,7 @@ case class HaveY(y: String)
 object Renames {
 
   case class User(id: Int, name: String, age: Option[Int])
+  case class UserStrict(id: Int, name: String, age: Int)
   case class UserPL(id: Int, imie: String, wiek: Either[Unit, Int])
   case class UserPLStd(id: Int, imie: String, wiek: Option[Int])
   case class User2ID(id: Int, name: String, age: Option[Int], extraID: Int)

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -1061,10 +1061,18 @@ it with another field. Since the usual cause of such cases is a _rename_, we can
 The requirements to use a rename are as follows:
 
   - you have to pass `_.fieldName` directly, it cannot be done with a reference to the function
-  - the field rename can be _nested_, you can pass `_.foo.bar.baz` there
   - you can only use `val`/nullary method/Bean getter as a source field name
   - you have to have a `val`/nullary method/Bean getter with a name matching constructor's argument (or Bean setter if
-    setters are enabled)
+    setters are enabled) to point which argument you are targeting
+  - the field rename can be _nested_, you can pass `_.foo.bar.baz` there, and on the constructor's arguments side
+    additionally you can use:
+     - `.matched[Subtype]` to select just one subtype of ADT e.g `_.adt.matched[Subtype].subtypeField`
+     - `.matchedSome` to select values inside `Option` e.g. `_.option.matchedSome.field
+     - `.matchedLeft` and `.matchedRight` to select values inside `Either` e.g. `_.either.matchedLeft.field` or
+       `_.either.matchedRight.field`
+     - `.everyItem` to select items inside collection or array e.g. `_.list.everyItem.field`, `_.array.everyItem.field`
+     - `.everyMapKey` and `.everyMapValue` to select keys/values inside maps e.g. `_.map.everyMapKey.field`,
+       `_.map.everyMapValue.field`
  
 The last 2 conditions are always met when working with `case class`es with no `private val`s in constructor, and classes
 with all arguments declared as public `val`s, and Java Beans where each setter has a corresponding getter defined.
@@ -1197,11 +1205,18 @@ As you can see, the transformed value will automatically preserve the field name
 The requirements to use a value provision are as follows:
 
   - you have to pass `_.fieldName` directly, it cannot be done with a reference to the function
-  - the field value provision can be _nested_, you can pass `_.foo.bar.baz` there
   - you have to have a `val`/nullary method/Bean getter with a name matching constructor's argument (or Bean setter if
     setters are enabled)
+  - the path can be _nested_, you can pass `_.foo.bar.baz` there, and additionally you can use:
+     - `.matched[Subtype]` to select just one subtype of ADT e.g `_.adt.matched[Subtype].subtypeField`
+     - `.matchedSome` to select values inside `Option` e.g. `_.option.matchedSome.field
+     - `.matchedLeft` and `.matchedRight` to select values inside `Either` e.g. `_.either.matchedLeft.field` or
+       `_.either.matchedRight.field`
+     - `.everyItem` to select items inside collection or array e.g. `_.list.everyItem.field`, `_.array.everyItem.field`
+     - `.everyMapKey` and `.everyMapValue` to select keys/values inside maps e.g. `_.map.everyMapKey.field`,
+       `_.map.everyMapValue.field`
 
-The last conditions is always met when working with `case class`es with no `private val`s in constructor, and classes
+The second condition is always met when working with `case class`es with no `private val`s in constructor, and classes
 with all arguments declared as public `val`s, and Java Beans where each setter has a corresponding getter defined.
 
 !!! example
@@ -1347,11 +1362,18 @@ As you can see, the transformed value will automatically preserve the field name
 The requirements to use a value computation are as follows:
 
   - you have to pass `_.fieldName` directly, it cannot be done with a reference to the function
-  - the field value computation can be _nested_, you can pass `_.foo.bar.baz` there
   - you have to have a `val`/nullary method/Bean getter with a name matching constructor's argument (or Bean setter if
     setters are enabled)
+  - the path can be _nested_, you can pass `_.foo.bar.baz` there, and additionally you can use:
+     - `.matched[Subtype]` to select just one subtype of ADT e.g `_.adt.matched[Subtype].subtypeField`
+     - `.matchedSome` to select values inside `Option` e.g. `_.option.matchedSome.field
+     - `.matchedLeft` and `.matchedRight` to select values inside `Either` e.g. `_.either.matchedLeft.field` or
+       `_.either.matchedRight.field`
+     - `.everyItem` to select items inside collection or array e.g. `_.list.everyItem.field`, `_.array.everyItem.field`
+     - `.everyMapKey` and `.everyMapValue` to select keys/values inside maps e.g. `_.map.everyMapKey.field`,
+       `_.map.everyMapValue.field`
 
-The last conditions is always met when working with `case class`es with no `private val`s in constructor, and classes
+The second condition is always met when working with `case class`es with no `private val`s in constructor, and classes
 with all arguments declared as public `val`s, and Java Beans where each setter has a corresponding getter defined.
 
 !!! example
@@ -2884,14 +2906,15 @@ If we need to customize it, we can use `.define.buildTransformer`:
 Arguments taken by both `.enableCustomFieldNameComparison` and `.enableCustomSubtypeNameComparison` are values of type
 `TransformedNamesComparison`. Out of the box, Chimney provides:
 
- * `TransformedNamesComparison.StrictEquality` - 2 names are considered equal only if they are identical `String`s.
+ - `TransformedNamesComparison.StrictEquality` - 2 names are considered equal only if they are identical `String`s.
    This is the default matching strategy for subtype names conparison
- * `TransformedNamesComparison.BeanAware` - 2 names are considered equal if they are identical `String`s OR if they are
-   identical after you convert them from Java Bean naming convention:
-   * if a name starts with `is`/`get`/`set` prefix (e.g. `isField`, `getField`, `setField`) then
-   * strip this name from the prefix (obtaining e.g. `Field`) and
-   * lower case the first letter (obtaining e.g. `field`)
-* `TransformedNamesComparison.CaseInsensitiveEquality` - 2 names are considered equal if `equalsIgnoreCase` returns
+ - `TransformedNamesComparison.BeanAware` - 2 names are considered equal if they are identical `String`s OR if they are
+   identical after you convert them from Java Bean naming convention: 
+    - if a name starts with `is`/`get`/`set` prefix (e.g. `isField`, `getField`, `setField`) then
+    - strip this name from the prefix (obtaining e.g. `Field`) and
+    - lower case the first letter (obtaining e.g. `field`)
+    
+ - `TransformedNamesComparison.CaseInsensitiveEquality` - 2 names are considered equal if `equalsIgnoreCase` returns
   `true`
 
 However, these 3 does not exhaust all possible comparisons and you might need to provide one yourself. 
@@ -2904,11 +2927,11 @@ The challenge is that the function you'd like to provie has to be called within 
 a way that the macro will be able to access it. Normally, there is no way to inject a custom login into existing macro,
 but Chimney has a specific solution for this:
 
- * you need to define your `TransformedNamesComparison` as `object` - objects do not need constructor arguments, so
+ - you need to define your `TransformedNamesComparison` as `object` - objects do not need constructor arguments, so
    they can be instantiated easily
- * your have to define this `object` as top-level definition or within another object - object defined within a `class`,
+ - your have to define this `object` as top-level definition or within another object - object defined within a `class`,
    a `trait` or locally, does need some logic for instantiation
- * you have to define your `object` in a module/subproject that is compiled _before_ the module where you need to use
+ - you have to define your `object` in a module/subproject that is compiled _before_ the module where you need to use
    it, so that the bytecode would already be accesible on classpath.
 
 !!! example


### PR DESCRIPTION
The goal of this PR is to enable paths like:

 - `_.matching[Foo]`
 - `_.matchingSome`
 - `_.matchingLeft`
 - `_.matchingRight`
 - `_.everyItem`
 - `_.everyMapKey`
 - `_.everyMapValue`

expanding the work started in #358.

This was unblocked by the work done in #490. The remaining works to do is to:

 - [x] provide missing `Path` cases in phantom type
 - [x] provide missing `Path` cases in `TransformationConfig`
 - [x] parsing `Path` phantom type into `Path` in `TransformationConfig`
 - [x] creating extension methods in DSL
 - [x] parsing extension methods by DSL macros
   - [x] Scala 2
   - [x] Scala 3
 - [x] test
   - [x] products
   - [x] DSL errors
   - [x] std lib (iterables, maps, arrays)
 - [x] write documentation
 - [x] `@implicitNotFound` for evidence
 - [x] `@compileTimeOnly` for extension methods