### PR TITLE
Test more previously ignored snippets

### DIFF
--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -1852,6 +1852,7 @@ It works also with Scala 3's `enum`:
     `sealed trait` into `enum`
 
     ```scala
+    // file: snippet.scala - part of sealed trait into Scala 3 enum example
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl.*
@@ -1865,10 +1866,12 @@ It works also with Scala 3's `enum`:
       case Fizz
       case Buzz
 
+    @main def example: Unit = {
     (Foo.Baz("value", 10): Foo)
       .transformInto[Bar] // Bar.Baz(10)
     (Foo.Buzz: Foo)
       .transformInto[Bar] // Bar.Buzz
+    }
     ```
     
 !!! example
@@ -1876,6 +1879,7 @@ It works also with Scala 3's `enum`:
     `enum` into `sealed trait` 
 
     ```scala
+    // file: snippet.scala - part of Scala 3 enum into sealed trait example
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl.*
@@ -1889,10 +1893,12 @@ It works also with Scala 3's `enum`:
       case object Fizz extends Bar
       case object Buzz extends Bar
 
+    @main def example: Unit = {
     (Foo.Baz("value", 10): Foo)
       .transformInto[Bar] // Bar.Baz(10)
     (Foo.Buzz: Foo)
       .transformInto[Bar] // Bar.Buzz
+    }
     ```
     
 !!! example
@@ -1900,6 +1906,7 @@ It works also with Scala 3's `enum`:
     `enum` into `enum` 
 
     ```scala
+    // file: snippet.scala - part of Scala 3 enum into Scala 3 enum example
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl.*
@@ -1912,10 +1919,12 @@ It works also with Scala 3's `enum`:
       case Fizz
       case Buzz
 
+    @main def example: Unit = {
     (Foo.Baz("value", 10): Foo)
       .transformInto[Bar] // Bar.Baz(10)
     (Foo.Buzz: Foo)
       .transformInto[Bar] // Bar.Buzz
+    }
     ```
 
 ### Non-flat ADTs
@@ -1970,13 +1979,14 @@ Java's `enum` can also be converted this way to/from `sealed`/Scala 3's `enum`/a
     Java's `enum` to/from `sealed`
 
     ```java
-    // in Java
+    // file: ColorJ.java - part of Java enum and Scala 2 example
     enum ColorJ {
       Red, Green, Blue;
     }
     ```
 
     ```scala
+    // file: example.sc - part of Java enum and Scala 2 example
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl._
 
@@ -2000,13 +2010,14 @@ Java's `enum` can also be converted this way to/from `sealed`/Scala 3's `enum`/a
     Java's `enum` to/from Scala's `enum`
 
     ```java
-    // in Java
+    // file: ColorJ.java - part of Java enum and Scala 3 example
     enum ColorJ {
       Red, Green, Blue;
     }
     ```
 
     ```scala
+    // file: example.scala - part of Java enum and Scala 3 example
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl._
@@ -2014,12 +2025,14 @@ Java's `enum` can also be converted this way to/from `sealed`/Scala 3's `enum`/a
     enum ColorE:
       case Red, Green, Blue
 
+    @main def example: Unit = {
     ColorJ.Red.transformInto[ColorE] // ColorE.Red
     ColorJ.Green.transformInto[ColorE] // ColorE.Green
     ColorJ.Blue.transformInto[ColorE] // ColorE.Blue
-    (ColorE.Red: ColorS).transformInto[ColorS] // ColorJ.Red
-    (ColorE.Green: ColorS).transformInto[ColorS] // ColorJ.Green
-    (ColorE.Blue: ColorS).transformInto[ColorS] // ColorJ.Blue
+    (ColorE.Red: ColorE).transformInto[ColorJ] // ColorJ.Red
+    (ColorE.Green: ColorE).transformInto[ColorJ] // ColorJ.Green
+    (ColorE.Blue: ColorE).transformInto[ColorJ] // ColorJ.Blue
+    }
     ```
 
 ### Handling a specific `sealed` subtype with a computed value
@@ -2117,6 +2130,7 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
     and `withEnumCaseHandledPartial`:
     
     ```scala
+    // file: snippet.scala - part of withEnumCaseHandled example 
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl.*
@@ -2132,6 +2146,7 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
       case Buzz
     }
 
+    @main def example: Unit = {
     (Bar.Baz("value"): Bar)
       .into[Foo]
       .withEnumCaseHandled[Bar.Fizz.type] { fizz =>
@@ -2172,6 +2187,7 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
       }
       .transform
       .asEither // Right(Foo.Buzz)
+    }
     ```
     
     These methods are only aliases and there is no difference in behavior between `withSealedCaseHandled` and
@@ -2197,13 +2213,14 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
     Java's `enum`s, the enum instance's exact type will always be upcasted/lost, turning the handler into "catch-all":
 
     ```java
