### PR TITLE
Two-directional transformations

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/CodecCompanionPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/CodecCompanionPlatform.scala
@@ -1,0 +1,44 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
+
+import scala.language.experimental.macros
+
+private[chimney] trait CodecCompanionPlatform { this: Codec.type =>
+
+  /** Provides [[io.scalaland.chimney.Codec]] derived with the default settings.
+    *
+    * When transformation can't be derived, it results with compilation error.
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    * @return
+    *   [[io.scalaland.chimney.Codec]] type class definition
+    *
+    * @since 1.2.0
+    */
+  def derive[Domain, Dto]: Codec[Domain, Dto] =
+    macro CodecMacros.deriveCodecWithDefaults[Domain, Dto]
+}
+
+private[chimney] trait CodecAutoDerivedCompanionPlatform { this: Codec.AutoDerived.type =>
+
+  /** Provides [[io.scalaland.chimney.Codec.AutoDerived]] derived with the default settings.
+    *
+    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.auto#deriveAutomaticCodec]].
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    * @return
+    *   [[io.scalaland.chimney.Codec.AutoDerived]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit def deriveAutomatic[Domain, Dto]: Codec.AutoDerived[Domain, Dto] =
+    macro CodecMacros.deriveCodecWithDefaults[Domain, Dto]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/CodecCompanionPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/CodecCompanionPlatform.scala
@@ -22,23 +22,3 @@ private[chimney] trait CodecCompanionPlatform { this: Codec.type =>
   def derive[Domain, Dto]: Codec[Domain, Dto] =
     macro CodecMacros.deriveCodecWithDefaults[Domain, Dto]
 }
-
-private[chimney] trait CodecAutoDerivedCompanionPlatform { this: Codec.AutoDerived.type =>
-
-  /** Provides [[io.scalaland.chimney.Codec.AutoDerived]] derived with the default settings.
-    *
-    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.auto#deriveAutomaticCodec]].
-    *
-    * @tparam Domain
-    *   type of domain value
-    * @tparam Dto
-    *   type of DTO value
-    * @return
-    *   [[io.scalaland.chimney.Codec.AutoDerived]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit def deriveAutomatic[Domain, Dto]: Codec.AutoDerived[Domain, Dto] =
-    macro CodecMacros.deriveCodecWithDefaults[Domain, Dto]
-}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/IsoCompanionPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/IsoCompanionPlatform.scala
@@ -10,17 +10,17 @@ private[chimney] trait IsoCompanionPlatform { this: Iso.type =>
     *
     * When transformation can't be derived, it results with compilation error.
     *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
+    * @tparam First
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam Second
+    *   output type of the first conversion, input type of the second conversion
     * @return
     *   [[io.scalaland.chimney.Iso]] type class definition
     *
     * @since 1.2.0
     */
-  def derive[From, To]: Iso[From, To] =
-    macro IsoMacros.deriveIsoWithDefaults[From, To]
+  def derive[First, Second]: Iso[First, Second] =
+    macro IsoMacros.deriveIsoWithDefaults[First, Second]
 }
 
 private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.type =>
