### PR TITLE
Make sealed trait/enum matching order deterministic

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -36,7 +36,7 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
       // calling .distinct here as `knownDirectSubclasses` returns duplicates for multiply-inherited types
       extractRecursively(Type[A].tpe.typeSymbol.asType).distinct.map(typeSymbol =>
         subtypeName(typeSymbol) -> subtypeTypeOf[A](typeSymbol)
-      )
+      ).sortBy(_._1)
     }
 
     private def symbolsToEnum[A: Type](subtypes: List[(String, ?<[A])]): Enum[A] =

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -35,7 +35,7 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
 
       // calling .distinct here as `children` returns duplicates for multiply-inherited types
       extractRecursively(TypeRepr.of[A].typeSymbol).distinct
-        .sortBy(_.pos)(order)
+        .sortBy(_.pos.filter(pos => scala.util.Try(pos.start).isSuccess))(order)
         .map(typeSymbol => subtypeName(typeSymbol) -> subtypeTypeOf[A](typeSymbol))
     }
 


### PR DESCRIPTION
Classfiles of generated transformers are slightly different, the order of sealed subclasses is non-deterministic.
We're using bazel as a build tool and it's important for build to produce an exact same file for the same input, otherwise it's dependent targets are re-evaluated.