### PR TITLE
Attempt to fix Scala 3 enum in snippet.sc, instead reproduce an issue with TypeRepr.of[A].memberType(subtype)

### DIFF
--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -160,11 +160,15 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit] = '{ val _ = ${ expr } }
 
     def prettyPrint[A](expr: Expr[A]): String =
-      expr.asTerm
-        .show(using Printer.TreeAnsiCode)
-        // remove $macro$n from freshterms to make it easier to test and read
-        .replaceAll("\\$macro", "")
-        .replaceAll("\\$\\d+", "")
+      try
+        expr.asTerm
+          .show(using Printer.TreeAnsiCode)
+          // remove $macro$n from freshterms to make it easier to test and read
+          .replaceAll("\\$macro", "")
+          .replaceAll("\\$\\d+", "")
+      catch {
+        case e: StackOverflowError => expr.toString
+      }
 
     def typeOf[A](expr: Expr[A]): Type[A] = Type.platformSpecific.fromUntyped[A](expr.asTerm.tpe)
   }

--- a/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/TotalTransformerEnumSpec.scala
@@ -15,6 +15,25 @@ class TotalTransformerEnumSpec extends ChimneySpec {
     (colors1enums.Color.Blue: colors1enums.Color).transformInto[colors2enums.Color] ==> colors2enums.Color.Blue
   }
 
+  test("""sdsdfs""") {
+    class Snippet {
+      enum Color1:
+        case Red, Blue, Green
+
+      enum Color2:
+        case Blue, Green, Red, Black
+
+      val result = {
+        // implicit val cfg = TransformerConfiguration.default.enableMacrosLogging
+        (Color1.Red: Color1).transformInto[Color2] ==> Color2.Red
+        (Color1.Green: Color1).transformInto[Color2] ==> Color2.Green
+        (Color1.Blue: Color1).transformInto[Color2] ==> Color2.Blue
+      }
+    }
+
+    new Snippet().result
+  }
+
   test(
     """transform nested sealed hierarchies between flat and nested hierarchies of case objects without modifiers"""
   ) {


### PR DESCRIPTION
When Scala CLI `snippet.sc` is used macro generates assertion errors when Scala 3 enum is used:

 * recommended way of calculating the type is `TypeRepr.of[A].memberType(subtypeSymbol)`
 * the current way is based on `subtypeSymbol.typeRef` which cannot be used for types defined in
   ```scala
   class SomeClass {
     type InnerType
   }
   ```

   and `enum` and each `case` becomes a type defined in another class when we use `snippet.sc` (interestingly, the issue does not appear for `case object`s nor `case class`es)
* however this recommended solution also upcasts parametherless cases, so that children of
  ```scala
   enum Foo:
     case Bar(value: Int)
     case Baz
  ```
  are resolved to `List(Foo.Bar, Foo)` (which breaks macro in another way).

Once this is solved, all Scala 3 snippets in documentation with enums - which required:
```scala
@main def example: Unit = {
// actual code
}
```
can have the workaround removed.

See:

 * https://github.com/scala/scala3/issues/20349
 * https://github.com/scala/scala3/issues/19825

for the context (and why it's _not_ so easy to "just fix in in the library").