-    // in Java
+    // file: ColorJ.java - part of Java enums in Scala 2 failure example
     enum ColorJ {
-      Red, Blue, Greed, Black;
+      Red, Blue, Green, Black;
     }
     ```
 
     ```scala
+    // file: example.sc - part of Java enums in Scala 2 failure example
     //> using scala {{ scala.2_13 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl._
@@ -2226,7 +2243,15 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
     There is nothing we can do about the type, however, we can analyze the code and, if it preserves the exact Java enum
     we can use a sort of a type refinement to remember the selected instance:
     
+    ```java
+    // file: ColorJ.java - part of Java enums in Scala 2 workaround example
+    enum ColorJ {
+      Red, Blue, Green, Black;
+    }
+    ```
+
     ```scala
+    // file: example.sc - part of Java enums in Scala 2 workaround example
     //> using scala {{ scala.2_13 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl._
@@ -2268,7 +2293,15 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
     
     This issue doesn't occur on Scala 3, which infers types correctly:
     
+    ```java
+    // file: ColorJ.java - part of Java enums in Scala 3 example
+    enum ColorJ {
+      Red, Blue, Green, Black;
+    }
+    ```
+
     ```scala
+    // file: example.scala - part of Java enums in Scala 3 example
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     import io.scalaland.chimney.dsl.*
@@ -2278,10 +2311,12 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
 
     def blackIsRed(black: ColorJ.Black.type): ColorS = ColorS.Red
 
-    ColorJ.Red.into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Red
-    ColorJ.Green.into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Green
-    ColorJ.Blue.into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Blue
-    ColorJ.Black.into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Black
+    @main def example: Unit = {
+    (ColorJ.Red: ColorJ).into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Red
+    (ColorJ.Green: ColorJ).into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Green
+    (ColorJ.Blue: ColorJ).into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Blue
+    (ColorJ.Black: ColorJ).into[ColorS].withSealedSubtypeHandled(blackIsRed).transform // ColorS.Black
+    }
     ```
 
 ### Customizing subtype name matching
@@ -3363,7 +3398,7 @@ but Chimney has a specific solution for this:
 !!! example
 
     ```scala
-    // file: PermissiveNamesComparison.scala - part of custom naming comparison example
+    // file: your/organization/PermissiveNamesComparison.scala - part of custom naming comparison example
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     package your.organization
 
@@ -3393,18 +3428,23 @@ but Chimney has a specific solution for this:
     be able to use that value.
 
     ```scala
-    // file: snippet.test.sc - part of custom naming comparison example
-    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    // file: your/organization/PermissiveNamesComparison.test.scala - part of custom naming comparison example
+    //> using dep org.scalameta::munit::1.0.0-RC1
+    import io.scalaland.chimney.dsl._
 
     case class Foo(a_name: String, BName: String)
     case class Bar(`a-name`: String, getBName: String)
 
-    Foo("value1", "value2")
-      .into[Bar]
-      .enableCustomFieldNameComparison(your.organization.PermissiveNamesComparison)
-      // this would be parsed as well
-      // .enableCustomSubtypeNameComparison(your.organization.PermissiveNamesComparison)
-      .transform
+    class Test extends munit.FunSuite {
+      test("should compile") {
+        Foo("value1", "value2")
+          .into[Bar]
+          .enableCustomFieldNameComparison(your.organization.PermissiveNamesComparison)
+          // this would be parsed as well
+          // .enableCustomSubtypeNameComparison(your.organization.PermissiveNamesComparison)
+          .transform
+      }
+    }
     ```
 
 Since this feature relied on ClassLoaders and class path lookup it, testing it with REPL may not work.

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -2896,6 +2896,7 @@ to be automatically recognized as such:
     than where they are being used:
 
     ```scala
+    // file: models.scala - part of opaque example
     package models
 
     case class StringIP(s1: String, s2: String, s3: String, s4: String)
@@ -2925,6 +2926,7 @@ to be automatically recognized as such:
     ```
 
     ```scala
+    // file: main.scala - part of opaque example
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     package example
@@ -2954,6 +2956,7 @@ to be automatically recognized as such:
 !!! example
 
     ```scala
+    // file: models.scala - part of opaque example 2
     package models
 
     case class Foo(value: String)
@@ -2967,6 +2970,7 @@ to be automatically recognized as such:
     ```
 
     ```scala
