### PR TITLE
Allow using field overrides in ADTs (when field is available to all subtypes)

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -98,6 +98,7 @@ private[compiletime] trait Configurations { this: Derivation =>
       case (Root, result)                                                                         => Some(result)
       case (AtField(name, prefix2), AtField(name2, tail)) if areFieldNamesMatching(name, name2)   => tail.drop(prefix2)
       case (AtSubtype(tpe, prefix2), AtSubtype(tpe2, tail)) if tpe.Underlying <:< tpe2.Underlying => tail.drop(prefix2)
+      case (AtSubtype(_, prefix2), AtField(_, _))                                                 => this.drop(prefix2)
       case (AtItem(prefix2), AtItem(tail))                                                        => tail.drop(prefix2)
       case (AtMapKey(prefix2), AtMapKey(tail))                                                    => tail.drop(prefix2)
       case (AtMapValue(prefix2), AtMapValue(tail))                                                => tail.drop(prefix2)

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -755,4 +755,9 @@ class IssuesSpec extends ChimneySpec {
       .enableCustomFieldNameComparison(TransformedNamesComparison.StrictEquality)
       .transform ==> To(uuid1, uuid2, "test")
   }
+
+  test("fix issue #498") {
+    import Issue498.*
+    (Foo.Sub1("test"): Foo).into[Bar].withFieldConst(_.b, 1).transform ==> Bar.Sub1("test", 1)
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -192,3 +192,19 @@ object Issue403 {
 object Issue434 {
   case class MyClass(x: Int, y: Int, z: String, zz: Option[Int])
 }
+
+object Issue498 {
+  sealed trait Foo
+  object Foo {
+    case class Sub1(a: String) extends Foo
+    case class Sub2(a: String) extends Foo
+  }
+
+  sealed trait Bar {
+    def b: Int
+  }
+  object Bar {
+    case class Sub1(a: String, b: Int) extends Bar
+    case class Sub2(a: String, b: Int) extends Bar
+  }
+}


### PR DESCRIPTION
Not an issue but suggestion from #498 