### PR TITLE
Add better error message on StackOverflow in macros, prevent SO in some cases with Scala 3 enums mapping

### DIFF
--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -42,7 +42,6 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
       def isJavaSetterOrVar(setter: Symbol): Boolean =
         isJavaSetter(setter) || isVar(setter)
-
     }
 
     import platformSpecific.*

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -63,7 +63,8 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
     }
     def isCaseVal[A](implicit A: Type[A]): Boolean = {
       val sym = TypeRepr.of(using A).typeSymbol
-      sym.isPublic && sym.flags.is(Flags.Case | Flags.Enum | Flags.JavaStatic)
+      sym.isPublic && sym.flags
+        .is(Flags.Case | Flags.Enum) && (sym.flags.is(Flags.JavaStatic) || sym.flags.is(Flags.StableRealizable))
     }
     def isJavaEnumValue[A: Type]: Boolean =
       Type[A] <:< scala.quoted.Type.of[java.lang.Enum[?]] && !TypeRepr.of[A].typeSymbol.isAbstract

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -14,7 +14,7 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
 
     def isSealed[A: Type]: Boolean = {
       val flags = TypeRepr.of[A].typeSymbol.flags
-      flags.is(Flags.Enum) || flags.is(Flags.Sealed)
+      flags.is(Flags.Sealed) // do NOT use flags.is(Flags.Enum) since it will also match enums cases!
     }
 
     def parse[A: Type]: Option[Enum[A]] =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
@@ -14,8 +14,16 @@ object DerivationError {
       .collectFirst {
         case MacroException(exception) =>
           val stackTrace =
-            exception.getStackTrace.view.take(10).map(ste => s"  \t${Console.RED}$ste${Console.RESET}").mkString("\n")
-          s"  macro expansion thrown exception!: $exception:\n$stackTrace\n  \t${Console.RED}...${Console.RESET}"
+            exception.getStackTrace.view
+              .take(10)
+              .map(ste => s"  \t${Console.RED}$ste${Console.RESET}")
+              .mkString("\n") + s"\n  \t${Console.RED}...${Console.RESET}"
+          exception match {
+            case _: StackOverflowError =>
+              s"  macro expansion thrown StackOverflow - usually it's a sign that JVM need larger Stack. Increase it with e.g. -Xss64m passed to JVM!: $exception:\n$stackTrace"
+            case _ =>
+              s"  macro expansion thrown exception!: $exception:\n$stackTrace"
+          }
         case NotYetImplemented(what) =>
           s"  derivation failed because functionality $what is not yet implemented!"
       }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -50,13 +50,7 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
             mapElementsMatchedByName[From, To](fromSubtype, toElements).orElse(mapWholeTo[From, To](fromSubtype))
           }
           .flatMap { (nameMatchedMappings: List[Existential[ExprPromise[*, TransformationExpr[To]]]]) =>
-            combineElementsMappings[From, To](overrideMappings ++ nameMatchedMappings).logSuccess { exp =>
-              exp match {
-                case Rule.ExpansionResult.Expanded(TransformationExpr.TotalExpr(value)) =>
-                  "we've got " + value.toString + value.asInstanceOf[Expr[Any]].tpe
-                case _ => "nope"
-              }
-            }
+            combineElementsMappings[From, To](overrideMappings ++ nameMatchedMappings)
           }
     }
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1677,8 +1677,8 @@ On Scala 2 `java.lang.UnsupportedOperationException: Position.point on NoPositio
 recursive derivation (not only in Chimney) can overflow this stack trace, but on Scala 2 it can become notorious in
 the form of an empty value used by the macro to report where error happened.
 
-These issues can be addressed by increasing the compiler's JVM stack size, passing it e.g. -Xss64m (to increase the size
-to 64MB).
+These issues can be addressed by increasing the compiler's JVM stack size, passing it e.g. `-Xss64m` (to increase
+the size to 64MB).
 
 However, if you are using the compiler's flags to report unused definitions when macros are involved, there can also be
 an error caused by [scala/bug#12895](https://github.com/scala/bug/issues/12895). This bug was fixed in Scala 2.13.14,


### PR DESCRIPTION
Description:
 * some snippets in our docs instead of generating reasonable code, generated StackOverflow in macros
 * investigation shown that it's caused by handling of Scala 3 enums - each parameterless case was treated as another enum, so we had "handle enum" calling "handle enum" calling "handle enum"...
   * of of the reasons was using `Flags.enum` when deciding if something is sealed
   * another was `Flags.JavaStatic` used to detect parameterless enum when - in those snippets - its was `Flags.StableRealizable`
 * it prevented SO, it generated a nice enableMacrosLogging messange... and compiler error :/

TODO 1: fix ignored snippets in docs once this is figured out

TODO 2:

```
  exception while retyping PaymentMethod.this of class This # -1

  An unhandled exception was thrown in the compiler.
  Please file a crash report here:
  https://github.com/lampepfl/dotty/issues/new/choose

     while compiling: /private/tmp/eldupa3/.scala-build/eldupa3_d091e5187c/src_generated/main/snippet.scala
        during phase: MegaPhase{elimErasedValueType, pureStats, vcElideAllocations, etaReduce, arrayApply, elimPolyFunction, tailrec, completeJavaEnums, mixin, lazyVals, memoize, nonLocalReturns, capturedVars}
                mode: Mode(ImplicitsEnabled)
     library version: version 2.13.12
    compiler version: version 3.3.3
            settings: -J<flag> List(-Xss128m) -classpath /Users/dev/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.3.3/scala3-library_3-3.3.3.jar:/Users/dev/.ivy2/local/io.scalaland/chimney_3/1.0.0-RC1-51-g4a37a24-SNAPSHOT/jars/chimney_3.jar:/Users/dev/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar:/Users/dev/.ivy2/local/io.scalaland/chimney-macro-commons_3/1.0.0-RC1-51-g4a37a24-SNAPSHOT/jars/chimney-macro-commons_3.jar:/Users/dev/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_3/2.11.0/scala-collection-compat_3-2.11.0.jar -d /private/tmp/eldupa3/.scala-build/eldupa3_d091e5187c/classes/main -java-output-version 17 -sourceroot /private/tmp/eldupa3
```

in [one of these snippets](https://github.com/scalalandio/chimney/blob/master/docs/docs/troubleshooting.md?plain=1#L810). Reported as https://github.com/scala/scala3/issues/20349