+    // file: main.scala - part of opaque example 2
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     package example
@@ -3359,6 +3363,7 @@ but Chimney has a specific solution for this:
 !!! example
 
     ```scala
+    // file: PermissiveNamesComparison.scala - part of custom naming comparison example
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     package your.organization
 
@@ -3388,6 +3393,7 @@ but Chimney has a specific solution for this:
     be able to use that value.
 
     ```scala
+    // file: snippet.test.sc - part of custom naming comparison example
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
 
     case class Foo(a_name: String, BName: String)

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -808,6 +808,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
     Chimney's counterpart:
     
     ```scala
+    // file: snippet.scala - part of Ductape counterpart 1
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     
@@ -835,6 +836,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
         case Card(digits: Long, name: String)
         case Cash
     
+    @main def example: Unit = {
     val wirePerson = wire.Person(
       "John",
       "Doe",
@@ -900,6 +902,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
     //     Card(digits = 23232323L, name = "J. Doe")
     //   )
     // )
+    }
     ```
 
 !!! example "Nested enum with missing counterpart"
@@ -967,6 +970,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
     which would handle them as top level:
 
     ```scala
+    // file: snippet.scala - part of Ductape counterpart 2
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     
@@ -995,6 +999,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
         case Card(digits: Long, name: String)
         case Cash
     
+    @main def example: Unit = {
     val wirePerson = wire.Person(
       "John",
       "Doe",
@@ -1033,6 +1038,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
     //     Cash
     //   )
     // )
+    }
     ```
 
 !!! example "Nested enum with missing counterpart"
@@ -1126,6 +1132,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
     Chimney's counterpart:
     
     ```scala
+    // file: snippet.scala - part of Ductape counterpart 3
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     
@@ -1156,6 +1163,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
         
     case class PaymentBand(name: String, digits: Long, color: String = "red")
     
+    @main def example: Unit = {
     val card: wire.PaymentMethod.Card =
       wire.PaymentMethod.Card(name = "J. Doe", digits = 213712345)
       
@@ -1205,6 +1213,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
       .into[DestToplevel]
       .enableOptionDefaultsToNone
       .transform
+    }
     ```
 
 !!! example "Coproduct configurations"
@@ -1268,6 +1277,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
     Chimney's counterpart:
 
     ```scala
+    // file: snippet.scala - part of Ductape counterpart 4
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     
@@ -1296,6 +1306,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
         case Card(digits: Long, name: String)
         case Cash
     
+    @main def example: Unit = {
     val transfer = wire.PaymentMethod.Transfer("2764262")
     
     val wirePerson = wire.Person(
@@ -1327,6 +1338,7 @@ Here are some features it shares with Chimney (Ducktape's code based on GitHub P
       .withEnumCaseHandled[wire.PaymentMethod.Transfer](transfer => domain.PaymentMethod.Card(name = "J. Doe", digits = transfer.accountNo.toLong))
       .transform
     // PaymentMethod = Card(name = "J. Doe", digits = 2764262L)
+    }
     ```
 
 The biggest difference might be approach towards transformations that can fail in runtime. Ducktape uses user-provided
@@ -1433,6 +1445,7 @@ deciding between error accumulating and fail-fast in runtime. It provides utilit
     Chimney's counterpart:
 
     ```scala
+    // file: snippet.scala - part of Ductape counterpart 5
     //> using scala {{ scala.3 }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     
@@ -1471,6 +1484,7 @@ deciding between error accumulating and fail-fast in runtime. It provides utilit
         case Card(digits: newtypes.Positive, name: newtypes.NonEmptyString)
         case Cash
         
+    @main def example: Unit = {
     val wirePerson = wire.Person(
       "John",
       "Doe",
@@ -1510,6 +1524,7 @@ deciding between error accumulating and fail-fast in runtime. It provides utilit
       )
       .transformFailFast
       .asEitherErrorPathMessageStrings
+    }
     ``` 
 
 Since Ducktape is inspired by Chimney, there is a huge overlap in functionality. However, there are some differences:

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -1,5 +1,5 @@
 //> using scala 3.3.3
-//> using dep com.kubuszok::scala-cli-md-spec:0.1.0
+//> using dep com.kubuszok::scala-cli-md-spec:0.1.1
 //> using dep org.virtuslab::scala-yaml:0.0.8
 
 import com.kubuszok.scalaclimdspec.*
@@ -51,24 +51,6 @@ class ChimneyExtendedRunner(runner: Runner)(
     (raw"\{\{\s*" + k + raw"\s*\}\}") -> v
   }
 