@@ -30,15 +30,15 @@ private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.t
     * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
     * differs from [[io.scalaland.chimney.auto#deriveAutomaticIso]].
     *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
+    * @tparam First
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam Second
+    *   output type of the first conversion, input type of the second conversion
     * @return
     *   [[io.scalaland.chimney.Iso.AutoDerived]] type class instance
     *
     * @since 1.2.0
     */
-  implicit def deriveAutomatic[From, To]: Iso.AutoDerived[From, To] =
-    macro IsoMacros.deriveIsoWithDefaults[From, To]
+  implicit def deriveAutomatic[First, Second]: Iso.AutoDerived[First, Second] =
+    macro IsoMacros.deriveIsoWithDefaults[First, Second]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/IsoCompanionPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/IsoCompanionPlatform.scala
@@ -1,0 +1,44 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
+
+import scala.language.experimental.macros
+
+private[chimney] trait IsoCompanionPlatform { this: Iso.type =>
+
+  /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
+    *
+    * When transformation can't be derived, it results with compilation error.
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    * @return
+    *   [[io.scalaland.chimney.Iso]] type class definition
+    *
+    * @since 1.2.0
+    */
+  def derive[From, To]: Iso[From, To] =
+    macro IsoMacros.deriveIsoWithDefaults[From, To]
+}
+
+private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.type =>
+
+  /** Provides [[io.scalaland.chimney.Iso.AutoDerived]] derived with the default settings.
+    *
+    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.auto#deriveAutomaticIso]].
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    * @return
+    *   [[io.scalaland.chimney.Iso.AutoDerived]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit def deriveAutomatic[From, To]: Iso.AutoDerived[From, To] =
+    macro IsoMacros.deriveIsoWithDefaults[From, To]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/IsoCompanionPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/IsoCompanionPlatform.scala
@@ -22,23 +22,3 @@ private[chimney] trait IsoCompanionPlatform { this: Iso.type =>
   def derive[First, Second]: Iso[First, Second] =
     macro IsoMacros.deriveIsoWithDefaults[First, Second]
 }
-
-private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.type =>
-
-  /** Provides [[io.scalaland.chimney.Iso.AutoDerived]] derived with the default settings.
-    *
-    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.auto#deriveAutomaticIso]].
-    *
-    * @tparam First
-    *   input type of the first conversion, output type of the second conversion
-    * @tparam Second
-    *   output type of the first conversion, input type of the second conversion
-    * @return
-    *   [[io.scalaland.chimney.Iso.AutoDerived]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit def deriveAutomatic[First, Second]: Iso.AutoDerived[First, Second] =
-    macro IsoMacros.deriveIsoWithDefaults[First, Second]
-}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/PartialTransformerCompanionPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/PartialTransformerCompanionPlatform.scala
@@ -4,7 +4,8 @@ import io.scalaland.chimney.internal.compiletime.derivation.transformer.Transfor
 
 import scala.language.experimental.macros
 
-private[chimney] trait PartialTransformerCompanionPlatform { this: PartialTransformer.type =>
+private[chimney] trait PartialTransformerCompanionPlatform extends PartialTransformerLowPriorityImplicits1 {
+  this: PartialTransformer.type =>
 
   /** Provides [[io.scalaland.chimney.PartialTransformer]] derived with the default settings.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/TransformerCompanionPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/TransformerCompanionPlatform.scala
@@ -4,7 +4,7 @@ import io.scalaland.chimney.internal.compiletime.derivation.transformer.Transfor
 
 import scala.language.experimental.macros
 
-private[chimney] trait TransformerCompanionPlatform { this: Transformer.type =>
+private[chimney] trait TransformerCompanionPlatform extends TransformerLowPriorityImplicits1 { this: Transformer.type =>
 
   /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
@@ -49,40 +49,6 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
   implicit def deriveAutomaticPartialTransformer[From, To]: PartialTransformer[From, To] =
     macro TransformerMacros.derivePartialTransformerWithDefaults[From, To]
 
-  /** Provides [[io.scalaland.chimney.Codec]] derived with the default settings.
-    *
-    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.Codec.AutoDerived#deriveAutomatic]].
-    *
-    * @tparam Domain
-    *   type of domain value
-    * @tparam Dto
-    *   type of DTO value
-    * @return
-    *   [[io.scalaland.chimney.Codec]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit def deriveAutomaticCodec[Domain, Dto]: Codec[Domain, Dto] =
-    macro CodecMacros.deriveCodecWithDefaults[Domain, Dto]
-
-  /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
-    *
-    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.Iso.AutoDerived#deriveAutomatic]].
-    *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
-    * @return
-    *   [[io.scalaland.chimney.Iso]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit def deriveAutomaticIso[From, To]: Iso[From, To] =
-    macro IsoMacros.deriveIsoWithDefaults[From, To]
-
   /** Provides [[io.scalaland.chimney.Patcher]] derived with the default settings.
     *
     * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it

--- a/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
@@ -1,5 +1,7 @@
 package io.scalaland.chimney
 
+import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
+import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
 import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacros
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 
@@ -61,11 +63,8 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
     *
     * @since 1.2.0
     */
-  implicit def deriveAutomaticCodec[Domain, Dto](implicit
-      encode: Transformer[Domain, Dto],
-      decode: PartialTransformer[Dto, Domain]
-  ): Codec[Domain, Dto] =
-    Codec.derive[Domain, Dto]
+  implicit def deriveAutomaticCodec[Domain, Dto]: Codec[Domain, Dto] =
+    macro CodecMacros.deriveCodecWithDefaults[Domain, Dto]
 
   /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
     *
@@ -81,11 +80,8 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
     *
     * @since 1.2.0
     */
-  implicit def deriveAutomaticIso[From, To](implicit
-      from: Transformer[From, To],
-      to: Transformer[To, From]
-  ): Iso[From, To] =
-    Iso.derive[From, To]
+  implicit def deriveAutomaticIso[From, To]: Iso[From, To] =
+    macro IsoMacros.deriveIsoWithDefaults[From, To]
 
   /** Provides [[io.scalaland.chimney.Patcher]] derived with the default settings.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
@@ -47,6 +47,46 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
   implicit def deriveAutomaticPartialTransformer[From, To]: PartialTransformer[From, To] =
     macro TransformerMacros.derivePartialTransformerWithDefaults[From, To]
 
+  /** Provides [[io.scalaland.chimney.Codec]] derived with the default settings.
+    *
+    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.Codec.AutoDerived#deriveAutomatic]].
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    * @return
+    *   [[io.scalaland.chimney.Codec]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit def deriveAutomaticCodec[Domain, Dto](implicit
+      encode: Transformer[Domain, Dto],
+      decode: PartialTransformer[Dto, Domain]
+  ): Codec[Domain, Dto] =
+    Codec.derive[Domain, Dto]
+
+  /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
+    *
+    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.Iso.AutoDerived#deriveAutomatic]].
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    * @return
+    *   [[io.scalaland.chimney.Iso]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit def deriveAutomaticIso[From, To](implicit
+      from: Transformer[From, To],
+      to: Transformer[To, From]
+  ): Iso[From, To] =
+    Iso.derive[From, To]
+
   /** Provides [[io.scalaland.chimney.Patcher]] derived with the default settings.
     *
     * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it

--- a/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/auto.scala
@@ -1,7 +1,5 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
-import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
 import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacros
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -1,7 +1,10 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.Codec
+import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
+import scala.language.experimental.macros
 
 final class CodecDefinition[
     Domain,
@@ -20,6 +23,6 @@ final class CodecDefinition[
 
   def buildCodec[ImplicitScopeFlags <: TransformerFlags](implicit
       tc: TransformerConfiguration[ImplicitScopeFlags]
-  ): Codec[Domain, Dto] = ???
-  // macro TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]
+  ): Codec[Domain, Dto] =
+    macro CodecMacros.deriveCodecWithConfig[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags, ImplicitScopeFlags]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -7,6 +7,21 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
 
 import scala.language.experimental.macros
 
+/** Allows customization of [[io.scalaland.chimney.Codec]] derivation.
+  *
+  * @tparam Domain
+  *   type of the domain value
+  * @tparam Dto
+  *   typeof the DTO value
+  * @tparam EncodeOverrides
+  *   type-level encoded config
+  * @tparam DecodeOverrides
+  *   type-level encoded config
+  * @tparam Flags
+  *   type-level encoded flags
+  *
+  * @since 1.2.0
+  */
 final class CodecDefinition[
     Domain,
     Dto,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -1,0 +1,25 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.Codec
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
+final class CodecDefinition[
+    Domain,
+    Dto,
+    EncodeOverrides <: TransformerOverrides,
+    DecodeOverrides <: TransformerOverrides,
+    Flags <: TransformerFlags
+](
+    val encode: TransformerDefinition[Domain, Dto, EncodeOverrides, Flags],
+    val decode: PartialTransformerDefinition[Dto, Domain, DecodeOverrides, Flags]
+) extends TransformerFlagsDsl[Lambda[
+      `Flags1 <: TransformerFlags` => CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags1]
+    ], Flags] {
+
+  // TODO: def withFieldRenamed
+
+  def buildCodec[ImplicitScopeFlags <: TransformerFlags](implicit
+      tc: TransformerConfiguration[ImplicitScopeFlags]
+  ): Codec[Domain, Dto] = ???
+  // macro TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -1,0 +1,25 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.Iso
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
+final class IsoDefinition[
+    From,
+    To,
+    FromOverrides <: TransformerOverrides,
+    ToOverrides <: TransformerOverrides,
+    Flags <: TransformerFlags
+](
+    val from: TransformerDefinition[From, To, FromOverrides, Flags],
+    val to: TransformerDefinition[To, From, ToOverrides, Flags]
+) extends TransformerFlagsDsl[Lambda[
+      `Flags1 <: TransformerFlags` => CodecDefinition[From, To, FromOverrides, ToOverrides, Flags1]
+    ], Flags] {
+
+  // TODO: def withFieldRenamed
+
+  def buildCodec[ImplicitScopeFlags <: TransformerFlags](implicit
+      tc: TransformerConfiguration[ImplicitScopeFlags]
+  ): Iso[From, To] = ???
+  // macro TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -32,7 +32,7 @@ final class IsoDefinition[
     val first: TransformerDefinition[First, Second, FirstOverrides, Flags],
     val second: TransformerDefinition[Second, First, SecondOverrides, Flags]
 ) extends TransformerFlagsDsl[Lambda[
-      `Flags1 <: TransformerFlags` => CodecDefinition[First, Second, FirstOverrides, SecondOverrides, Flags1]
+      `Flags1 <: TransformerFlags` => IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags1]
     ], Flags] {
 
   /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -7,50 +7,65 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
 
 import scala.language.experimental.macros
 
+/** Allows customization of [[io.scalaland.chimney.Iso]] derivation.
+  *
+  * @tparam First
+  *   input type of the first conversion, output type of the second conversion
+  * @tparam Second
+  *   output type of the first conversion, input type of the second conversion
+  * @tparam FirstOverrides
+  *   type-level encoded config
+  * @tparam SecondOverrides
+  *   type-level encoded config
+  * @tparam Flags
+  *   type-level encoded flags
+  *
+  * @since 1.2.0
+  */
 final class IsoDefinition[
-    From,
-    To,
-    FromOverrides <: TransformerOverrides,
-    ToOverrides <: TransformerOverrides,
+    First,
+    Second,
+    FirstOverrides <: TransformerOverrides,
+    SecondOverrides <: TransformerOverrides,
     Flags <: TransformerFlags
 ](
-    val from: TransformerDefinition[From, To, FromOverrides, Flags],
-    val to: TransformerDefinition[To, From, ToOverrides, Flags]
+    val first: TransformerDefinition[First, Second, FirstOverrides, Flags],
+    val second: TransformerDefinition[Second, First, SecondOverrides, Flags]
 ) extends TransformerFlagsDsl[Lambda[
-      `Flags1 <: TransformerFlags` => CodecDefinition[From, To, FromOverrides, ToOverrides, Flags1]
+      `Flags1 <: TransformerFlags` => CodecDefinition[First, Second, FirstOverrides, SecondOverrides, Flags1]
     ], Flags] {
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`
     *
-    * By default if `From` is missing field picked by `selectorTo` (or reverse) the compilation fails.
+    * By default if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
     *   for more details
     *
     * @tparam T
-    *   type of source field
+    *   type of the first field
     * @tparam U
-    *   type of target field
-    * @param selectorFrom
-    *   source field in `From`, defined like `_.originalName`
-    * @param selectorTo
-    *   target field in `To`, defined like `_.newName`
+    *   type of the second field
+    * @param selectorFirst
+    *   source field in `First`, defined like `_.originalName`
+    * @param selectorSecond
+    *   target field in `Second`, defined like `_.newName`
     * @return
     *   [[io.scalaland.chimney.dsl.IsoDefinition]]
     *
     * @since 1.2.0
     */
   def withFieldRenamed[T, U](
-      selectorFrom: From => T,
-      selectorTo: To => U
-  ): IsoDefinition[From, To, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
-    macro IsoDefinitionMacros.withFieldRenamedImpl[From, To, FromOverrides, ToOverrides, Flags]
+      selectorFirst: First => T,
+      selectorSecond: Second => U
+  ): IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    macro IsoDefinitionMacros.withFieldRenamedImpl[First, Second, FirstOverrides, SecondOverrides, Flags]
 
   /** Build Iso using current configuration.
     *
-    * It runs macro that tries to derive instance of `Iso[From, To]`. When transformation can't be derived, it results
-    * with compilation error.
+    * It runs macro that tries to derive instance of `Iso[First, Second]`. When transformation can't be derived, it
+    * results with compilation error.
     *
     * @return
     *   [[io.scalaland.chimney.Iso]] type class instance
@@ -59,6 +74,6 @@ final class IsoDefinition[
     */
   def buildIso[ImplicitScopeFlags <: TransformerFlags](implicit
       tc: TransformerConfiguration[ImplicitScopeFlags]
-  ): Iso[From, To] =
-    macro IsoMacros.deriveIsoWithConfig[From, To, FromOverrides, ToOverrides, Flags, ImplicitScopeFlags]
+  ): Iso[First, Second] =
+    macro IsoMacros.deriveIsoWithConfig[First, Second, FirstOverrides, SecondOverrides, Flags, ImplicitScopeFlags]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.Iso
 import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
+import io.scalaland.chimney.internal.compiletime.dsl.IsoDefinitionMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
 import scala.language.experimental.macros
@@ -19,9 +20,44 @@ final class IsoDefinition[
       `Flags1 <: TransformerFlags` => CodecDefinition[From, To, FromOverrides, ToOverrides, Flags1]
     ], Flags] {
 
-  // TODO: def withFieldRenamed
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+    *
+    * By default if `From` is missing field picked by `selectorTo` (or reverse) the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
+    *   for more details
+    *
+    * @tparam T
+    *   type of source field
+    * @tparam U
+    *   type of target field
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.originalName`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.newName`
+    * @return
+    *   [[io.scalaland.chimney.dsl.IsoDefinition]]
+    *
+    * @since 1.2.0
+    */
+  def withFieldRenamed[T, U](
+      selectorFrom: From => T,
+      selectorTo: To => U
+  ): IsoDefinition[From, To, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    macro IsoDefinitionMacros.withFieldRenamedImpl[From, To, FromOverrides, ToOverrides, Flags]
 
-  def buildCodec[ImplicitScopeFlags <: TransformerFlags](implicit
+  /** Build Iso using current configuration.
+    *
+    * It runs macro that tries to derive instance of `Iso[From, To]`. When transformation can't be derived, it results
+    * with compilation error.
+    *
+    * @return
+    *   [[io.scalaland.chimney.Iso]] type class instance
+    *
+    * @since 1.2.0
+    */
+  def buildIso[ImplicitScopeFlags <: TransformerFlags](implicit
       tc: TransformerConfiguration[ImplicitScopeFlags]
   ): Iso[From, To] =
     macro IsoMacros.deriveIsoWithConfig[From, To, FromOverrides, ToOverrides, Flags, ImplicitScopeFlags]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -1,7 +1,10 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.Iso
+import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
+import scala.language.experimental.macros
 
 final class IsoDefinition[
     From,
@@ -20,6 +23,6 @@ final class IsoDefinition[
 
   def buildCodec[ImplicitScopeFlags <: TransformerFlags](implicit
       tc: TransformerConfiguration[ImplicitScopeFlags]
-  ): Iso[From, To] = ???
-  // macro TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]
+  ): Iso[From, To] =
+    macro IsoMacros.deriveIsoWithConfig[From, To, FromOverrides, ToOverrides, Flags, ImplicitScopeFlags]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -7,7 +7,7 @@ object TransformerDefinitionCommons {
   def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
 }
 
-private[chimney] trait TransformerDefinitionCommons[UpdateTail[_ <: TransformerOverrides]] {
+private[chimney] trait TransformerDefinitionCommons[UpdateOverrides[_ <: TransformerOverrides]] {
 
   import TransformerDefinitionCommons.*
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -1,0 +1,137 @@
+package io.scalaland.chimney.internal.compiletime.derivation.codec
+
+import io.scalaland.chimney.dsl
+import io.scalaland.chimney.Codec
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.{DerivationPlatform, Gateway}
+import io.scalaland.chimney.internal.runtime
+
+import scala.reflect.macros.blackbox
+
+final class CodecMacros(val c: blackbox.Context) extends DerivationPlatform with Gateway {
+
+  import c.universe.{internal as _, Transformer as _, *}
+
+  def deriveCodecWithDefaults[
+      Domain: WeakTypeTag,
+      Dto: WeakTypeTag
+  ]: c.universe.Expr[Codec[Domain, Dto]] =
+    retypecheck(
+      suppressWarnings(
+        resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+          import implicitScopeFlagsType.Underlying
+          c.Expr(
+            q"""
+            io.scalaland.chimney.Codec[${Type[Domain]}, ${Type[Dto]}](
+              encode = ${deriveTotalTransformer[
+                Domain,
+                Dto,
+                runtime.TransformerOverrides.Empty,
+                runtime.TransformerFlags.Default,
+                implicitScopeFlagsType.Underlying
+              ](ChimneyExpr.RuntimeDataStore.empty)},
+              decode = ${derivePartialTransformer[
+                Dto,
+                Domain,
+                runtime.TransformerOverrides.Empty,
+                runtime.TransformerFlags.Default,
+                implicitScopeFlagsType.Underlying
+              ](ChimneyExpr.RuntimeDataStore.empty)}
+            )
+            """
+          )
+        }
+      )
+    )
+
+  def deriveCodecWithConfig[
+      Domain: WeakTypeTag,
+      Dto: WeakTypeTag,
+      EncodeOverrides <: runtime.TransformerOverrides: WeakTypeTag,
+      DecodeOverrides <: runtime.TransformerOverrides: WeakTypeTag,
+      InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
+      ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
+  ](
+      tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
+  ): Expr[Codec[Domain, Dto]] = retypecheck(
+    suppressWarnings(
+      Expr.block(
+        List(Expr.suppressUnused(tc)),
+        c.Expr(
+          q"""
+          io.scalaland.chimney.Codec[${Type[Domain]}, ${Type[Dto]}](
+            encode = ${deriveTotalTransformer[
+              Domain,
+              Dto,
+              EncodeOverrides,
+              InstanceFlags,
+              ImplicitScopeFlags
+            ](
+              // Called by CodecDefinition => prefix is CodecDefinition
+              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.encode.runtimeData")
+            )},
+            decode = ${derivePartialTransformer[
+              Dto,
+              Domain,
+              DecodeOverrides,
+              InstanceFlags,
+              ImplicitScopeFlags
+            ](
+              // Called by CodecDefinition => prefix is CodecDefinition
+              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.decode.runtimeData")
+            )}
+          )
+          """
+        )
+      )
+    )
+  )
+
+  private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
+      useImplicitScopeFlags: ?<[runtime.TransformerFlags] => Expr[A]
+  ): Expr[A] = {
+    val implicitScopeConfig = {
+      val transformerConfigurationType = Type.platformSpecific
+        .fromUntyped[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]](
+          c.typecheck(
+            tree = tq"${typeOf[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]]}",
+            silent = true,
+            mode = c.TYPEmode,
+            withImplicitViewsDisabled = true,
+            withMacrosDisabled = false
+          ).tpe
+        )
+
+      Expr.summonImplicit(transformerConfigurationType).getOrElse {
+        // $COVERAGE-OFF$
+        reportError("Can't locate implicit TransformerConfiguration!")
+        // $COVERAGE-ON$
+      }
+    }
+    val implicitScopeFlagsType = Type.platformSpecific
+      .fromUntyped[runtime.TransformerFlags](implicitScopeConfig.tpe.tpe.typeArgs.head)
+      .as_?<[runtime.TransformerFlags]
+
+    Expr.block(
+      List(Expr.suppressUnused(implicitScopeConfig)),
+      useImplicitScopeFlags(implicitScopeFlagsType)
+    )
+  }
+
+  private def retypecheck[A: Type](expr: c.Expr[A]): c.Expr[A] = try
+    c.Expr[A](c.typecheck(tree = c.untypecheck(expr.tree)))
+  catch {
+    case scala.reflect.macros.TypecheckException(_, msg) => c.abort(c.enclosingPosition, msg)
+  }
+
+  private def suppressWarnings[A: Type](expr: c.Expr[A]): c.Expr[A] = {
+    // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
+    val result = c.internal.reificationSupport.freshTermName("result$macro$")
+    c.Expr[A](
+      q"""{
+          @_root_.java.lang.SuppressWarnings(_root_.scala.Array("org.wartremover.warts.All", "all"))
+          val $result = $expr
+          $result
+        }"""
+    )
+  }
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -29,7 +29,7 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
                 runtime.TransformerFlags.Default,
                 implicitScopeFlagsType.Underlying
               ](ChimneyExpr.RuntimeDataStore.empty)},
-              second = ${derivePartialTransformer[
+              second = ${deriveTotalTransformer[
                 Second,
                 First,
                 runtime.TransformerOverrides.Empty,
@@ -77,7 +77,7 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
               ImplicitScopeFlags
             ](
               // Called by CodecDefinition => prefix is CodecDefinition
-              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.to.runtimeData")
+              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.second.runtimeData")
             )}
           )
           """

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -66,7 +66,7 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
               InstanceFlags,
               ImplicitScopeFlags
             ](
-              // Called by CodecDefinition => prefix is CodecDefinition
+              // Called by IsoDefinition => prefix is IsoDefinition
               c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.first.runtimeData")
             )},
             second = ${deriveTotalTransformer[
@@ -76,7 +76,7 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
               InstanceFlags,
               ImplicitScopeFlags
             ](
-              // Called by CodecDefinition => prefix is CodecDefinition
+              // Called by IsoDefinition => prefix is IsoDefinition
               c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.second.runtimeData")
             )}
           )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -1,0 +1,137 @@
+package io.scalaland.chimney.internal.compiletime.derivation.iso
+
+import io.scalaland.chimney.dsl
+import io.scalaland.chimney.Iso
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.{DerivationPlatform, Gateway}
+import io.scalaland.chimney.internal.runtime
+
+import scala.reflect.macros.blackbox
+
+final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with Gateway {
+
+  import c.universe.{internal as _, Transformer as _, *}
+
+  def deriveIsoWithDefaults[
+      From: WeakTypeTag,
+      To: WeakTypeTag
+  ]: c.universe.Expr[Iso[From, To]] =
+    retypecheck(
+      suppressWarnings(
+        resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+          import implicitScopeFlagsType.Underlying
+          c.Expr(
+            q"""
+            io.scalaland.chimney.Iso[${Type[From]}, ${Type[To]}](
+              from = ${deriveTotalTransformer[
+                From,
+                To,
+                runtime.TransformerOverrides.Empty,
+                runtime.TransformerFlags.Default,
+                implicitScopeFlagsType.Underlying
+              ](ChimneyExpr.RuntimeDataStore.empty)},
+              to = ${derivePartialTransformer[
+                To,
+                From,
+                runtime.TransformerOverrides.Empty,
+                runtime.TransformerFlags.Default,
+                implicitScopeFlagsType.Underlying
+              ](ChimneyExpr.RuntimeDataStore.empty)}
+            )
+            """
+          )
+        }
+      )
+    )
+
+  def deriveIsoWithConfig[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      FromOverrides <: runtime.TransformerOverrides: WeakTypeTag,
+      ToOverrides <: runtime.TransformerOverrides: WeakTypeTag,
+      InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
+      ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
+  ](
+      tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
+  ): Expr[Iso[From, To]] = retypecheck(
+    suppressWarnings(
+      Expr.block(
+        List(Expr.suppressUnused(tc)),
+        c.Expr(
+          q"""
+          io.scalaland.chimney.Iso[${Type[From]}, ${Type[To]}](
+            from = ${deriveTotalTransformer[
+              From,
+              To,
+              FromOverrides,
+              InstanceFlags,
+              ImplicitScopeFlags
+            ](
+              // Called by CodecDefinition => prefix is CodecDefinition
+              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.from.runtimeData")
+            )},
+            to = ${deriveTotalTransformer[
+              To,
+              From,
+              ToOverrides,
+              InstanceFlags,
+              ImplicitScopeFlags
+            ](
+              // Called by CodecDefinition => prefix is CodecDefinition
+              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.to.runtimeData")
+            )}
+          )
+          """
+        )
+      )
+    )
+  )
+
+  private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
+      useImplicitScopeFlags: ?<[runtime.TransformerFlags] => Expr[A]
+  ): Expr[A] = {
+    val implicitScopeConfig = {
+      val transformerConfigurationType = Type.platformSpecific
+        .fromUntyped[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]](
+          c.typecheck(
+            tree = tq"${typeOf[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]]}",
+            silent = true,
+            mode = c.TYPEmode,
+            withImplicitViewsDisabled = true,
+            withMacrosDisabled = false
+          ).tpe
+        )
+
+      Expr.summonImplicit(transformerConfigurationType).getOrElse {
+        // $COVERAGE-OFF$
+        reportError("Can't locate implicit TransformerConfiguration!")
+        // $COVERAGE-ON$
+      }
+    }
+    val implicitScopeFlagsType = Type.platformSpecific
+      .fromUntyped[runtime.TransformerFlags](implicitScopeConfig.tpe.tpe.typeArgs.head)
+      .as_?<[runtime.TransformerFlags]
+
+    Expr.block(
+      List(Expr.suppressUnused(implicitScopeConfig)),
+      useImplicitScopeFlags(implicitScopeFlagsType)
+    )
+  }
+
+  private def retypecheck[A: Type](expr: c.Expr[A]): c.Expr[A] = try
+    c.Expr[A](c.typecheck(tree = c.untypecheck(expr.tree)))
+  catch {
+    case scala.reflect.macros.TypecheckException(_, msg) => c.abort(c.enclosingPosition, msg)
+  }
+
+  private def suppressWarnings[A: Type](expr: c.Expr[A]): c.Expr[A] = {
+    // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
+    val result = c.internal.reificationSupport.freshTermName("result$macro$")
+    c.Expr[A](
+      q"""{
+          @_root_.java.lang.SuppressWarnings(_root_.scala.Array("org.wartremover.warts.All", "all"))
+          val $result = $expr
+          $result
+        }"""
+    )
+  }
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -12,26 +12,26 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
   import c.universe.{internal as _, Transformer as _, *}
 
   def deriveIsoWithDefaults[
-      From: WeakTypeTag,
-      To: WeakTypeTag
-  ]: c.universe.Expr[Iso[From, To]] =
+      First: WeakTypeTag,
+      Second: WeakTypeTag
+  ]: c.universe.Expr[Iso[First, Second]] =
     retypecheck(
       suppressWarnings(
         resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
           import implicitScopeFlagsType.Underlying
           c.Expr(
             q"""
-            io.scalaland.chimney.Iso[${Type[From]}, ${Type[To]}](
-              from = ${deriveTotalTransformer[
-                From,
-                To,
+            io.scalaland.chimney.Iso[${Type[First]}, ${Type[Second]}](
+              first = ${deriveTotalTransformer[
+                First,
+                Second,
                 runtime.TransformerOverrides.Empty,
                 runtime.TransformerFlags.Default,
                 implicitScopeFlagsType.Underlying
               ](ChimneyExpr.RuntimeDataStore.empty)},
-              to = ${derivePartialTransformer[
-                To,
-                From,
+              second = ${derivePartialTransformer[
+                Second,
+                First,
                 runtime.TransformerOverrides.Empty,
                 runtime.TransformerFlags.Default,
                 implicitScopeFlagsType.Underlying
@@ -44,35 +44,35 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
     )
 
   def deriveIsoWithConfig[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      FromOverrides <: runtime.TransformerOverrides: WeakTypeTag,
-      ToOverrides <: runtime.TransformerOverrides: WeakTypeTag,
+      First: WeakTypeTag,
+      Second: WeakTypeTag,
+      FirstOverrides <: runtime.TransformerOverrides: WeakTypeTag,
+      SecondOverrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
   ](
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
-  ): Expr[Iso[From, To]] = retypecheck(
+  ): Expr[Iso[First, Second]] = retypecheck(
     suppressWarnings(
       Expr.block(
         List(Expr.suppressUnused(tc)),
         c.Expr(
           q"""
-          io.scalaland.chimney.Iso[${Type[From]}, ${Type[To]}](
-            from = ${deriveTotalTransformer[
-              From,
-              To,
-              FromOverrides,
+          io.scalaland.chimney.Iso[${Type[First]}, ${Type[Second]}](
+            first = ${deriveTotalTransformer[
+              First,
+              Second,
+              FirstOverrides,
               InstanceFlags,
               ImplicitScopeFlags
             ](
               // Called by CodecDefinition => prefix is CodecDefinition
-              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.from.runtimeData")
+              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.first.runtimeData")
             )},
-            to = ${deriveTotalTransformer[
-              To,
-              From,
-              ToOverrides,
+            second = ${deriveTotalTransformer[
+              Second,
+              First,
+              SecondOverrides,
               InstanceFlags,
               ImplicitScopeFlags
             ](

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -12,7 +12,7 @@ final class PatcherMacros(val c: blackbox.Context) extends DerivationPlatform wi
   def derivePatchWithConfig[
       A: WeakTypeTag,
       Patch: WeakTypeTag,
-      Tail <: runtime.PatcherOverrides: WeakTypeTag,
+      Overrides <: runtime.PatcherOverrides: WeakTypeTag,
       Flags <: runtime.PatcherFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.PatcherFlags: WeakTypeTag
   ](
@@ -20,10 +20,10 @@ final class PatcherMacros(val c: blackbox.Context) extends DerivationPlatform wi
   ): c.Expr[A] = retypecheck(
     suppressWarnings(
       // Called by PatcherUsing => prefix is PatcherUsing
-      cacheDefinition(c.Expr[dsl.PatcherUsing[A, Patch, Tail, Flags]](c.prefix.tree)) { pu =>
+      cacheDefinition(c.Expr[dsl.PatcherUsing[A, Patch, Overrides, Flags]](c.prefix.tree)) { pu =>
         Expr.block(
           List(Expr.suppressUnused(pu)),
-          derivePatcherResult[A, Patch, Tail, Flags, ImplicitScopeFlags](
+          derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
             obj = c.Expr[A](q"$pu.obj"),
             patch = c.Expr[Patch](q"$pu.objPatch")
           )
@@ -35,17 +35,17 @@ final class PatcherMacros(val c: blackbox.Context) extends DerivationPlatform wi
   def derivePatcherWithConfig[
       A: WeakTypeTag,
       Patch: WeakTypeTag,
-      Tail <: runtime.PatcherOverrides: WeakTypeTag,
+      Overrides <: runtime.PatcherOverrides: WeakTypeTag,
       InstanceFlags <: runtime.PatcherFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.PatcherFlags: WeakTypeTag
   ](
       tc: Expr[io.scalaland.chimney.dsl.PatcherConfiguration[ImplicitScopeFlags]]
   ): Expr[Patcher[A, Patch]] = retypecheck(
     suppressWarnings(
-      cacheDefinition(c.Expr[dsl.PatcherDefinition[A, Patch, Tail, InstanceFlags]](c.prefix.tree)) { pu =>
+      cacheDefinition(c.Expr[dsl.PatcherDefinition[A, Patch, Overrides, InstanceFlags]](c.prefix.tree)) { pu =>
         Expr.block(
           List(Expr.suppressUnused(pu)),
-          derivePatcher[A, Patch, Tail, InstanceFlags, ImplicitScopeFlags]
+          derivePatcher[A, Patch, Overrides, InstanceFlags, ImplicitScopeFlags]
         )
       }
     )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -14,7 +14,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   def deriveTotalTransformationWithConfig[
       From: WeakTypeTag,
       To: WeakTypeTag,
-      Tail <: runtime.TransformerOverrides: WeakTypeTag,
+      Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
   ](
@@ -23,10 +23,10 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
     suppressWarnings(
       // Called by TransformerInto => prefix is TransformerInto
       // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-      cacheDefinition(c.Expr[dsl.TransformerInto[From, To, Tail, InstanceFlags]](c.prefix.tree)) { ti =>
+      cacheDefinition(c.Expr[dsl.TransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { ti =>
         Expr.block(
           List(Expr.suppressUnused(tc)),
-          deriveTotalTransformationResult[From, To, Tail, InstanceFlags, ImplicitScopeFlags](
+          deriveTotalTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
             src = c.Expr[From](q"$ti.source"),
             runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$ti.td.runtimeData")
           )
@@ -56,7 +56,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   def deriveTotalTransformerWithConfig[
       From: WeakTypeTag,
       To: WeakTypeTag,
-      Tail <: runtime.TransformerOverrides: WeakTypeTag,
+      Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
   ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]): Expr[Transformer[From, To]] =
@@ -64,7 +64,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
       suppressWarnings(
         Expr.block(
           List(Expr.suppressUnused(tc)),
-          deriveTotalTransformer[From, To, Tail, InstanceFlags, ImplicitScopeFlags](
+          deriveTotalTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
             // Called by TransformerDefinition => prefix is TransformerDefinition
             c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
           )
@@ -75,7 +75,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   def derivePartialTransformationWithConfigNoFailFast[
       From: WeakTypeTag,
       To: WeakTypeTag,
-      Tail <: runtime.TransformerOverrides: WeakTypeTag,
+      Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
   ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]): Expr[partial.Result[To]] =
@@ -83,10 +83,10 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
       suppressWarnings(
         // Called by PartialTransformerInto => prefix is PartialTransformerInto
         // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-        cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Tail, InstanceFlags]](c.prefix.tree)) { pti =>
+        cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
           Expr.block(
             List(Expr.suppressUnused(tc)),
-            derivePartialTransformationResult[From, To, Tail, InstanceFlags, ImplicitScopeFlags](
+            derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
               src = c.Expr[From](q"$pti.source"),
               failFast = c.Expr[Boolean](q"false"),
               runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
@@ -99,7 +99,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   def derivePartialTransformationWithConfigFailFast[
       From: WeakTypeTag,
       To: WeakTypeTag,
-      Tail <: runtime.TransformerOverrides: WeakTypeTag,
+      Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
   ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]): Expr[partial.Result[To]] =
@@ -107,10 +107,10 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
       suppressWarnings(
         // Called by PartialTransformerInto => prefix is PartialTransformerInto
         // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-        cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Tail, InstanceFlags]](c.prefix.tree)) { pti =>
+        cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
           Expr.block(
             List(Expr.suppressUnused(tc)),
-            derivePartialTransformationResult[From, To, Tail, InstanceFlags, ImplicitScopeFlags](
+            derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
               src = c.Expr[From](q"$pti.source"),
               failFast = c.Expr[Boolean](q"true"),
               runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
@@ -142,7 +142,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   def derivePartialTransformerWithConfig[
       From: WeakTypeTag,
       To: WeakTypeTag,
-      Tail <: runtime.TransformerOverrides: WeakTypeTag,
+      Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
   ](
@@ -151,7 +151,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
     suppressWarnings(
       Expr.block(
         List(Expr.suppressUnused(tc)),
-        derivePartialTransformer[From, To, Tail, InstanceFlags, ImplicitScopeFlags](
+        derivePartialTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
           // Called by PartialTransformerDefinition => prefix is PartialTransformerDefinition
           c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
         )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
@@ -1,0 +1,32 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.dsl.CodecDefinition
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.reflect.macros.whitebox
+
+class CodecDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
+
+  import c.universe.{Select as _, *}
+
+  def withFieldRenamedImpl[
+      Domain: WeakTypeTag,
+      Dto: WeakTypeTag,
+      EncodeOverrides <: TransformerOverrides: WeakTypeTag,
+      DecodeOverrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorDomain: Tree, selectorDto: Tree): Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      new ApplyFieldNameTypes {
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[CodecDefinition[
+            Domain,
+            Dto,
+            RenamedFrom[FromPath, ToPath, EncodeOverrides],
+            RenamedFrom[ToPath, FromPath, DecodeOverrides],
+            Flags
+          ]]
+      }.applyFromSelectors(selectorDomain, selectorDto)
+    )
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -11,22 +11,22 @@ class IsoDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
   import c.universe.{Select as _, *}
 
   def withFieldRenamedImpl[
-      From: WeakTypeTag,
-      To: WeakTypeTag,
-      FromOverrides <: TransformerOverrides: WeakTypeTag,
-      ToOverrides <: TransformerOverrides: WeakTypeTag,
+      First: WeakTypeTag,
+      Second: WeakTypeTag,
+      FirstOverrides <: TransformerOverrides: WeakTypeTag,
+      SecondOverrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selectorFrom: Tree, selectorTo: Tree): Tree = c.prefix.tree
+  ](selectorFirst: Tree, selectorSecond: Tree): Tree = c.prefix.tree
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
-        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        def apply[FirstPath <: Path: WeakTypeTag, SecondPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
           weakTypeTag[IsoDefinition[
-            From,
-            To,
-            RenamedFrom[FromPath, ToPath, FromOverrides],
-            RenamedFrom[ToPath, FromPath, ToOverrides],
+            First,
+            Second,
+            RenamedFrom[FirstPath, SecondPath, FirstOverrides],
+            RenamedFrom[SecondPath, FirstPath, SecondOverrides],
             Flags
           ]]
-      }.applyFromSelectors(selectorFrom, selectorTo)
+      }.applyFromSelectors(selectorFirst, selectorSecond)
     )
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -1,0 +1,32 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.dsl.IsoDefinition
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.reflect.macros.whitebox
+
+class IsoDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
+
+  import c.universe.{Select as _, *}
+
+  def withFieldRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      FromOverrides <: TransformerOverrides: WeakTypeTag,
+      ToOverrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree): Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      new ApplyFieldNameTypes {
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[IsoDefinition[
+            From,
+            To,
+            RenamedFrom[FromPath, ToPath, FromOverrides],
+            RenamedFrom[ToPath, FromPath, ToOverrides],
+            Flags
+          ]]
+      }.applyFromSelectors(selectorFrom, selectorTo)
+    )
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/CodecCompanionPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/CodecCompanionPlatform.scala
@@ -20,23 +20,3 @@ private[chimney] trait CodecCompanionPlatform { this: Codec.type =>
   inline def derive[Domain, Dto]: Codec[Domain, Dto] =
     ${ CodecMacros.deriveCodecWithDefaults[Domain, Dto] }
 }
-
-private[chimney] trait CodecAutoDerivedCompanionPlatform { this: Codec.AutoDerived.type =>
-
-  /** Provides [[io.scalaland.chimney.Codec.AutoDerived]] derived with the default settings.
-    *
-    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]].
-    *
-    * @tparam Domain
-    *   type of domain value
-    * @tparam Dto
-    *   type of DTO value
-    * @return
-    *   [[io.scalaland.chimney.Codec.AutoDerived]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit inline def deriveAutomatic[Domain, Dto]: Codec.AutoDerived[Domain, Dto] =
-    ${ CodecMacros.deriveCodecWithDefaults[Domain, Dto] }
-}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/CodecCompanionPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/CodecCompanionPlatform.scala
@@ -1,0 +1,42 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
+
+private[chimney] trait CodecCompanionPlatform { this: Codec.type =>
+
+  /** Provides [[io.scalaland.chimney.Codec]] derived with the default settings.
+    *
+    * When transformation can't be derived, it results with compilation error.
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    * @return
+    *   [[io.scalaland.chimney.Codec]] type class definition
+    *
+    * @since 1.2.0
+    */
+  inline def derive[Domain, Dto]: Codec[Domain, Dto] =
+    ${ CodecMacros.deriveCodecWithDefaults[Domain, Dto] }
+}
+
+private[chimney] trait CodecAutoDerivedCompanionPlatform { this: Codec.AutoDerived.type =>
+
+  /** Provides [[io.scalaland.chimney.Codec.AutoDerived]] derived with the default settings.
+    *
+    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]].
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    * @return
+    *   [[io.scalaland.chimney.Codec.AutoDerived]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit inline def deriveAutomatic[Domain, Dto]: Codec.AutoDerived[Domain, Dto] =
+    ${ CodecMacros.deriveCodecWithDefaults[Domain, Dto] }
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/IsoCompanionPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/IsoCompanionPlatform.scala
@@ -8,17 +8,17 @@ private[chimney] trait IsoCompanionPlatform { this: Iso.type =>
     *
     * When transformation can't be derived, it results with compilation error.
     *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
+    * @tparam First
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam Second
+    *   output type of the first conversion, input type of the second conversion
     * @return
     *   [[io.scalaland.chimney.Iso]] type class definition
     *
     * @since 1.2.0
     */
-  inline def derive[From, To]: Iso[From, To] =
-    ${ IsoMacros.deriveIsoWithDefaults[From, To] }
+  inline def derive[First, Second]: Iso[First, Second] =
+    ${ IsoMacros.deriveIsoWithDefaults[First, Second] }
 }
 
 private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.type =>
@@ -28,15 +28,15 @@ private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.t
     * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
     * differs from [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]].
     *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
+    * @tparam First
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam Second
+    *   output type of the first conversion, input type of the second conversion
     * @return
     *   [[io.scalaland.chimney.Iso.AutoDerived]] type class instance
     *
     * @since 1.2.0
     */
-  implicit inline def deriveAutomatic[From, To]: Iso.AutoDerived[From, To] =
-    ${ IsoMacros.deriveIsoWithDefaults[From, To] }
+  implicit inline def deriveAutomatic[First, Second]: Iso.AutoDerived[First, Second] =
+    ${ IsoMacros.deriveIsoWithDefaults[First, Second] }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/IsoCompanionPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/IsoCompanionPlatform.scala
@@ -20,23 +20,3 @@ private[chimney] trait IsoCompanionPlatform { this: Iso.type =>
   inline def derive[First, Second]: Iso[First, Second] =
     ${ IsoMacros.deriveIsoWithDefaults[First, Second] }
 }
-
-private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.type =>
-
-  /** Provides [[io.scalaland.chimney.Iso.AutoDerived]] derived with the default settings.
-    *
-    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]].
-    *
-    * @tparam First
-    *   input type of the first conversion, output type of the second conversion
-    * @tparam Second
-    *   output type of the first conversion, input type of the second conversion
-    * @return
-    *   [[io.scalaland.chimney.Iso.AutoDerived]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit inline def deriveAutomatic[First, Second]: Iso.AutoDerived[First, Second] =
-    ${ IsoMacros.deriveIsoWithDefaults[First, Second] }
-}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/IsoCompanionPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/IsoCompanionPlatform.scala
@@ -1,0 +1,42 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
+
+private[chimney] trait IsoCompanionPlatform { this: Iso.type =>
+
+  /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
+    *
+    * When transformation can't be derived, it results with compilation error.
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    * @return
+    *   [[io.scalaland.chimney.Iso]] type class definition
+    *
+    * @since 1.2.0
+    */
+  inline def derive[From, To]: Iso[From, To] =
+    ${ IsoMacros.deriveIsoWithDefaults[From, To] }
+}
+
+private[chimney] trait IsoAutoDerivedCompanionPlatform { this: Iso.AutoDerived.type =>
+
+  /** Provides [[io.scalaland.chimney.Iso.AutoDerived]] derived with the default settings.
+    *
+    * This instance WILL NOT be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.auto#deriveAutomaticPartialTransformer]].
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    * @return
+    *   [[io.scalaland.chimney.Iso.AutoDerived]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit inline def deriveAutomatic[From, To]: Iso.AutoDerived[From, To] =
+    ${ IsoMacros.deriveIsoWithDefaults[From, To] }
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/PartialTransformerCompanionPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/PartialTransformerCompanionPlatform.scala
@@ -2,7 +2,10 @@ package io.scalaland.chimney
 
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 
-private[chimney] trait PartialTransformerCompanionPlatform { this: PartialTransformer.type =>
+import scala.annotation.targetName
+
+private[chimney] trait PartialTransformerCompanionPlatform extends PartialTransformerLowPriorityImplicits1 {
+  this: PartialTransformer.type =>
 
   /** Provides [[io.scalaland.chimney.PartialTransformer]] derived with the default settings.
     *
@@ -37,6 +40,7 @@ private[chimney] trait PartialTransformerAutoDerivedCompanionPlatform { this: Pa
     *
     * @since 0.8.0
     */
-  implicit inline def derive[From, To]: PartialTransformer.AutoDerived[From, To] =
+  @targetName("derive") // all methods were suppose to be named deriveAutomatic, but this one slipped through
+  implicit inline def deriveAutomatic[From, To]: PartialTransformer.AutoDerived[From, To] =
     ${ TransformerMacros.derivePartialTransformerWithDefaults[From, To] }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/TransformerCompanionPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/TransformerCompanionPlatform.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney
 
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 
-private[chimney] trait TransformerCompanionPlatform { this: Transformer.type =>
+private[chimney] trait TransformerCompanionPlatform extends TransformerLowPriorityImplicits1 { this: Transformer.type =>
 
   /** Provides [[io.scalaland.chimney.Transformer]] derived with the default settings.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
@@ -45,6 +45,46 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
   implicit inline def deriveAutomaticPartialTransformer[From, To]: PartialTransformer[From, To] =
     ${ TransformerMacros.derivePartialTransformerWithDefaults[From, To] }
 
+  /** Provides [[io.scalaland.chimney.Codec]] derived with the default settings.
+    *
+    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.Codec.AutoDerived#deriveAutomatic]].
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    * @return
+    *   [[io.scalaland.chimney.Codec]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit def deriveAutomaticCodec[Domain, Dto](implicit
+      encode: Transformer[Domain, Dto],
+      decode: PartialTransformer[Dto, Domain]
+  ): Codec[Domain, Dto] =
+    Codec.derive[Domain, Dto]
+
+  /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
+    *
+    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
+    * differs from [[io.scalaland.chimney.Iso.AutoDerived#deriveAutomatic]].
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    * @return
+    *   [[io.scalaland.chimney.Iso]] type class instance
+    *
+    * @since 1.2.0
+    */
+  implicit def deriveAutomaticIso[From, To](implicit
+      from: Transformer[From, To],
+      to: Transformer[To, From]
+  ): Iso[From, To] =
+    Iso.derive[From, To]
+
   /** Provides [[io.scalaland.chimney.Patcher]] derived with the default settings.
     *
     * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it

--- a/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
@@ -1,7 +1,5 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
-import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
 import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacros
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
@@ -47,40 +47,6 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
   implicit inline def deriveAutomaticPartialTransformer[From, To]: PartialTransformer[From, To] =
     ${ TransformerMacros.derivePartialTransformerWithDefaults[From, To] }
 
-  /** Provides [[io.scalaland.chimney.Codec]] derived with the default settings.
-    *
-    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.Codec.AutoDerived#deriveAutomatic]].
-    *
-    * @tparam Domain
-    *   type of domain value
-    * @tparam Dto
-    *   type of DTO value
-    * @return
-    *   [[io.scalaland.chimney.Codec]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit inline def deriveAutomaticCodec[Domain, Dto]: Codec[Domain, Dto] =
-    ${ CodecMacros.deriveCodecWithDefaults[Domain, Dto] }
-
-  /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
-    *
-    * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it
-    * differs from [[io.scalaland.chimney.Iso.AutoDerived#deriveAutomatic]].
-    *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
-    * @return
-    *   [[io.scalaland.chimney.Iso]] type class instance
-    *
-    * @since 1.2.0
-    */
-  implicit inline def deriveAutomaticIso[From, To]: Iso[From, To] =
-    ${ IsoMacros.deriveIsoWithDefaults[From, To] }
-
   /** Provides [[io.scalaland.chimney.Patcher]] derived with the default settings.
     *
     * This instance WILL be visible for recursive derivation (automatic, semiautomatic, inlined), which is how it

--- a/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/auto.scala
@@ -1,5 +1,7 @@
 package io.scalaland.chimney
 
+import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
+import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
 import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacros
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 
@@ -59,11 +61,8 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
     *
     * @since 1.2.0
     */
-  implicit def deriveAutomaticCodec[Domain, Dto](implicit
-      encode: Transformer[Domain, Dto],
-      decode: PartialTransformer[Dto, Domain]
-  ): Codec[Domain, Dto] =
-    Codec.derive[Domain, Dto]
+  implicit inline def deriveAutomaticCodec[Domain, Dto]: Codec[Domain, Dto] =
+    ${ CodecMacros.deriveCodecWithDefaults[Domain, Dto] }
 
   /** Provides [[io.scalaland.chimney.Iso]] derived with the default settings.
     *
@@ -79,11 +78,8 @@ private[chimney] trait LowPriorityAutoInstances { this: auto.type =>
     *
     * @since 1.2.0
     */
-  implicit def deriveAutomaticIso[From, To](implicit
-      from: Transformer[From, To],
-      to: Transformer[To, From]
-  ): Iso[From, To] =
-    Iso.derive[From, To]
+  implicit inline def deriveAutomaticIso[From, To]: Iso[From, To] =
+    ${ IsoMacros.deriveIsoWithDefaults[From, To] }
 
   /** Provides [[io.scalaland.chimney.Patcher]] derived with the default settings.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -1,0 +1,26 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.Codec
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
+final class CodecDefinition[
+    Domain,
+    Dto,
+    EncodeOverrides <: TransformerOverrides,
+    DecodeOverrides <: TransformerOverrides,
+    Flags <: TransformerFlags
+](
+    val encode: TransformerDefinition[Domain, Dto, EncodeOverrides, Flags],
+    val decode: PartialTransformerDefinition[Dto, Domain, DecodeOverrides, Flags]
+) extends TransformerFlagsDsl[
+      [Flags1 <: TransformerFlags] =>> CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags1],
+      Flags
+    ] {
+
+  // TODO: def withFieldRenamed
+
+  inline def buildCodec[ImplicitScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ImplicitScopeFlags]
+  ): Codec[Domain, Dto] = ???
+  // ${ TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]('this) }
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -5,6 +5,21 @@ import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
 import io.scalaland.chimney.internal.compiletime.dsl.CodecDefinitionMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
+/** Allows customization of [[io.scalaland.chimney.Codec]] derivation.
+  *
+  * @tparam Domain
+  *   type of the domain value
+  * @tparam Dto
+  *   typeof the DTO value
+  * @tparam EncodeOverrides
+  *   type-level encoded config
+  * @tparam DecodeOverrides
+  *   type-level encoded config
+  * @tparam Flags
+  *   type-level encoded flags
+  *
+  * @since 1.2.0
+  */
 final class CodecDefinition[
     Domain,
     Dto,
@@ -19,6 +34,27 @@ final class CodecDefinition[
       Flags
     ] {
 
+  /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`
+    *
+    * By default if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
+    *   for more details
+    *
+    * @tparam T
+    *   type of domain field
+    * @tparam U
+    *   type of DTO field
+    * @param selectorDomain
+    *   source field in `Domain`, defined like `_.originalName`
+    * @param selectorDto
+    *   target field in `Dto`, defined like `_.newName`
+    * @return
+    *   [[io.scalaland.chimney.dsl.CodecDefinition]]
+    *
+    * @since 1.2.0
+    */
   transparent inline def withFieldRenamed[T, U](
       inline selectorDomain: Domain => T,
       inline selectorDto: Dto => U

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.Codec
 import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
+import io.scalaland.chimney.internal.compiletime.dsl.CodecDefinitionMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
 final class CodecDefinition[
@@ -18,8 +19,22 @@ final class CodecDefinition[
       Flags
     ] {
 
-  // TODO: def withFieldRenamed
+  transparent inline def withFieldRenamed[T, U](
+      inline selectorDomain: Domain => T,
+      inline selectorDto: Dto => U
+  ): CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    ${ CodecDefinitionMacros.withFieldRenamedImpl('this, 'selectorDomain, 'selectorDto) }
 
+  /** Build Codec using current configuration.
+    *
+    * It runs macro that tries to derive instance of `Codec[Domain, Dto]`. When transformation can't be derived, it
+    * results with compilation error.
+    *
+    * @return
+    *   [[io.scalaland.chimney.Codec]] type class instance
+    *
+    * @since 1.2.0
+    */
   inline def buildCodec[ImplicitScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ImplicitScopeFlags]
   ): Codec[Domain, Dto] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.Codec
+import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
 final class CodecDefinition[
@@ -21,6 +22,8 @@ final class CodecDefinition[
 
   inline def buildCodec[ImplicitScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ImplicitScopeFlags]
-  ): Codec[Domain, Dto] = ???
-  // ${ TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]('this) }
+  ): Codec[Domain, Dto] =
+    ${
+      CodecMacros.deriveCodecWithConfig[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags, ImplicitScopeFlags]('this)
+    }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.Iso
 import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
+import io.scalaland.chimney.internal.compiletime.dsl.IsoDefinitionMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
 final class IsoDefinition[
@@ -18,9 +19,44 @@ final class IsoDefinition[
       Flags
     ] {
 
-  // TODO: def withFieldRenamed
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+    *
+    * By default if `From` is missing field picked by `selectorTo` (or reverse) the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
+    *   for more details
+    *
+    * @tparam T
+    *   type of source field
+    * @tparam U
+    *   type of target field
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.originalName`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.newName`
+    * @return
+    *   [[io.scalaland.chimney.dsl.IsoDefinition]]
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withFieldRenamed[T, U](
+      inline selectorFrom: From => T,
+      inline selectorTo: To => U
+  ): IsoDefinition[From, To, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    ${ IsoDefinitionMacros.withFieldRenamedImpl('this, 'selectorFrom, 'selectorTo) }
 
-  inline def buildCodec[ImplicitScopeFlags <: TransformerFlags](using
+  /** Build Iso using current configuration.
+    *
+    * It runs macro that tries to derive instance of `Iso[From, To]`. When transformation can't be derived, it results
+    * with compilation error.
+    *
+    * @return
+    *   [[io.scalaland.chimney.Iso]] type class instance
+    *
+    * @since 1.2.0
+    */
+  inline def buildIso[ImplicitScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ImplicitScopeFlags]
   ): Iso[From, To] =
     ${ IsoMacros.deriveIsoWithConfig[From, To, FromOverrides, ToOverrides, Flags, ImplicitScopeFlags]('this) }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -30,7 +30,7 @@ final class IsoDefinition[
     val first: TransformerDefinition[First, Second, FirstOverrides, Flags],
     val second: TransformerDefinition[Second, First, SecondOverrides, Flags]
 ) extends TransformerFlagsDsl[
-      [Flags1 <: TransformerFlags] =>> CodecDefinition[First, Second, FirstOverrides, SecondOverrides, Flags1],
+      [Flags1 <: TransformerFlags] =>> IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags1],
       Flags
     ] {
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -1,0 +1,26 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.Iso
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
+final class IsoDefinition[
+    From,
+    To,
+    FromOverrides <: TransformerOverrides,
+    ToOverrides <: TransformerOverrides,
+    Flags <: TransformerFlags
+](
+    val from: TransformerDefinition[From, To, FromOverrides, Flags],
+    val to: TransformerDefinition[To, From, ToOverrides, Flags]
+) extends TransformerFlagsDsl[
+      [Flags1 <: TransformerFlags] =>> CodecDefinition[From, To, FromOverrides, ToOverrides, Flags1],
+      Flags
+    ] {
+
+  // TODO: def withFieldRenamed
+
+  inline def buildCodec[ImplicitScopeFlags <: TransformerFlags](using
+      tc: TransformerConfiguration[ImplicitScopeFlags]
+  ): Iso[From, To] = ???
+  // ${ TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]('this) }
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -1,6 +1,7 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.Iso
+import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
 final class IsoDefinition[
@@ -21,6 +22,6 @@ final class IsoDefinition[
 
   inline def buildCodec[ImplicitScopeFlags <: TransformerFlags](using
       tc: TransformerConfiguration[ImplicitScopeFlags]
-  ): Iso[From, To] = ???
-  // ${ TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]('this) }
+  ): Iso[From, To] =
+    ${ IsoMacros.deriveIsoWithConfig[From, To, FromOverrides, ToOverrides, Flags, ImplicitScopeFlags]('this) }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -13,7 +13,7 @@ object TransformerDefinitionCommons {
   // @static final def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
 }
 
-private[chimney] trait TransformerDefinitionCommons[UpdateTail[_ <: TransformerOverrides]] {
+private[chimney] trait TransformerDefinitionCommons[UpdateOverrides[_ <: TransformerOverrides]] {
 
   import TransformerDefinitionCommons.*
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -1,0 +1,118 @@
+package io.scalaland.chimney.internal.compiletime.derivation.codec
+
+import io.scalaland.chimney.dsl.CodecDefinition
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.{DerivationPlatform, Gateway}
+import io.scalaland.chimney.Codec
+import io.scalaland.chimney.internal.runtime
+
+import scala.quoted.{Expr, Quotes, Type}
+
+final class CodecMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
+
+  import quotes.*, quotes.reflect.*
+
+  def deriveCodecWithDefaults[
+      Domain: Type,
+      Dto: Type
+  ]: Expr[Codec[Domain, Dto]] = suppressWarnings {
+    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+      '{
+        Codec[Domain, Dto](
+          encode = ${
+            deriveTotalTransformer[
+              Domain,
+              Dto,
+              runtime.TransformerOverrides.Empty,
+              runtime.TransformerFlags.Default,
+              ImplicitScopeFlags
+            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+          },
+          decode = ${
+            derivePartialTransformer[
+              Dto,
+              Domain,
+              runtime.TransformerOverrides.Empty,
+              runtime.TransformerFlags.Default,
+              ImplicitScopeFlags
+            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+          }
+        )
+      }
+    }
+  }
+
+  def deriveCodecWithConfig[
+      Domain: Type,
+      Dto: Type,
+      EncodeOverrides <: runtime.TransformerOverrides: Type,
+      DecodeOverrides <: runtime.TransformerOverrides: Type,
+      Flags <: runtime.TransformerFlags: Type,
+      ImplicitScopeFlags <: runtime.TransformerFlags: Type
+  ](
+      cd: Expr[CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags]]
+  ): Expr[Codec[Domain, Dto]] = suppressWarnings {
+    '{
+      Codec[Domain, Dto](
+        encode = ${
+          deriveTotalTransformer[Domain, Dto, EncodeOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
+            ${ cd }.encode.runtimeData
+          })
+        },
+        decode = ${
+          derivePartialTransformer[Dto, Domain, DecodeOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
+            ${ cd }.decode.runtimeData
+          })
+        }
+      )
+    }
+  }
+
+  private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
+      useImplicitScopeFlags: ?<[runtime.TransformerFlags] => Expr[A]
+  ): Expr[A] = {
+    val implicitScopeConfig = scala.quoted.Expr
+      .summon[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]]
+      .getOrElse {
+        // $COVERAGE-OFF$
+        reportError("Can't locate implicit TransformerConfiguration!")
+        // $COVERAGE-ON$
+      }
+    val implicitScopeFlagsType = implicitScopeConfig.asTerm.tpe.widen.typeArgs.head.asType
+      .asInstanceOf[Type[runtime.TransformerFlags]]
+      .as_?<[runtime.TransformerFlags]
+
+    Expr.block(
+      List(Expr.suppressUnused(implicitScopeConfig)),
+      useImplicitScopeFlags(implicitScopeFlagsType)
+    )
+  }
+
+  private def suppressWarnings[A: Type](expr: Expr[A]): Expr[A] = '{
+    @SuppressWarnings(Array("org.wartremover.warts.All", "all"))
+    val result = ${ expr }
+    result
+  }
+}
+
+object CodecMacros {
+
+  final def deriveCodecWithDefaults[
+      Domain: Type,
+      Dto: Type
+  ](using quotes: Quotes): Expr[Codec[Domain, Dto]] =
+    new CodecMacros(quotes).deriveCodecWithDefaults[Domain, Dto]
+
+  final def deriveCodecWithConfig[
+      Domain: Type,
+      Dto: Type,
+      EncodeOverrides <: runtime.TransformerOverrides: Type,
+      DecodeOverrides <: runtime.TransformerOverrides: Type,
+      Flags <: runtime.TransformerFlags: Type,
+      ImplicitScopeFlags <: runtime.TransformerFlags: Type
+  ](
+      cd: Expr[CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags]]
+  )(using quotes: Quotes): Expr[Codec[Domain, Dto]] =
+    new CodecMacros(quotes)
+      .deriveCodecWithConfig[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags, ImplicitScopeFlags](cd)
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -12,26 +12,26 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
   import quotes.*, quotes.reflect.*
 
   def deriveIsoWithDefaults[
-      From: Type,
-      To: Type
-  ]: Expr[Iso[From, To]] = suppressWarnings {
+      First: Type,
+      Second: Type
+  ]: Expr[Iso[First, Second]] = suppressWarnings {
     resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
       import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
       '{
-        Iso[From, To](
-          from = ${
+        Iso[First, Second](
+          first = ${
             deriveTotalTransformer[
-              From,
-              To,
+              First,
+              Second,
               runtime.TransformerOverrides.Empty,
               runtime.TransformerFlags.Default,
               ImplicitScopeFlags
             ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
           },
-          to = ${
+          second = ${
             deriveTotalTransformer[
-              To,
-              From,
+              Second,
+              First,
               runtime.TransformerOverrides.Empty,
               runtime.TransformerFlags.Default,
               ImplicitScopeFlags
@@ -43,25 +43,25 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
   }
 
   def deriveIsoWithConfig[
-      From: Type,
-      To: Type,
-      FromOverrides <: runtime.TransformerOverrides: Type,
-      ToOverrides <: runtime.TransformerOverrides: Type,
+      First: Type,
+      Second: Type,
+      FirstOverrides <: runtime.TransformerOverrides: Type,
+      SecondOverrides <: runtime.TransformerOverrides: Type,
       Flags <: runtime.TransformerFlags: Type,
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
-      id: Expr[IsoDefinition[From, To, FromOverrides, ToOverrides, Flags]]
-  ): Expr[Iso[From, To]] = suppressWarnings {
+      id: Expr[IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags]]
+  ): Expr[Iso[First, Second]] = suppressWarnings {
     '{
-      Iso[From, To](
-        from = ${
-          deriveTotalTransformer[From, To, FromOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
-            ${ id }.from.runtimeData
+      Iso[First, Second](
+        first = ${
+          deriveTotalTransformer[First, Second, FirstOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
+            ${ id }.first.runtimeData
           })
         },
-        to = ${
-          deriveTotalTransformer[To, From, ToOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
-            ${ id }.to.runtimeData
+        second = ${
+          deriveTotalTransformer[Second, First, SecondOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
+            ${ id }.second.runtimeData
           })
         }
       )
@@ -98,20 +98,21 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
 object IsoMacros {
 
   final def deriveIsoWithDefaults[
-      From: Type,
-      To: Type
-  ](using quotes: Quotes): Expr[Iso[From, To]] =
-    new IsoMacros(quotes).deriveIsoWithDefaults[From, To]
+      First: Type,
+      Second: Type
+  ](using quotes: Quotes): Expr[Iso[First, Second]] =
+    new IsoMacros(quotes).deriveIsoWithDefaults[First, Second]
 
   final def deriveIsoWithConfig[
-      From: Type,
-      To: Type,
-      FromOverrides <: runtime.TransformerOverrides: Type,
-      ToOverrides <: runtime.TransformerOverrides: Type,
+      First: Type,
+      Second: Type,
+      FirstOverrides <: runtime.TransformerOverrides: Type,
+      SecondOverrides <: runtime.TransformerOverrides: Type,
       Flags <: runtime.TransformerFlags: Type,
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
-      id: Expr[IsoDefinition[From, To, FromOverrides, ToOverrides, Flags]]
-  )(using quotes: Quotes): Expr[Iso[From, To]] =
-    new IsoMacros(quotes).deriveIsoWithConfig[From, To, FromOverrides, ToOverrides, Flags, ImplicitScopeFlags](id)
+      id: Expr[IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags]]
+  )(using quotes: Quotes): Expr[Iso[First, Second]] =
+    new IsoMacros(quotes)
+      .deriveIsoWithConfig[First, Second, FirstOverrides, SecondOverrides, Flags, ImplicitScopeFlags](id)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -1,0 +1,117 @@
+package io.scalaland.chimney.internal.compiletime.derivation.iso
+
+import io.scalaland.chimney.dsl.IsoDefinition
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.{DerivationPlatform, Gateway}
+import io.scalaland.chimney.Iso
+import io.scalaland.chimney.internal.runtime
+
+import scala.quoted.{Expr, Quotes, Type}
+
+final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
+
+  import quotes.*, quotes.reflect.*
+
+  def deriveIsoWithDefaults[
+      From: Type,
+      To: Type
+  ]: Expr[Iso[From, To]] = suppressWarnings {
+    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+      '{
+        Iso[From, To](
+          from = ${
+            deriveTotalTransformer[
+              From,
+              To,
+              runtime.TransformerOverrides.Empty,
+              runtime.TransformerFlags.Default,
+              ImplicitScopeFlags
+            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+          },
+          to = ${
+            deriveTotalTransformer[
+              To,
+              From,
+              runtime.TransformerOverrides.Empty,
+              runtime.TransformerFlags.Default,
+              ImplicitScopeFlags
+            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+          }
+        )
+      }
+    }
+  }
+
+  def deriveIsoWithConfig[
+      From: Type,
+      To: Type,
+      FromOverrides <: runtime.TransformerOverrides: Type,
+      ToOverrides <: runtime.TransformerOverrides: Type,
+      Flags <: runtime.TransformerFlags: Type,
+      ImplicitScopeFlags <: runtime.TransformerFlags: Type
+  ](
+      id: Expr[IsoDefinition[From, To, FromOverrides, ToOverrides, Flags]]
+  ): Expr[Iso[From, To]] = suppressWarnings {
+    '{
+      Iso[From, To](
+        from = ${
+          deriveTotalTransformer[From, To, FromOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
+            ${ id }.from.runtimeData
+          })
+        },
+        to = ${
+          deriveTotalTransformer[To, From, ToOverrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
+            ${ id }.to.runtimeData
+          })
+        }
+      )
+    }
+  }
+
+  private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
+      useImplicitScopeFlags: ?<[runtime.TransformerFlags] => Expr[A]
+  ): Expr[A] = {
+    val implicitScopeConfig = scala.quoted.Expr
+      .summon[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]]
+      .getOrElse {
+        // $COVERAGE-OFF$
+        reportError("Can't locate implicit TransformerConfiguration!")
+        // $COVERAGE-ON$
+      }
+    val implicitScopeFlagsType = implicitScopeConfig.asTerm.tpe.widen.typeArgs.head.asType
+      .asInstanceOf[Type[runtime.TransformerFlags]]
+      .as_?<[runtime.TransformerFlags]
+
+    Expr.block(
+      List(Expr.suppressUnused(implicitScopeConfig)),
+      useImplicitScopeFlags(implicitScopeFlagsType)
+    )
+  }
+
+  private def suppressWarnings[A: Type](expr: Expr[A]): Expr[A] = '{
+    @SuppressWarnings(Array("org.wartremover.warts.All", "all"))
+    val result = ${ expr }
+    result
+  }
+}
+
+object IsoMacros {
+
+  final def deriveIsoWithDefaults[
+      From: Type,
+      To: Type
+  ](using quotes: Quotes): Expr[Iso[From, To]] =
+    new IsoMacros(quotes).deriveIsoWithDefaults[From, To]
+
+  final def deriveIsoWithConfig[
+      From: Type,
+      To: Type,
+      FromOverrides <: runtime.TransformerOverrides: Type,
+      ToOverrides <: runtime.TransformerOverrides: Type,
+      Flags <: runtime.TransformerFlags: Type,
+      ImplicitScopeFlags <: runtime.TransformerFlags: Type
+  ](
+      id: Expr[IsoDefinition[From, To, FromOverrides, ToOverrides, Flags]]
+  )(using quotes: Quotes): Expr[Iso[From, To]] =
+    new IsoMacros(quotes).deriveIsoWithConfig[From, To, FromOverrides, ToOverrides, Flags, ImplicitScopeFlags](id)
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -2,11 +2,10 @@ package io.scalaland.chimney.internal.compiletime.derivation.transformer
 
 import io.scalaland.chimney.dsl.{PartialTransformerDefinition, TransformerDefinition}
 import io.scalaland.chimney.{PartialTransformer, Transformer}
-import io.scalaland.chimney.internal.compiletime.DefinitionsPlatform
 import io.scalaland.chimney.internal.runtime
 import io.scalaland.chimney.partial
 
-import scala.quoted.{Expr, Quotes, Type, Varargs}
+import scala.quoted.{Expr, Quotes, Type}
 
 final class TransformerMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -10,30 +10,30 @@ import scala.quoted.*
 object IsoDefinitionMacros {
 
   def withFieldRenamedImpl[
-      From: Type,
-      To: Type,
-      FromOverrides <: TransformerOverrides: Type,
-      ToOverrides <: TransformerOverrides: Type,
+      First: Type,
+      Second: Type,
+      FirstOverrides <: TransformerOverrides: Type,
+      SecondOverrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
       T: Type,
       U: Type
   ](
-      id: Expr[IsoDefinition[From, To, FromOverrides, ToOverrides, Flags]],
-      selectorFrom: Expr[From => T],
-      selectorTo: Expr[To => U]
-  )(using Quotes): Expr[IsoDefinition[From, To, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags]] =
+      id: Expr[IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags]],
+      selectorFirst: Expr[First => T],
+      selectorSecond: Expr[Second => U]
+  )(using Quotes): Expr[IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyFieldNameTypes {
-      [fromPath <: Path, toPath <: Path] =>
-        (_: Type[fromPath]) ?=>
-          (_: Type[toPath]) ?=>
+      [firstPath <: Path, secondPath <: Path] =>
+        (_: Type[firstPath]) ?=>
+          (_: Type[secondPath]) ?=>
             '{
               $id.asInstanceOf[IsoDefinition[
-                From,
-                To,
-                RenamedFrom[fromPath, toPath, FromOverrides],
-                RenamedFrom[toPath, fromPath, ToOverrides],
+                First,
+                Second,
+                RenamedFrom[firstPath, secondPath, FirstOverrides],
+                RenamedFrom[secondPath, firstPath, SecondOverrides],
                 Flags
               ]]
           }
-    }(selectorFrom, selectorTo)
+    }(selectorFirst, selectorSecond)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -1,0 +1,39 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.quoted.*
+
+object IsoDefinitionMacros {
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      FromOverrides <: TransformerOverrides: Type,
+      ToOverrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      id: Expr[IsoDefinition[From, To, FromOverrides, ToOverrides, Flags]],
+      selectorFrom: Expr[From => T],
+      selectorTo: Expr[To => U]
+  )(using Quotes): Expr[IsoDefinition[From, To, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] =>
+        (_: Type[fromPath]) ?=>
+          (_: Type[toPath]) ?=>
+            '{
+              $id.asInstanceOf[IsoDefinition[
+                From,
+                To,
+                RenamedFrom[fromPath, toPath, FromOverrides],
+                RenamedFrom[toPath, fromPath, ToOverrides],
+                Flags
+              ]]
+          }
+    }(selectorFrom, selectorTo)
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -1,8 +1,6 @@
 package io.scalaland.chimney.internal.compiletime.dsl
 
-import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl.*
-import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
 import io.scalaland.chimney.internal.runtime.{
   ArgumentLists,

--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -3,17 +3,74 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.CodecDefinition
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
+/** Type class representing bidirectional conversion from the type that can be always converted (total transformation),
+  * usually the domain model, into type that has to be validated when converting back (partial transformation), usually
+  * the DTO model.
+  *
+  * @see
+  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *
+  * @tparam Domain
+  *   type of the domain value
+  * @tparam Dto
+  *   typeof the DTO value
+  * @param encode
+  *   conversion from domain model to DTO which is guaranteed to succeed
+  * @param decode
+  *   conversion from DTO to domain model which can fail
+  *
+  * @since 1.2.0
+  */
 final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: PartialTransformer[Dto, Domain])
     extends Codec.AutoDerived[Domain, Dto]
+
+/** Companion of [[io.scalaland.chimney.Codec]].
+  *
+  * @see
+  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *
+  * @since 1.2.0
+  */
 object Codec extends CodecCompanionPlatform {
 
+  /** Creates an empty [[io.scalaland.chimney.dsl.CodecDefinition]] that you can customize to derive
+    * [[io.scalaland.chimney.Codec]].
+    *
+    * @see
+    *   [[io.scalaland.chimney.dsl.CodecDefinition]] for available settings
+    *
+    * @tparam Domain
+    *   type of the domain value
+    * @tparam Dto
+    *   typeof the DTO value
+    *
+    * @return
+    *   [[io.scalaland.chimney.dsl.CodecDefinition]] with defaults
+    */
   def define[Domain, Dto]
       : CodecDefinition[Domain, Dto, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
     new CodecDefinition(Transformer.define, PartialTransformer.define)
 
+  /** Type class used when you want o allow using automatically derived transformations.
+    *
+    * When we want to only allow semiautomatically derived/manually defined instances you should use
+    * [[io.scalaland.chimney.Codec]].
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/cookbook/#automatic-semiautomatic-and-inlined-derivation]] for more details
+    *
+    * @tparam Domain
+    *   type of the domain value
+    * @tparam Dto
+    *   typeof the DTO value
+    *
+    * @since 1.2.0
+    */
   trait AutoDerived[Domain, Dto] {
     val encode: Transformer[Domain, Dto]
     val decode: PartialTransformer[Dto, Domain]
   }
+
+  /** @since 1.2.0 */
   object AutoDerived extends CodecAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -1,44 +1,19 @@
 package io.scalaland.chimney
 
-import io.scalaland.chimney.dsl.{CodecDefinition, TransformerDefinition}
+import io.scalaland.chimney.dsl.CodecDefinition
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
 final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: PartialTransformer[Dto, Domain])
     extends Codec.AutoDerived[Domain, Dto]
-object Codec {
-
-  def derive[Domain, Dto](implicit
-      encode: Transformer.AutoDerived[Domain, Dto],
-      decode: PartialTransformer.AutoDerived[Dto, Domain]
-  ): Codec[Domain, Dto] = Codec[Domain, Dto](encode = safeUpcast[Domain, Dto], decode = safeUpcastPartial[Dto, Domain])
+object Codec extends CodecCompanionPlatform {
 
   def define[Domain, Dto]
       : CodecDefinition[Domain, Dto, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
     new CodecDefinition(Transformer.define, PartialTransformer.define)
 
-  private def safeUpcast[From, To](implicit t: Transformer.AutoDerived[From, To]): Transformer[From, To] =
-    t match {
-      case _: Transformer[?, ?] => t.asInstanceOf[Transformer[From, To]]
-      case _                    => (src: From) => t.transform(src)
-    }
-
-  private def safeUpcastPartial[From, To](implicit
-      t: PartialTransformer.AutoDerived[From, To]
-  ): PartialTransformer[From, To] =
-    t match {
-      case _: PartialTransformer[?, ?] => t.asInstanceOf[PartialTransformer[From, To]]
-      case _                           => (src: From, failFast: Boolean) => t.transform(src, failFast)
-    }
-
   trait AutoDerived[Domain, Dto] {
     val encode: Transformer[Domain, Dto]
     val decode: PartialTransformer[Dto, Domain]
   }
-  object AutoDerived {
-
-    implicit def deriveAutomatic[Domain, Dto](implicit
-        encode: Transformer.AutoDerived[Domain, Dto],
-        decode: PartialTransformer.AutoDerived[Dto, Domain]
-    ): Codec.AutoDerived[Domain, Dto] = Codec.derive(encode, decode)
-  }
+  object AutoDerived extends CodecAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -22,7 +22,6 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
   * @since 1.2.0
   */
 final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: PartialTransformer[Dto, Domain])
-    extends Codec.AutoDerived[Domain, Dto]
 
 /** Companion of [[io.scalaland.chimney.Codec]].
   *
@@ -50,27 +49,4 @@ object Codec extends CodecCompanionPlatform {
   def define[Domain, Dto]
       : CodecDefinition[Domain, Dto, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
     new CodecDefinition(Transformer.define, PartialTransformer.define)
-
-  /** Type class used when you want o allow using automatically derived transformations.
-    *
-    * When we want to only allow semiautomatically derived/manually defined instances you should use
-    * [[io.scalaland.chimney.Codec]].
-    *
-    * @see
-    *   [[https://chimney.readthedocs.io/cookbook/#automatic-semiautomatic-and-inlined-derivation]] for more details
-    *
-    * @tparam Domain
-    *   type of the domain value
-    * @tparam Dto
-    *   typeof the DTO value
-    *
-    * @since 1.2.0
-    */
-  trait AutoDerived[Domain, Dto] {
-    val encode: Transformer[Domain, Dto]
-    val decode: PartialTransformer[Dto, Domain]
-  }
-
-  /** @since 1.2.0 */
-  object AutoDerived extends CodecAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -8,7 +8,7 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
   * the DTO model.
   *
   * @see
-  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *   [[https://chimney.readthedocs.io/cookbook/#bidirectional-transformations]]
   *
   * @tparam Domain
   *   type of the domain value
@@ -26,7 +26,7 @@ final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: Pa
 /** Companion of [[io.scalaland.chimney.Codec]].
   *
   * @see
-  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *   [[https://chimney.readthedocs.io/cookbook/#bidirectional-transformations]]
   *
   * @since 1.2.0
   */

--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -31,7 +31,7 @@ object Codec {
   }
   object AutoDerived {
 
-    implicit def derive[Domain, Dto](implicit
+    implicit def deriveAutomatic[Domain, Dto](implicit
         encode: Transformer.AutoDerived[Domain, Dto],
         decode: PartialTransformer.AutoDerived[Dto, Domain]
     ): Codec.AutoDerived[Domain, Dto] = Codec.derive(encode, decode)

--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -1,5 +1,8 @@
 package io.scalaland.chimney
 
+import io.scalaland.chimney.dsl.{CodecDefinition, TransformerDefinition}
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
 final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: PartialTransformer[Dto, Domain])
     extends Codec.AutoDerived[Domain, Dto]
 object Codec {
@@ -9,7 +12,9 @@ object Codec {
       decode: PartialTransformer.AutoDerived[Dto, Domain]
   ): Codec[Domain, Dto] = Codec[Domain, Dto](encode = safeUpcast[Domain, Dto], decode = safeUpcastPartial[Dto, Domain])
 
-  // TODO: define
+  def define[Domain, Dto]
+      : CodecDefinition[Domain, Dto, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
+    new CodecDefinition(Transformer.define, PartialTransformer.define)
 
   private def safeUpcast[From, To](implicit t: Transformer.AutoDerived[From, To]): Transformer[From, To] =
     t match {

--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -1,0 +1,39 @@
+package io.scalaland.chimney
+
+final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: PartialTransformer[Dto, Domain])
+    extends Codec.AutoDerived[Domain, Dto]
+object Codec {
+
+  def derive[Domain, Dto](implicit
+      encode: Transformer.AutoDerived[Domain, Dto],
+      decode: PartialTransformer.AutoDerived[Dto, Domain]
+  ): Codec[Domain, Dto] = Codec[Domain, Dto](encode = safeUpcast[Domain, Dto], decode = safeUpcastPartial[Dto, Domain])
+
+  // TODO: define
+
+  private def safeUpcast[From, To](implicit t: Transformer.AutoDerived[From, To]): Transformer[From, To] =
+    t match {
+      case _: Transformer[?, ?] => t.asInstanceOf[Transformer[From, To]]
+      case _                    => (src: From) => t.transform(src)
+    }
+
+  private def safeUpcastPartial[From, To](implicit
+      t: PartialTransformer.AutoDerived[From, To]
+  ): PartialTransformer[From, To] =
+    t match {
+      case _: PartialTransformer[?, ?] => t.asInstanceOf[PartialTransformer[From, To]]
+      case _                           => (src: From, failFast: Boolean) => t.transform(src, failFast)
+    }
+
+  trait AutoDerived[Domain, Dto] {
+    val encode: Transformer[Domain, Dto]
+    val decode: PartialTransformer[Dto, Domain]
+  }
+  object AutoDerived {
+
+    implicit def derive[Domain, Dto](implicit
+        encode: Transformer.AutoDerived[Domain, Dto],
+        decode: PartialTransformer.AutoDerived[Dto, Domain]
+    ): Codec.AutoDerived[Domain, Dto] = Codec.derive(encode, decode)
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -4,32 +4,15 @@ import io.scalaland.chimney.dsl.IsoDefinition
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
 final case class Iso[From, To](from: Transformer[From, To], to: Transformer[To, From]) extends Iso.AutoDerived[From, To]
-object Iso {
-
-  def derive[From, To](implicit
-      from: Transformer.AutoDerived[From, To],
-      to: Transformer.AutoDerived[To, From]
-  ): Iso[From, To] = Iso[From, To](from = safeUpcast[From, To], to = safeUpcast[To, From])
+object Iso extends IsoCompanionPlatform {
 
   def define[From, To]
       : IsoDefinition[From, To, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
     new IsoDefinition(Transformer.define, Transformer.define)
 
-  private def safeUpcast[From, To](implicit t: Transformer.AutoDerived[From, To]): Transformer[From, To] =
-    t match {
-      case _: Transformer[?, ?] => t.asInstanceOf[Transformer[From, To]]
-      case _                    => (src: From) => t.transform(src)
-    }
-
   trait AutoDerived[From, To] {
     val from: Transformer[From, To]
     val to: Transformer[To, From]
   }
-  object AutoDerived {
-
-    implicit def deriveAutomatic[From, To](implicit
-        from: Transformer.AutoDerived[From, To],
-        to: Transformer.AutoDerived[To, From]
-    ): Iso.AutoDerived[From, To] = Iso.derive(from, to)
-  }
+  object AutoDerived extends IsoAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -1,5 +1,8 @@
 package io.scalaland.chimney
 
+import io.scalaland.chimney.dsl.IsoDefinition
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+
 final case class Iso[From, To](from: Transformer[From, To], to: Transformer[To, From]) extends Iso.AutoDerived[From, To]
 object Iso {
 
@@ -8,7 +11,9 @@ object Iso {
       to: Transformer.AutoDerived[To, From]
   ): Iso[From, To] = Iso[From, To](from = safeUpcast[From, To], to = safeUpcast[To, From])
 
-  // TODO: define
+  def define[From, To]
+      : IsoDefinition[From, To, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
+    new IsoDefinition(Transformer.define, Transformer.define)
 
   private def safeUpcast[From, To](implicit t: Transformer.AutoDerived[From, To]): Transformer[From, To] =
     t match {

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -3,16 +3,72 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.IsoDefinition
 import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
 
+/** Type class representing bidirectional conversion between isomorphic types, where conversion in each can always
+  * succeed (total transformation).
+  *
+  * @see
+  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *
+  * @tparam From
+  *   input type of the first conversion, output type of the second conversion
+  * @tparam To
+  *   output type of the first conversion, input type of the second conversion
+  * @param from
+  *   conversion from the first type into the second type
+  * @param to
+  *   conversion from the second type into the first type
+  *
+  * @since 1.2.0
+  */
 final case class Iso[From, To](from: Transformer[From, To], to: Transformer[To, From]) extends Iso.AutoDerived[From, To]
+
+/** Companion of [[io.scalaland.chimney.Iso]].
+  *
+  * @see
+  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *
+  * @since 1.2.0
+  */
 object Iso extends IsoCompanionPlatform {
 
+  /** Creates an empty [[io.scalaland.chimney.dsl.IsoDefinition]] that you can customize to derive
+    * [[io.scalaland.chimney.Iso]].
+    *
+    * @see
+    *   [[io.scalaland.chimney.dsl.IsoDefinition]] for available settings
+    *
+    * @tparam From
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam To
+    *   output type of the first conversion, input type of the second conversion
+    *
+    * @return
+    *   [[io.scalaland.chimney.dsl.IsoDefinition]] with defaults
+    */
   def define[From, To]
       : IsoDefinition[From, To, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
     new IsoDefinition(Transformer.define, Transformer.define)
 
+  /** Type class used when you want o allow using automatically derived transformations.
+    *
+    * When we want to only allow semiautomatically derived/manually defined instances you should use
+    * [[io.scalaland.chimney.Iso]].
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/cookbook/#automatic-semiautomatic-and-inlined-derivation]] for more details
+    *
+    * @tparam From
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam To
+    *   output type of the first conversion, input type of the second conversion
+    *
+    * @since 1.2.0
+    */
   trait AutoDerived[From, To] {
     val from: Transformer[From, To]
     val to: Transformer[To, From]
   }
+
+  /** @since 1.2.0 */
   object AutoDerived extends IsoAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -1,0 +1,30 @@
+package io.scalaland.chimney
+
+final case class Iso[From, To](from: Transformer[From, To], to: Transformer[To, From]) extends Iso.AutoDerived[From, To]
+object Iso {
+
+  def derive[From, To](implicit
+      from: Transformer.AutoDerived[From, To],
+      to: Transformer.AutoDerived[To, From]
+  ): Iso[From, To] = Iso[From, To](from = safeUpcast[From, To], to = safeUpcast[To, From])
+
+  // TODO: define
+
+  private def safeUpcast[From, To](implicit t: Transformer.AutoDerived[From, To]): Transformer[From, To] =
+    t match {
+      case _: Transformer[?, ?] => t.asInstanceOf[Transformer[From, To]]
+      case _                    => (src: From) => t.transform(src)
+    }
+
+  trait AutoDerived[From, To] {
+    val from: Transformer[From, To]
+    val to: Transformer[To, From]
+  }
+  object AutoDerived {
+    
+    implicit def derive[From, To](implicit
+        from: Transformer.AutoDerived[From, To],
+        to: Transformer.AutoDerived[To, From]
+    ): Iso.AutoDerived[From, To] = Iso.derive(from, to)
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -21,7 +21,6 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
   * @since 1.2.0
   */
 final case class Iso[First, Second](first: Transformer[First, Second], second: Transformer[Second, First])
-    extends Iso.AutoDerived[First, Second]
 
 /** Companion of [[io.scalaland.chimney.Iso]].
   *
@@ -49,27 +48,4 @@ object Iso extends IsoCompanionPlatform {
   def define[First, Second]
       : IsoDefinition[First, Second, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
     new IsoDefinition(Transformer.define, Transformer.define)
-
-  /** Type class used when you want o allow using automatically derived transformations.
-    *
-    * When we want to only allow semiautomatically derived/manually defined instances you should use
-    * [[io.scalaland.chimney.Iso]].
-    *
-    * @see
-    *   [[https://chimney.readthedocs.io/cookbook/#automatic-semiautomatic-and-inlined-derivation]] for more details
-    *
-    * @tparam First
-    *   input type of the first conversion, output type of the second conversion
-    * @tparam Second
-    *   output type of the first conversion, input type of the second conversion
-    *
-    * @since 1.2.0
-    */
-  trait AutoDerived[First, Second] {
-    val first: Transformer[First, Second]
-    val second: Transformer[Second, First]
-  }
-
-  /** @since 1.2.0 */
-  object AutoDerived extends IsoAutoDerivedCompanionPlatform
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -21,8 +21,8 @@ object Iso {
     val to: Transformer[To, From]
   }
   object AutoDerived {
-    
-    implicit def derive[From, To](implicit
+
+    implicit def deriveAutomatic[From, To](implicit
         from: Transformer.AutoDerived[From, To],
         to: Transformer.AutoDerived[To, From]
     ): Iso.AutoDerived[From, To] = Iso.derive(from, to)

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -9,18 +9,19 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
   * @see
   *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
   *
-  * @tparam From
+  * @tparam First
   *   input type of the first conversion, output type of the second conversion
-  * @tparam To
+  * @tparam Second
   *   output type of the first conversion, input type of the second conversion
-  * @param from
-  *   conversion from the first type into the second type
-  * @param to
-  *   conversion from the second type into the first type
+  * @param first
+  *   conversion the first type into the second type
+  * @param second
+  *   conversion the second type into the first type
   *
   * @since 1.2.0
   */
-final case class Iso[From, To](from: Transformer[From, To], to: Transformer[To, From]) extends Iso.AutoDerived[From, To]
+final case class Iso[First, Second](first: Transformer[First, Second], second: Transformer[Second, First])
+    extends Iso.AutoDerived[First, Second]
 
 /** Companion of [[io.scalaland.chimney.Iso]].
   *
@@ -37,16 +38,16 @@ object Iso extends IsoCompanionPlatform {
     * @see
     *   [[io.scalaland.chimney.dsl.IsoDefinition]] for available settings
     *
-    * @tparam From
+    * @tparam First
     *   input type of the first conversion, output type of the second conversion
-    * @tparam To
+    * @tparam Second
     *   output type of the first conversion, input type of the second conversion
     *
     * @return
     *   [[io.scalaland.chimney.dsl.IsoDefinition]] with defaults
     */
-  def define[From, To]
-      : IsoDefinition[From, To, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
+  def define[First, Second]
+      : IsoDefinition[First, Second, TransformerOverrides.Empty, TransformerOverrides.Empty, TransformerFlags.Default] =
     new IsoDefinition(Transformer.define, Transformer.define)
 
   /** Type class used when you want o allow using automatically derived transformations.
@@ -57,16 +58,16 @@ object Iso extends IsoCompanionPlatform {
     * @see
     *   [[https://chimney.readthedocs.io/cookbook/#automatic-semiautomatic-and-inlined-derivation]] for more details
     *
-    * @tparam From
+    * @tparam First
     *   input type of the first conversion, output type of the second conversion
-    * @tparam To
+    * @tparam Second
     *   output type of the first conversion, input type of the second conversion
     *
     * @since 1.2.0
     */
-  trait AutoDerived[From, To] {
-    val from: Transformer[From, To]
-    val to: Transformer[To, From]
+  trait AutoDerived[First, Second] {
+    val first: Transformer[First, Second]
+    val second: Transformer[Second, First]
   }
 
   /** @since 1.2.0 */

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -7,7 +7,7 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
   * succeed (total transformation).
   *
   * @see
-  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *   [[https://chimney.readthedocs.io/cookbook/#bidirectional-transformations]]
   *
   * @tparam First
   *   input type of the first conversion, output type of the second conversion
@@ -25,7 +25,7 @@ final case class Iso[First, Second](first: Transformer[First, Second], second: T
 /** Companion of [[io.scalaland.chimney.Iso]].
   *
   * @see
-  *   [[https://chimney.readthedocs.io/supported-transformations/TODO]]
+  *   [[https://chimney.readthedocs.io/cookbook/#bidirectional-transformations]]
   *
   * @since 1.2.0
   */

--- a/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
@@ -186,7 +186,7 @@ private[chimney] trait PartialTransformerLowPriorityImplicits1 { this: PartialTr
     *
     * @since 1.2.0
     */
-  implicit def transformerFromCodecDecoder[Dto, Domain](implicit
+  implicit def partialTransformerFromCodecDecoder[Dto, Domain](implicit
       codec: Codec[Domain, Dto]
   ): PartialTransformer[Dto, Domain] =
     codec.decode

--- a/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
@@ -174,3 +174,20 @@ object PartialTransformer extends PartialTransformerCompanionPlatform {
       (src: From, failFast: Boolean) => partial.Result.fromCatching(total.transform(src))
   }
 }
+// extended by PartialTransformerCompanionPlatform
+private[chimney] trait PartialTransformerLowPriorityImplicits1 { this: PartialTransformer.type =>
+
+  /** Extracts [[io.scalaland.chimney.PartialTransformer]] from existing [[io.scalaland.chimney.Codec#decode]].
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    *
+    * @since 1.2.0
+    */
+  implicit def transformerFromCodecDecoder[Dto, Domain](implicit
+      codec: Codec[Domain, Dto]
+  ): PartialTransformer[Dto, Domain] =
+    codec.decode
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -103,3 +103,46 @@ object Transformer extends TransformerCompanionPlatform {
   /** @since 0.8.0 */
   object AutoDerived extends TransformerAutoDerivedCompanionPlatform
 }
+// extended by TransformerCompanionPlatform
+private[chimney] trait TransformerLowPriorityImplicits1 extends TransformerLowPriorityImplicits2 {
+  this: Transformer.type =>
+
+  /** Extracts [[io.scalaland.chimney.Transformer]] from existing [[io.scalaland.chimney.Iso#from]].
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    *
+    * @since 1.2.0
+    */
+  implicit def transformerFromIsoFrom[From, To](implicit iso: Iso[From, To]): Transformer[From, To] = iso.from
+}
+private[chimney] trait TransformerLowPriorityImplicits2 extends TransformerLowPriorityImplicits3 {
+  this: Transformer.type =>
+
+  /** Extracts [[io.scalaland.chimney.Transformer]] from existing [[io.scalaland.chimney.Iso#to]].
+    *
+    * @tparam From
+    *   type of input value
+    * @tparam To
+    *   type of output value
+    *
+    * @since 1.2.0
+    */
+  implicit def transformerFromIsoTo[From, To](implicit iso: Iso[To, From]): Transformer[From, To] = iso.to
+}
+private[chimney] trait TransformerLowPriorityImplicits3 { this: Transformer.type =>
+
+  /** Extracts [[io.scalaland.chimney.Transformer]] from existing [[io.scalaland.chimney.Codec#encode]].
+    *
+    * @tparam Domain
+    *   type of domain value
+    * @tparam Dto
+    *   type of DTO value
+    *
+    * @since 1.2.0
+    */
+  implicit def transformerFromCodecEncoder[Domain, Dto](implicit codec: Codec[Domain, Dto]): Transformer[Domain, Dto] =
+    codec.encode
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -107,30 +107,32 @@ object Transformer extends TransformerCompanionPlatform {
 private[chimney] trait TransformerLowPriorityImplicits1 extends TransformerLowPriorityImplicits2 {
   this: Transformer.type =>
 
-  /** Extracts [[io.scalaland.chimney.Transformer]] from existing [[io.scalaland.chimney.Iso#from]].
+  /** Extracts [[io.scalaland.chimney.Transformer]] from existing [[io.scalaland.chimney.Iso#left]].
     *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
+    * @tparam First
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam Second
+    *   output type of the first conversion, input type of the second conversion
     *
     * @since 1.2.0
     */
-  implicit def transformerFromIsoFrom[From, To](implicit iso: Iso[From, To]): Transformer[From, To] = iso.from
+  implicit def transformerFromIsoFirst[First, Second](implicit iso: Iso[First, Second]): Transformer[First, Second] =
+    iso.first
 }
 private[chimney] trait TransformerLowPriorityImplicits2 extends TransformerLowPriorityImplicits3 {
   this: Transformer.type =>
 
-  /** Extracts [[io.scalaland.chimney.Transformer]] from existing [[io.scalaland.chimney.Iso#to]].
+  /** Extracts [[io.scalaland.chimney.Transformer]] from existing [[io.scalaland.chimney.Iso#right]].
     *
-    * @tparam From
-    *   type of input value
-    * @tparam To
-    *   type of output value
+    * @tparam First
+    *   input type of the first conversion, output type of the second conversion
+    * @tparam Second
+    *   output type of the first conversion, input type of the second conversion
     *
     * @since 1.2.0
     */
-  implicit def transformerFromIsoTo[From, To](implicit iso: Iso[To, From]): Transformer[From, To] = iso.to
+  implicit def transformerFromIsoSecond[First, Second](implicit iso: Iso[First, Second]): Transformer[Second, First] =
+    iso.second
 }
 private[chimney] trait TransformerLowPriorityImplicits3 { this: Transformer.type =>
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Gateway.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Gateway.scala
@@ -12,7 +12,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
   final def derivePatcherResult[
       A: Type,
       Patch: Type,
-      Tail <: runtime.PatcherOverrides: Type,
+      Overrides <: runtime.PatcherOverrides: Type,
       Flags <: runtime.PatcherFlags: Type,
       ImplicitScopeFlags <: runtime.PatcherFlags: Type
   ](
@@ -24,7 +24,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
         .create[A, Patch](
           obj,
           patch,
-          config = PatcherConfigurations.readPatcherConfiguration[Tail, Flags, ImplicitScopeFlags]
+          config = PatcherConfigurations.readPatcherConfiguration[Overrides, Flags, ImplicitScopeFlags]
         )
         .updateConfig(_.allowAPatchImplicitSearch)
 
@@ -40,7 +40,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
   final def derivePatcher[
       A: Type,
       Patch: Type,
-      Tail <: runtime.PatcherOverrides: Type,
+      Overrides <: runtime.PatcherOverrides: Type,
       Flags <: runtime.PatcherFlags: Type,
       ImplicitScopeFlags <: runtime.PatcherFlags: Type
   ]: Expr[Patcher[A, Patch]] = {
@@ -49,7 +49,7 @@ private[compiletime] trait Gateway extends GatewayCommons { this: Derivation =>
         val context = PatcherContext.create[A, Patch](
           obj,
           patch,
-          config = PatcherConfigurations.readPatcherConfiguration[Tail, Flags, ImplicitScopeFlags]
+          config = PatcherConfigurations.readPatcherConfiguration[Overrides, Flags, ImplicitScopeFlags]
         )
 
         await(enableLoggingIfFlagEnabled(derivePatcherResultExpr(context), context))

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecImplicitResolutionSpec.scala
@@ -7,22 +7,26 @@ class CodecImplicitResolutionSpec extends ChimneySpec {
 
   test("encode using Total Transformer from Codec when available") {
     import products.Domain1.*
-    implicit def usernameToString: Transformer[UserName, String] =
-      userNameToStringTransformer
-    implicit def stringToUsername: PartialTransformer[String, UserName] =
-      PartialTransformer.liftTotal(value => UserName(value))
-    implicit def codec: Codec[User, UserDTO] = Codec.derive
+    implicit def codec: Codec[User, UserDTO] = locally {
+      implicit def usernameToString: Transformer[UserName, String] =
+        userNameToStringTransformer
+      implicit def stringToUsername: PartialTransformer[String, UserName] =
+        PartialTransformer.liftTotal(value => UserName(value))
+      Codec.derive
+    }
 
     User("1", UserName("name")).transformInto[UserDTO] ==> UserDTO("1", "nameT")
   }
 
   test("decode using Partial Transformer from Codec when available") {
     import products.Domain1.*
-    implicit def usernameToString: Transformer[UserName, String] =
-      userNameToStringTransformer
-    implicit def stringToUsername: PartialTransformer[String, UserName] =
-      PartialTransformer.liftTotal(value => UserName(value + "T"))
-    implicit def codec: Codec[User, UserDTO] = Codec.derive
+    implicit def codec: Codec[User, UserDTO] = locally {
+      implicit def usernameToString: Transformer[UserName, String] =
+        userNameToStringTransformer
+      implicit def stringToUsername: PartialTransformer[String, UserName] =
+        PartialTransformer.liftTotal(value => UserName(value + "T"))
+      Codec.derive
+    }
 
     UserDTO("1", "name").transformIntoPartial[User].asOption ==> Some(User("1", UserName("nameT")))
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecImplicitResolutionSpec.scala
@@ -12,7 +12,7 @@ class CodecImplicitResolutionSpec extends ChimneySpec {
         userNameToStringTransformer
       implicit def stringToUsername: PartialTransformer[String, UserName] =
         PartialTransformer.liftTotal(value => UserName(value))
-      Codec.derive
+      Codec.derive[User, UserDTO]
     }
 
     User("1", UserName("name")).transformInto[UserDTO] ==> UserDTO("1", "nameT")
@@ -25,7 +25,7 @@ class CodecImplicitResolutionSpec extends ChimneySpec {
         userNameToStringTransformer
       implicit def stringToUsername: PartialTransformer[String, UserName] =
         PartialTransformer.liftTotal(value => UserName(value + "T"))
-      Codec.derive
+      Codec.derive[User, UserDTO]
     }
 
     UserDTO("1", "name").transformIntoPartial[User].asOption ==> Some(User("1", UserName("nameT")))

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecImplicitResolutionSpec.scala
@@ -1,0 +1,29 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class CodecImplicitResolutionSpec extends ChimneySpec {
+
+  test("encode using Total Transformer from Codec when available") {
+    import products.Domain1.*
+    implicit def usernameToString: Transformer[UserName, String] =
+      userNameToStringTransformer
+    implicit def stringToUsername: PartialTransformer[String, UserName] =
+      PartialTransformer.liftTotal(value => UserName(value))
+    implicit def codec: Codec[User, UserDTO] = Codec.derive
+
+    User("1", UserName("name")).transformInto[UserDTO] ==> UserDTO("1", "nameT")
+  }
+
+  test("decode using Partial Transformer from Codec when available") {
+    import products.Domain1.*
+    implicit def usernameToString: Transformer[UserName, String] =
+      userNameToStringTransformer
+    implicit def stringToUsername: PartialTransformer[String, UserName] =
+      PartialTransformer.liftTotal(value => UserName(value + "T"))
+    implicit def codec: Codec[User, UserDTO] = Codec.derive
+
+    UserDTO("1", "name").transformIntoPartial[User].asOption ==> Some(User("1", UserName("nameT")))
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
@@ -1,0 +1,23 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class CodecProductSpec extends ChimneySpec {
+
+  group("""setting .withFieldRenamed(_.from, _.to)""") {
+
+    test("should be correctly forwarded to Transformer/PartialTransformer") {
+      import products.Renames.{User, UserPLStd}
+
+      implicit val iso: Codec[User, UserPLStd] = Codec
+        .define[User, UserPLStd]
+        .withFieldRenamed(_.name, _.imie)
+        .withFieldRenamed(_.age, _.wiek)
+        .buildCodec
+
+      User(1, "John", Some(27)).transformInto[UserPLStd] ==> UserPLStd(1, "John", Some(27))
+      UserPLStd(1, "John", Some(27)).transformIntoPartial[User].asOption ==> Some(User(1, "John", Some(27)))
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
@@ -5,19 +5,28 @@ import io.scalaland.chimney.fixtures.*
 
 class CodecProductSpec extends ChimneySpec {
 
-  group("""setting .withFieldRenamed(_.from, _.to)""") {
+  test("""setting .withFieldRenamed(_.from, _.to) should be correctly forwarded to Transformer/PartialTransformer""") {
+    import products.Renames.{User, UserPLStd}
 
-    test("should be correctly forwarded to Transformer/PartialTransformer") {
-      import products.Renames.{User, UserPLStd}
+    implicit val iso: Codec[User, UserPLStd] = Codec
+      .define[User, UserPLStd]
+      .withFieldRenamed(_.name, _.imie)
+      .withFieldRenamed(_.age, _.wiek)
+      .buildCodec
 
-      implicit val iso: Codec[User, UserPLStd] = Codec
-        .define[User, UserPLStd]
-        .withFieldRenamed(_.name, _.imie)
-        .withFieldRenamed(_.age, _.wiek)
-        .buildCodec
+    User(1, "John", Some(27)).transformInto[UserPLStd] ==> UserPLStd(1, "John", Some(27))
+    UserPLStd(1, "John", Some(27)).transformIntoPartial[User].asOption ==> Some(User(1, "John", Some(27)))
+  }
 
-      User(1, "John", Some(27)).transformInto[UserPLStd] ==> UserPLStd(1, "John", Some(27))
-      UserPLStd(1, "John", Some(27)).transformIntoPartial[User].asOption ==> Some(User(1, "John", Some(27)))
-    }
+  test("""flags should be correctly forwarded to Transformers""") {
+    import products.Defaults.{Target, Target2}
+
+    implicit val codec: Codec[Target, Target2] = Codec
+      .define[Target, Target2]
+      .enableDefaultValues
+      .buildCodec
+
+    Target(1, "n", 7.7).transformInto[Target2] ==> Target2(10, "y", 7.7)
+    Target2(1, "n", 7.7).transformIntoPartial[Target].asOption ==> Some(Target(10, "y", 7.7))
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoImplicitResolutionSpec.scala
@@ -11,7 +11,7 @@ class IsoImplicitResolutionSpec extends ChimneySpec {
       implicit def usernameToString: Transformer[UserName, String] =
         userNameToStringTransformer
       implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
-      Iso.derive
+      Iso.derive[User, UserDTO]
     }
 
     User("1", UserName("name")).transformInto[UserDTO] ==> UserDTO("1", "nameT")
@@ -23,7 +23,7 @@ class IsoImplicitResolutionSpec extends ChimneySpec {
       implicit def usernameToString: Transformer[UserName, String] =
         userNameToStringTransformer
       implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
-      Iso.derive
+      Iso.derive[User, UserDTO]
     }
 
     UserDTO("1", "name").transformIntoPartial[User].asOption ==> Some(User("1", UserName("nameT")))

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoImplicitResolutionSpec.scala
@@ -7,20 +7,24 @@ class IsoImplicitResolutionSpec extends ChimneySpec {
 
   test("convert using the first Total Transformer from Iso when available") {
     import products.Domain1.*
-    implicit def usernameToString: Transformer[UserName, String] =
-      userNameToStringTransformer
-    implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
-    implicit def iso: Iso[User, UserDTO] = Iso.derive
+    implicit def iso: Iso[User, UserDTO] = locally {
+      implicit def usernameToString: Transformer[UserName, String] =
+        userNameToStringTransformer
+      implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
+      Iso.derive
+    }
 
     User("1", UserName("name")).transformInto[UserDTO] ==> UserDTO("1", "nameT")
   }
 
   test("convert using the second Total Transformer from Iso when available") {
     import products.Domain1.*
-    implicit def usernameToString: Transformer[UserName, String] =
-      userNameToStringTransformer
-    implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
-    implicit def iso: Iso[User, UserDTO] = Iso.derive
+    implicit def iso: Iso[User, UserDTO] = locally {
+      implicit def usernameToString: Transformer[UserName, String] =
+        userNameToStringTransformer
+      implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
+      Iso.derive
+    }
 
     UserDTO("1", "name").transformIntoPartial[User].asOption ==> Some(User("1", UserName("nameT")))
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoImplicitResolutionSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoImplicitResolutionSpec.scala
@@ -1,0 +1,27 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class IsoImplicitResolutionSpec extends ChimneySpec {
+
+  test("convert using the first Total Transformer from Iso when available") {
+    import products.Domain1.*
+    implicit def usernameToString: Transformer[UserName, String] =
+      userNameToStringTransformer
+    implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
+    implicit def iso: Iso[User, UserDTO] = Iso.derive
+
+    User("1", UserName("name")).transformInto[UserDTO] ==> UserDTO("1", "nameT")
+  }
+
+  test("convert using the second Total Transformer from Iso when available") {
+    import products.Domain1.*
+    implicit def usernameToString: Transformer[UserName, String] =
+      userNameToStringTransformer
+    implicit def stringToUsername: Transformer[String, UserName] = value => UserName(value + "T")
+    implicit def iso: Iso[User, UserDTO] = Iso.derive
+
+    UserDTO("1", "name").transformIntoPartial[User].asOption ==> Some(User("1", UserName("nameT")))
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
@@ -5,19 +5,29 @@ import io.scalaland.chimney.fixtures.*
 
 class IsoProductSpec extends ChimneySpec {
 
-  group("""setting .withFieldRenamed(_.from, _.to)""") {
+  test("""setting .withFieldRenamed(_.from, _.to) should be correctly forwarded to Transformers""") {
 
-    test("should be correctly forwarded to Transformers") {
-      import products.Renames.{User, UserPLStd}
+    import products.Renames.{User, UserPLStd}
 
-      implicit val iso: Iso[User, UserPLStd] = Iso
-        .define[User, UserPLStd]
-        .withFieldRenamed(_.name, _.imie)
-        .withFieldRenamed(_.age, _.wiek)
-        .buildIso
+    implicit val iso: Iso[User, UserPLStd] = Iso
+      .define[User, UserPLStd]
+      .withFieldRenamed(_.name, _.imie)
+      .withFieldRenamed(_.age, _.wiek)
+      .buildIso
 
-      User(1, "John", Some(27)).transformInto[UserPLStd] ==> UserPLStd(1, "John", Some(27))
-      UserPLStd(1, "John", Some(27)).transformInto[User] ==> User(1, "John", Some(27))
-    }
+    User(1, "John", Some(27)).transformInto[UserPLStd] ==> UserPLStd(1, "John", Some(27))
+    UserPLStd(1, "John", Some(27)).transformInto[User] ==> User(1, "John", Some(27))
+  }
+
+  test("""flags should be correctly forwarded to Transformers""") {
+    import products.Defaults.{Target, Target2}
+
+    implicit val iso: Iso[Target, Target2] = Iso
+      .define[Target, Target2]
+      .enableDefaultValues
+      .buildIso
+
+    Target(1, "n", 7.7).transformInto[Target2] ==> Target2(10, "y", 7.7)
+    Target2(1, "n", 7.7).transformInto[Target] ==> Target(10, "y", 7.7)
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
@@ -1,0 +1,23 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.*
+
+class IsoProductSpec extends ChimneySpec {
+
+  group("""setting .withFieldRenamed(_.from, _.to)""") {
+
+    test("should be correctly forwarded to Transformers") {
+      import products.Renames.{User, UserPLStd}
+
+      implicit val iso: Iso[User, UserPLStd] = Iso
+        .define[User, UserPLStd]
+        .withFieldRenamed(_.name, _.imie)
+        .withFieldRenamed(_.age, _.wiek)
+        .buildIso
+
+      User(1, "John", Some(27)).transformInto[UserPLStd] ==> UserPLStd(1, "John", Some(27))
+      UserPLStd(1, "John", Some(27)).transformInto[User] ==> User(1, "John", Some(27))
+    }
+  }
+}


### PR DESCRIPTION
 - [x] define `Iso`
 - [x] define `Codec`
 - [x] ~automatic derivation in `AutoDerived` companions~ after consideration - it is not needed
 - [x] ~automatic derivation in `chimney.auto`~ after consideration - it is not needed
 - [x] `define`
   - [x] `withFieldRenamed`
 - [x] extract total/partial from `Iso`/`Codec`
 - [x] tests
 - [x] documentation