### PR TITLE
Hide the last internal utility from the public API

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -89,7 +89,7 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
             result: Expr[partial.Result[A]]
         ): Expr[partial.Result.Errors] =
           c.Expr[partial.Result.Errors](
-            q"_root_.io.scalaland.chimney.partial.Result.Errors.__mergeResultNullable[${Type[A]}]($errorsNullable, $result)"
+            q"_root_.io.scalaland.chimney.internal.runtime.ResultUtils.mergeNullable[${Type[A]}]($errorsNullable, $result)"
           )
       }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -74,7 +74,7 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
             errorsNullable: Expr[partial.Result.Errors],
             result: Expr[partial.Result[A]]
         ): Expr[partial.Result.Errors] =
-          '{ partial.Result.Errors.__mergeResultNullable[A](${ errorsNullable }, ${ result }) }
+          '{ io.scalaland.chimney.internal.runtime.ResultUtils.mergeNullable[A](${ errorsNullable }, ${ result }) }
       }
 
       def fromEmpty[A: Type]: Expr[partial.Result[A]] = '{ partial.Result.fromEmpty[A] }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ResultUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ResultUtils.scala
@@ -1,0 +1,10 @@
+package io.scalaland.chimney.internal.runtime
+
+import io.scalaland.chimney.partial.Result
+import io.scalaland.chimney.partial.Result.Errors
+
+object ResultUtils {
+
+  def mergeNullable[A](errorsNullable: Errors, result: Result[A]): Errors =
+    Result.Errors.__mergeResultNullable(errorsNullable, result)
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
@@ -298,9 +298,8 @@ object Result {
     final def merge(errors1: Errors, errors2: Errors): Errors =
       apply(errors1.errors ++ errors2.errors)
 
-    /** Used internally by macro. Please don't use in your code.
-      */
-    final def __mergeResultNullable[A](errorsNullable: Errors, result: Result[A]): Errors =
+    /** Used internally by macro. Please don't use in your code. */
+    final private[chimney] def __mergeResultNullable[A](errorsNullable: Errors, result: Result[A]): Errors =
       result match {
         case _: Value[?]    => errorsNullable
         case errors: Errors => if (errorsNullable == null) errors else merge(errorsNullable, errors)


### PR DESCRIPTION
Let's test if `private[chimney]` fails MiMa check (it should be binary compatible)?

EDIT: it seems it does.

 * `Result.Errors.__mergeResultNullable` is an utility we need for performance (it allow us to avoid allocations, since we can just use `var` and `null` when we have no errors to report)
 * we cannot remove it for backward compatibility reasons
 * but also showing users the method `__mergeResultNullable` with docs "Please do not use" (which is not defined in `internal` package), is rather ugly

so we can use some redirection to make it package private - for JVM it is _still_ public but it should no longer be directly usable/no longer shown by IDE.