-  private val manuallyIgnored = ListMap(
-    "supported-transformations.md#Between `sealed`/`enum`s[2]" -> "snippet fails!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349
-    "supported-transformations.md#Between `sealed`/`enum`s[3]" -> "snippet throws exception!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349
-    "supported-transformations.md#Between `sealed`/`enum`s[4]" -> "snippet throws exception!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349
-    "supported-transformations.md#Java's `enum`s[1]" -> "requires previous snippet with Java code",
-    "supported-transformations.md#Java's `enum`s[2]" -> "requires previous snippet with Java code",
-    "supported-transformations.md#Handling a specific `sealed` subtype with a computed value[3]" -> "snippet throws exception!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349
-    "supported-transformations.md#Handling a specific `sealed` subtype with a computed value[4]" -> "requires previous snippet with Java code",
-    "supported-transformations.md#Handling a specific `sealed` subtype with a computed value[5]" -> "requires previous snippet with Java code",
-    "supported-transformations.md#Handling a specific `sealed` subtype with a computed value[6]" -> "requires previous snippet with Java code",
-    "supported-transformations.md#Defining custom name matching predicate[1]" -> "example split into multiple files",
-    "supported-transformations.md#Defining custom name matching predicate[2]" -> "contunuation from the previous snippet",
-    "troubleshooting.md#Ducktape[2]" -> "snippet throws exception!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349
-    "troubleshooting.md#Ducktape[4]" -> "snippet throws exception!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349
-    "troubleshooting.md#Ducktape[8]" -> "snippet throws exception!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349
-    "troubleshooting.md#Ducktape[10]" -> "snippet throws exception!!! investigate later" // FIXME: https://github.com/scala/scala3/issues/20349
-  )
-
   val addDefaultScala: Snippet.Content => Snippet.Content = {
     case Snippet.Content.Single(content) =>
       Snippet.Content.Single(
@@ -96,19 +78,16 @@ class ChimneyExtendedRunner(runner: Runner)(
       )
   }
 
-  export runner.{docsDir, filter, tmpDir}
+  export runner.{docsDir, filter, howToRun, tmpDir}
 
   extension (snippet: Snippet)
     def adjusted: Snippet =
       // interpolate templates before Default adjustments
       runner.adjusted(snippet.copy(content = interpolateTemplates(snippet.content)))
 
-    def howToRun: Runner.Strategy = manuallyIgnored.get(snippet.stableName) match
-      case None         => runner.howToRun(snippet)
-      case Some(reason) => Runner.Strategy.Ignore(reason)
-
   extension (snippets: List[Snippet])
     def adjusted: List[Snippet] = runner.adjusted(snippets).map { snippet =>
+      // add default Scala but only to those snippets that are already run (adding it before would make all of them run)
       howToRun(snippet) match
         case Runner.Strategy.Ignore(_) => snippet
         case _                         => snippet.copy(content = addDefaultScala(snippet.content))

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -61,10 +61,6 @@ class ChimneyExtendedRunner(runner: Runner)(
     "supported-transformations.md#Handling a specific `sealed` subtype with a computed value[4]" -> "requires previous snippet with Java code",
     "supported-transformations.md#Handling a specific `sealed` subtype with a computed value[5]" -> "requires previous snippet with Java code",
     "supported-transformations.md#Handling a specific `sealed` subtype with a computed value[6]" -> "requires previous snippet with Java code",
-    "supported-transformations.md#Types with manually provided constructors[3]" -> "example split into multiple files",
-    "supported-transformations.md#Types with manually provided constructors[4]" -> "contunuation from the previous snippet",
-    "supported-transformations.md#Types with manually provided constructors[5]" -> "example split into multiple files",
-    "supported-transformations.md#Types with manually provided constructors[6]" -> "contunuation from the previous snippet",
     "supported-transformations.md#Defining custom name matching predicate[1]" -> "example split into multiple files",
     "supported-transformations.md#Defining custom name matching predicate[2]" -> "contunuation from the previous snippet",
     "troubleshooting.md#Ducktape[2]" -> "snippet throws exception!!! investigate later", // FIXME: https://github.com/scala/scala3/issues/20349


### PR DESCRIPTION
Removes the need of maintaining a list of snippets that should be ignored - everything is handled as in vanilla [ScalaCLI.md Spec](https://github.com/MateuszKubuszok/scala-cli-md-spec/) (but decorated with default Scala and MkDocs Macros interpolation).

Since Scala 3 enums has a bug that makes them throw compiler assertions when using `snippet.sc` as a workaround all of them are using `@main def example: Unit = { ... }`.