### PR TITLE
Rename subtype

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -65,7 +65,8 @@ final class CodecDefinition[
   /** Use `DomainSubtype` in `Domain` as a source for `DtoSubtype` in `Dto`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam DomainSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -35,7 +35,7 @@ final class CodecDefinition[
       `Flags1 <: TransformerFlags` => CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags1]
     ], Flags] {
 
-  /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`
+  /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`.
     *
     * By default if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
     *
@@ -61,6 +61,34 @@ final class CodecDefinition[
       selectorDto: Dto => U
   ): CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
     macro CodecDefinitionMacros.withFieldRenamedImpl[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags]
+
+  /** Use `DomainSubtype` in `Domain` as a source for `DtoSubtype` in `Dto`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam DomainSubtype
+    *   type of sealed/enum instance
+    * @tparam DtoSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.CodecDefinition]]
+    *
+    * @since 1.2.0
+    */
+  def withSealedSubtypeRenamed[DomainSubtype, DtoSubtype]
+      : CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    macro CodecDefinitionMacros
+      .withSealedSubtypeRenamedImpl[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags, DomainSubtype, DtoSubtype]
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  def withEnumCaseRenamed[DomainSubtype, DtoSubtype]
+      : CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    macro CodecDefinitionMacros
+      .withSealedSubtypeRenamedImpl[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags, DomainSubtype, DtoSubtype]
 
   /** Build Codec using current configuration.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -35,7 +35,7 @@ final class IsoDefinition[
       `Flags1 <: TransformerFlags` => IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags1]
     ], Flags] {
 
-  /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`
+  /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`.
     *
     * By default if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
     *
@@ -61,6 +61,34 @@ final class IsoDefinition[
       selectorSecond: Second => U
   ): IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
     macro IsoDefinitionMacros.withFieldRenamedImpl[First, Second, FirstOverrides, SecondOverrides, Flags]
+
+  /** Use `FirstSubtype` in `First` as a source for `SecondSubtype` in `Second`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam FirstSubtype
+    *   type of sealed/enum instance
+    * @tparam SecondSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.IsoDefinition]]
+    *
+    * @since 1.2.0
+    */
+  def withSealedSubtypeRenamed[FirstSubtype, SecondSubtype]
+      : IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    macro IsoDefinitionMacros
+      .withSealedSubtypeRenamedImpl[First, Second, FirstOverrides, SecondOverrides, Flags, FirstSubtype, SecondSubtype]
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  def withEnumCaseRenamed[FirstSubtype, SecondSubtype]
+      : IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    macro IsoDefinitionMacros
+      .withSealedSubtypeRenamedImpl[First, Second, FirstOverrides, SecondOverrides, Flags, FirstSubtype, SecondSubtype]
 
   /** Build Iso using current configuration.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -65,7 +65,8 @@ final class IsoDefinition[
   /** Use `FirstSubtype` in `First` as a source for `SecondSubtype` in `Second`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FirstSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -262,7 +262,8 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam DomainSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -135,7 +135,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
@@ -258,6 +258,34 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       f: Subtype => partial.Result[To]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialImpl[From, To, Overrides, Flags, Subtype]
+
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam DomainSubtype
+    *   type of sealed/enum instance
+    * @tparam DtoSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.2.0
+    */
+  def withSealedSubtypeRenamed[FromSubtype, ToSubtype]
+      : PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros
+      .withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  def withEnumCaseRenamed[FromSubtype, ToSubtype]
+      : PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros
+      .withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
 
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -264,6 +264,31 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withSealedSubtypeHandledPartialImpl[From, To, Overrides, Flags, Subtype]
 
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam FromSubtype
+    *   type of sealed/enum instance
+    * @tparam ToSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.2.0
+    */
+  def withSealedSubtypeRenamed[FromSubtype, ToSubtype]
+      : PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  def withEnumCaseRenamed[FromSubtype, ToSubtype]: PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
+
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -267,7 +267,8 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FromSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -171,7 +171,8 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FromSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -173,9 +173,9 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
     *
-    * @tparam DomainSubtype
+    * @tparam FromSubtype
     *   type of sealed/enum instance
-    * @tparam DtoSubtype
+    * @tparam ToSubtype
     *   type of sealed/enum instance
     * @return
     *   [[io.scalaland.chimney.dsl.TransformerDefinition]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -93,7 +93,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
@@ -167,6 +167,31 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
       f: Subtype => To
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withSealedSubtypeHandledImpl[From, To, Overrides, Flags, Subtype]
+
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam DomainSubtype
+    *   type of sealed/enum instance
+    * @tparam DtoSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerDefinition]]
+    *
+    * @since 1.2.0
+    */
+  def withSealedSubtypeRenamed[FromSubtype, ToSubtype]
+      : TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  def withEnumCaseRenamed[FromSubtype, ToSubtype]: TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
 
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -159,7 +159,8 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FromSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -177,7 +177,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     *
     * @since 1.2.0
     */
-  def withEnumCaseRenamed[FromSubtype, ToSubtype]: TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+  def withEnumCaseRenamed[FromSubtype, ToSubtype]: TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
 
   /** Use `f` instead of the primary constructor to construct the `To` value.

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -156,6 +156,30 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   def withCoproductInstance[Subtype](f: Subtype => To): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withSealedSubtypeHandledImpl[From, To, Overrides, Flags, Subtype]
 
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam FromSubtype
+    *   type of sealed/enum instance
+    * @tparam ToSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 1.2.0
+    */
+  def withSealedSubtypeRenamed[FromSubtype, ToSubtype]: TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  def withEnumCaseRenamed[FromSubtype, ToSubtype]: TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]
+
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -233,6 +233,22 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             )
           }
       }
+      object RenamedTo extends RenamedToModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.RenamedTo[FromPath, ToPath, Tail]] =
+          weakTypeTag[runtime.TransformerOverrides.RenamedTo[FromPath, ToPath, Tail]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.RenamedTo[?, ?, ?]].map { A0 =>
+            (
+              A0.param_<[runtime.Path](0),
+              fixJavaEnums(A0.param_<[runtime.Path](1)),
+              A0.param_<[runtime.TransformerOverrides](2)
+            )
+          }
+      }
     }
 
     object TransformerFlags extends TransformerFlagsModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
@@ -43,14 +43,14 @@ class CodecDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       weakTypeTag[CodecDefinition[
         Domain,
         Dto,
-        RenamedFrom[
+        RenamedTo[
           Path.SourceMatching[Path.Root, DomainSubtype],
-          Path.SourceMatching[Path.Root, DtoSubtype],
+          Path.Matching[Path.Root, DtoSubtype],
           EncodeOverrides
         ],
-        RenamedFrom[
+        RenamedTo[
           Path.SourceMatching[Path.Root, DtoSubtype],
-          Path.SourceMatching[Path.Root, DomainSubtype],
+          Path.Matching[Path.Root, DomainSubtype],
           DecodeOverrides
         ],
         Flags

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
@@ -29,4 +29,31 @@ class CodecDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils
           ]]
       }.applyFromSelectors(selectorDomain, selectorDto)
     )
+
+  def withSealedSubtypeRenamedImpl[
+      Domain: WeakTypeTag,
+      Dto: WeakTypeTag,
+      EncodeOverrides <: TransformerOverrides: WeakTypeTag,
+      DecodeOverrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      DomainSubtype: WeakTypeTag,
+      DtoSubtype: WeakTypeTag
+  ]: Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      weakTypeTag[CodecDefinition[
+        Domain,
+        Dto,
+        RenamedFrom[
+          Path.SourceMatching[Path.Root, DomainSubtype],
+          Path.SourceMatching[Path.Root, DtoSubtype],
+          EncodeOverrides
+        ],
+        RenamedFrom[
+          Path.SourceMatching[Path.Root, DtoSubtype],
+          Path.SourceMatching[Path.Root, DomainSubtype],
+          DecodeOverrides
+        ],
+        Flags
+      ]]
+    )
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -43,14 +43,14 @@ class IsoDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
       weakTypeTag[IsoDefinition[
         First,
         Second,
-        RenamedFrom[
+        RenamedTo[
           Path.SourceMatching[Path.Root, FirstSubtype],
-          Path.SourceMatching[Path.Root, SecondSubtype],
+          Path.Matching[Path.Root, SecondSubtype],
           FirstOverrides
         ],
-        RenamedFrom[
+        RenamedTo[
           Path.SourceMatching[Path.Root, SecondSubtype],
-          Path.SourceMatching[Path.Root, FirstSubtype],
+          Path.Matching[Path.Root, FirstSubtype],
           SecondOverrides
         ],
         Flags

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -29,4 +29,31 @@ class IsoDefinitionMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
           ]]
       }.applyFromSelectors(selectorFirst, selectorSecond)
     )
+
+  def withSealedSubtypeRenamedImpl[
+      First: WeakTypeTag,
+      Second: WeakTypeTag,
+      FirstOverrides <: TransformerOverrides: WeakTypeTag,
+      SecondOverrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FirstSubtype: WeakTypeTag,
+      SecondSubtype: WeakTypeTag
+  ]: Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      weakTypeTag[IsoDefinition[
+        First,
+        Second,
+        RenamedFrom[
+          Path.SourceMatching[Path.Root, FirstSubtype],
+          Path.SourceMatching[Path.Root, SecondSubtype],
+          FirstOverrides
+        ],
+        RenamedFrom[
+          Path.SourceMatching[Path.Root, SecondSubtype],
+          Path.SourceMatching[Path.Root, FirstSubtype],
+          SecondOverrides
+        ],
+        Flags
+      ]]
+    )
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -125,7 +125,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       weakTypeTag[PartialTransformerDefinition[
         From,
         To,
-        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
         Flags
       ]]
     )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -113,6 +113,23 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
 
+  def withSealedSubtypeRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromSubtype: WeakTypeTag,
+      ToSubtype: WeakTypeTag
+  ]: Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      weakTypeTag[PartialTransformerDefinition[
+        From,
+        To,
+        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        Flags
+      ]]
+    )
+
   def withConstructorImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -114,6 +114,23 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
 
+  def withSealedSubtypeRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromSubtype: WeakTypeTag,
+      ToSubtype: WeakTypeTag
+  ]: Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      weakTypeTag[PartialTransformerInto[
+        From,
+        To,
+        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        Flags
+      ]]
+    )
+
   def withConstructorImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -126,7 +126,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       weakTypeTag[PartialTransformerInto[
         From,
         To,
-        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
         Flags
       ]]
     )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -81,7 +81,7 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       weakTypeTag[TransformerDefinition[
         From,
         To,
-        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
         Flags
       ]]
     )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -69,6 +69,23 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
 
+  def withSealedSubtypeRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromSubtype: WeakTypeTag,
+      ToSubtype: WeakTypeTag
+  ]: Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      weakTypeTag[TransformerDefinition[
+        From,
+        To,
+        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        Flags
+      ]]
+    )
+
   def withConstructorImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -81,7 +81,7 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       weakTypeTag[TransformerInto[
         From,
         To,
-        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
         Flags
       ]]
     )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -69,6 +69,23 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
 
+  def withSealedSubtypeRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromSubtype: WeakTypeTag,
+      ToSubtype: WeakTypeTag
+  ]: Tree = c.prefix.tree
+    .asInstanceOfExpr(
+      weakTypeTag[TransformerInto[
+        From,
+        To,
+        RenamedFrom[Path.SourceMatching[Path.Root, FromSubtype], Path.SourceMatching[Path.Root, ToSubtype], Overrides],
+        Flags
+      ]]
+    )
+
   def withConstructorImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -64,7 +64,8 @@ final class CodecDefinition[
   /** Use `DomainSubtype` in `Domain` as a source for `DtoSubtype` in `Dto`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam DomainSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -34,7 +34,7 @@ final class CodecDefinition[
       Flags
     ] {
 
-  /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`
+  /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`.
     *
     * By default if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
     *
@@ -60,6 +60,42 @@ final class CodecDefinition[
       inline selectorDto: Dto => U
   ): CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
     ${ CodecDefinitionMacros.withFieldRenamedImpl('this, 'selectorDomain, 'selectorDto) }
+
+  /** Use `DomainSubtype` in `Domain` as a source for `DtoSubtype` in `Dto`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam DomainSubtype
+    *   type of sealed/enum instance
+    * @tparam DtoSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.CodecDefinition]]
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withSealedSubtypeRenamed[DomainSubtype, DtoSubtype]
+      : CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    ${
+      CodecDefinitionMacros
+        .withSealedSubtypeRenamedImpl[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags, DomainSubtype, DtoSubtype](
+          'this
+        )
+    }
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withEnumCaseRenamed[DomainSubtype, DtoSubtype]
+      : CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    ${
+      CodecDefinitionMacros
+        .withSealedSubtypeRenamedImpl[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags, DomainSubtype, DtoSubtype](
+          'this
+        )
+    }
 
   /** Build Codec using current configuration.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -64,7 +64,8 @@ final class IsoDefinition[
   /** Use `FirstSubtype` in `First` as a source for `SecondSubtype` in `Second`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam DomainSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -34,7 +34,7 @@ final class IsoDefinition[
       Flags
     ] {
 
-  /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`
+  /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`.
     *
     * By default if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
     *
@@ -60,6 +60,42 @@ final class IsoDefinition[
       inline selectorSecond: Second => U
   ): IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
     ${ IsoDefinitionMacros.withFieldRenamedImpl('this, 'selectorFirst, 'selectorSecond) }
+
+  /** Use `FirstSubtype` in `First` as a source for `SecondSubtype` in `Second`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam DomainSubtype
+    *   type of sealed/enum instance
+    * @tparam DtoSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.IsoDefinition]]
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withSealedSubtypeRenamed[DomainSubtype, DtoSubtype]
+      : IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    ${
+      IsoDefinitionMacros
+        .withSealedSubtypeRenamedImpl[First, Second, FirstOverrides, SecondOverrides, Flags, DomainSubtype, DtoSubtype](
+          'this
+        )
+    }
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withEnumCaseRenamed[DomainSubtype, DtoSubtype]
+      : IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
+    ${
+      IsoDefinitionMacros
+        .withSealedSubtypeRenamedImpl[First, Second, FirstOverrides, SecondOverrides, Flags, DomainSubtype, DtoSubtype](
+          'this
+        )
+    }
 
   /** Build Iso using current configuration.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -264,7 +264,8 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FromSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -137,7 +137,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
@@ -260,6 +260,38 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       inline f: Subtype => partial.Result[To]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialImpl('this, 'f) }
+
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam FromSubtype
+    *   type of sealed/enum instance
+    * @tparam ToSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withSealedSubtypeRenamed[FromSubtype, ToSubtype]
+      : PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${
+      PartialTransformerDefinitionMacros
+        .withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]('this)
+    }
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withEnumCaseRenamed[FromSubtype, ToSubtype]
+      : PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${
+      PartialTransformerDefinitionMacros
+        .withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]('this)
+    }
 
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -268,7 +268,8 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FromSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -265,6 +265,40 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withSealedSubtypeHandledPartialImpl('this, 'f) }
 
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam FromSubtype
+    *   type of sealed/enum instance
+    * @tparam ToSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withSealedSubtypeRenamed[FromSubtype, ToSubtype]
+      : PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${
+      PartialTransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype](
+        'this
+      )
+    }
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withEnumCaseRenamed[FromSubtype, ToSubtype]
+      : PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${
+      PartialTransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype](
+        'this
+      )
+    }
+
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -96,7 +96,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
     *
@@ -170,6 +170,40 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
       inline f: Subtype => To
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withSealedSubtypeHandledImpl('this, 'f) }
+
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam FromSubtype
+    *   type of sealed/enum instance
+    * @tparam ToSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerDefinition]]
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withSealedSubtypeRenamed[FromSubtype, ToSubtype]
+      : TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${
+      TransformerDefinitionMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype](
+        'this
+      )
+    }
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withEnumCaseRenamed[FromSubtype, ToSubtype]
+      : TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${
+      TransformerDefinitionMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype](
+        'this
+      )
+    }
 
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -160,6 +160,32 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withSealedSubtypeHandledImpl('this, 'f) }
 
+  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *
+    * @tparam FromSubtype
+    *   type of sealed/enum instance
+    * @tparam ToSubtype
+    *   type of sealed/enum instance
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withSealedSubtypeRenamed[FromSubtype, ToSubtype]
+      : TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]('this) }
+
+  /** Alias to [[withSealedSubtypeRenamed]].
+    *
+    * @since 1.2.0
+    */
+  transparent inline def withEnumCaseRenamed[FromSubtype, ToSubtype]
+      : TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerIntoMacros.withSealedSubtypeRenamedImpl[From, To, Overrides, Flags, FromSubtype, ToSubtype]('this) }
+
   /** Use `f` instead of the primary constructor to construct the `To` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -187,6 +187,25 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
               )
             case _ => scala.None
       }
+      object RenamedTo extends RenamedToModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.RenamedTo[FromPath, ToPath, Tail]] =
+          quoted.Type.of[runtime.TransformerOverrides.RenamedTo[FromPath, ToPath, Tail]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          tpe match
+            case '[runtime.TransformerOverrides.RenamedTo[fromPath, toPath, cfg]] =>
+              Some(
+                (
+                  Type[fromPath].as_?<[runtime.Path],
+                  Type[toPath].as_?<[runtime.Path],
+                  Type[cfg].as_?<[runtime.TransformerOverrides]
+                )
+              )
+            case _ => scala.None
+      }
     }
 
     object TransformerFlags extends TransformerFlagsModule {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
@@ -36,4 +36,34 @@ object CodecDefinitionMacros {
               ]]
           }
     }(selectorDomain, selectorDto)
+
+  def withSealedSubtypeRenamedImpl[
+      Domain: Type,
+      Dto: Type,
+      EncodeOverrides <: TransformerOverrides: Type,
+      DecodeOverrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      DomainSubtype: Type,
+      DtoSubtype: Type
+  ](
+      id: Expr[CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags]]
+  )(using Quotes): Expr[CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags]] =
+    '{
+      $id
+        .asInstanceOf[CodecDefinition[
+          Domain,
+          Dto,
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, DomainSubtype],
+            Path.SourceMatching[Path.Root, DtoSubtype],
+            EncodeOverrides
+          ],
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, DtoSubtype],
+            Path.SourceMatching[Path.Root, DomainSubtype],
+            DecodeOverrides
+          ],
+          Flags
+        ]]
+    }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
@@ -53,14 +53,14 @@ object CodecDefinitionMacros {
         .asInstanceOf[CodecDefinition[
           Domain,
           Dto,
-          RenamedFrom[
+          RenamedTo[
             Path.SourceMatching[Path.Root, DomainSubtype],
-            Path.SourceMatching[Path.Root, DtoSubtype],
+            Path.Matching[Path.Root, DtoSubtype],
             EncodeOverrides
           ],
-          RenamedFrom[
+          RenamedTo[
             Path.SourceMatching[Path.Root, DtoSubtype],
-            Path.SourceMatching[Path.Root, DomainSubtype],
+            Path.Matching[Path.Root, DomainSubtype],
             DecodeOverrides
           ],
           Flags

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -36,4 +36,34 @@ object IsoDefinitionMacros {
               ]]
           }
     }(selectorFirst, selectorSecond)
+
+  def withSealedSubtypeRenamedImpl[
+      First: Type,
+      Second: Type,
+      FirstOverrides <: TransformerOverrides: Type,
+      SecondOverrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FirstSubtype: Type,
+      SecondSubtype: Type
+  ](
+      id: Expr[IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags]]
+  )(using Quotes): Expr[IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags]] =
+    '{
+      $id
+        .asInstanceOf[IsoDefinition[
+          First,
+          Second,
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, FirstSubtype],
+            Path.SourceMatching[Path.Root, SecondSubtype],
+            FirstOverrides
+          ],
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, SecondSubtype],
+            Path.SourceMatching[Path.Root, FirstSubtype],
+            SecondOverrides
+          ],
+          Flags
+        ]]
+    }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -53,14 +53,14 @@ object IsoDefinitionMacros {
         .asInstanceOf[IsoDefinition[
           First,
           Second,
-          RenamedFrom[
+          RenamedTo[
             Path.SourceMatching[Path.Root, FirstSubtype],
-            Path.SourceMatching[Path.Root, SecondSubtype],
+            Path.Matching[Path.Root, SecondSubtype],
             FirstOverrides
           ],
-          RenamedFrom[
+          RenamedTo[
             Path.SourceMatching[Path.Root, SecondSubtype],
-            Path.SourceMatching[Path.Root, FirstSubtype],
+            Path.Matching[Path.Root, FirstSubtype],
             SecondOverrides
           ],
           Flags

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -182,6 +182,30 @@ object PartialTransformerDefinitionMacros {
         ]]
     }
 
+  def withSealedSubtypeRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromSubtype: Type,
+      ToSubtype: Type
+  ](
+      td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    '{
+      $td
+        .asInstanceOf[PartialTransformerDefinition[
+          From,
+          To,
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, FromSubtype],
+            Path.SourceMatching[Path.Root, ToSubtype],
+            Overrides
+          ],
+          Flags
+        ]]
+    }
+
   def withConstructorImpl[
       From: Type,
       To: Type,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -197,11 +197,7 @@ object PartialTransformerDefinitionMacros {
         .asInstanceOf[PartialTransformerDefinition[
           From,
           To,
-          RenamedFrom[
-            Path.SourceMatching[Path.Root, FromSubtype],
-            Path.SourceMatching[Path.Root, ToSubtype],
-            Overrides
-          ],
+          RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
           Flags
         ]]
     }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -187,11 +187,7 @@ object PartialTransformerIntoMacros {
         .asInstanceOf[PartialTransformerInto[
           From,
           To,
-          RenamedFrom[
-            Path.SourceMatching[Path.Root, FromSubtype],
-            Path.SourceMatching[Path.Root, ToSubtype],
-            Overrides
-          ],
+          RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
           Flags
         ]]
     }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -172,6 +172,30 @@ object PartialTransformerIntoMacros {
         ]]
     }
 
+  def withSealedSubtypeRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromSubtype: Type,
+      ToSubtype: Type
+  ](
+      td: Expr[PartialTransformerInto[From, To, Overrides, Flags]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    '{
+      $td
+        .asInstanceOf[PartialTransformerInto[
+          From,
+          To,
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, FromSubtype],
+            Path.SourceMatching[Path.Root, ToSubtype],
+            Overrides
+          ],
+          Flags
+        ]]
+    }
+
   def withConstructorImpl[
       From: Type,
       To: Type,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -106,6 +106,30 @@ object TransformerDefinitionMacros {
         ]]
     }
 
+  def withSealedSubtypeRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromSubtype: Type,
+      ToSubtype: Type
+  ](
+      td: Expr[TransformerDefinition[From, To, Overrides, Flags]]
+  )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    '{
+      $td
+        .asInstanceOf[TransformerDefinition[
+          From,
+          To,
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, FromSubtype],
+            Path.SourceMatching[Path.Root, ToSubtype],
+            Overrides
+          ],
+          Flags
+        ]]
+    }
+
   def withConstructorImpl[
       From: Type,
       To: Type,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -121,11 +121,7 @@ object TransformerDefinitionMacros {
         .asInstanceOf[TransformerDefinition[
           From,
           To,
-          RenamedFrom[
-            Path.SourceMatching[Path.Root, FromSubtype],
-            Path.SourceMatching[Path.Root, ToSubtype],
-            Overrides
-          ],
+          RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
           Flags
         ]]
     }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -104,6 +104,30 @@ object TransformerIntoMacros {
         ]]
     }
 
+  def withSealedSubtypeRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromSubtype: Type,
+      ToSubtype: Type
+  ](
+      td: Expr[TransformerInto[From, To, Overrides, Flags]]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    '{
+      $td
+        .asInstanceOf[TransformerInto[
+          From,
+          To,
+          RenamedFrom[
+            Path.SourceMatching[Path.Root, FromSubtype],
+            Path.SourceMatching[Path.Root, ToSubtype],
+            Overrides
+          ],
+          Flags
+        ]]
+    }
+
   def withConstructorImpl[
       From: Type,
       To: Type,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -119,11 +119,7 @@ object TransformerIntoMacros {
         .asInstanceOf[TransformerInto[
           From,
           To,
-          RenamedFrom[
-            Path.SourceMatching[Path.Root, FromSubtype],
-            Path.SourceMatching[Path.Root, ToSubtype],
-            Overrides
-          ],
+          RenamedTo[Path.SourceMatching[Path.Root, FromSubtype], Path.Matching[Path.Root, ToSubtype], Overrides],
           Flags
         ]]
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -142,6 +142,15 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerOverrides,
             runtime.TransformerOverrides.RenamedFrom
           ] { this: RenamedFrom.type => }
+
+      val RenamedTo: RenamedToModule
+      trait RenamedToModule
+          extends Type.Ctor3UpperBounded[
+            runtime.Path,
+            runtime.Path,
+            runtime.TransformerOverrides,
+            runtime.TransformerOverrides.RenamedTo
+          ] { this: RenamedTo.type => }
     }
 
     val TransformerFlags: TransformerFlagsModule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationResult.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationResult.scala
@@ -247,7 +247,7 @@ private[compiletime] object DerivationResult {
     }
     try {
       val result = thunk(await)
-      Success(result, stateCache)
+      Success(result, if (stateCache != null) stateCache else State()) // if await wasn't called stateCache is null
     } catch {
       case PassErrors(derivationErrors, `await`) => Failure(derivationErrors, stateCache)
       case NonFatal(error)                       => DerivationResult.fromException(error)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -473,8 +473,8 @@ private[compiletime] trait Configurations { this: Derivation =>
         import fromPath.Underlying as FromPath, toPath.Underlying as ToPath, cfg.Underlying as Tail2
         extractTransformerConfig[Tail2](runtimeDataIdx, runtimeDataStore)
           .addTransformerOverride(
-            extractPath[ToPath],
-            TransformerOverride.RenamedTo(extractPath[FromPath])
+            extractPath[FromPath],
+            TransformerOverride.RenamedTo(extractPath[ToPath])
           )
       case _ =>
         // $COVERAGE-OFF$

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -215,6 +215,7 @@ private[compiletime] trait Configurations { this: Derivation =>
     }
 
     final case class RenamedFrom(sourcePath: Path) extends ForField
+    final case class RenamedTo(targetPath: Path) extends ForSubtype
 
     private def printArgs(args: Args): String = {
       import ExistentialType.prettyPrint as printTpe
@@ -467,6 +468,13 @@ private[compiletime] trait Configurations { this: Derivation =>
           .addTransformerOverride(
             extractPath[ToPath],
             TransformerOverride.RenamedFrom(extractPath[FromPath])
+          )
+      case ChimneyType.TransformerOverrides.RenamedTo(fromPath, toPath, cfg) =>
+        import fromPath.Underlying as FromPath, toPath.Underlying as ToPath, cfg.Underlying as Tail2
+        extractTransformerConfig[Tail2](runtimeDataIdx, runtimeDataStore)
+          .addTransformerOverride(
+            extractPath[ToPath],
+            TransformerOverride.RenamedTo(extractPath[FromPath])
           )
       case _ =>
         // $COVERAGE-OFF$

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/Path.scala
@@ -17,7 +17,7 @@ object Path {
     */
   final class Matching[Init <: Path, Subtype] extends Path
 
-  /** Used only for withSealedSubtypeMatching to denote that type is matched on the source side!!! */
+  /** Used only for withSealedSubtypeMatching/Renamed to denote that type is matched on the source side!!! */
   final class SourceMatching[Init <: Path, SourceSubtype] extends Path
 
   /** Represents $init.everyItem path. */

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
@@ -19,4 +19,6 @@ object TransformerOverrides {
   final class ConstructorPartial[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
   // Computes a value using manually pointed value from (src: From)
   final class RenamedFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
+  // Computes a value from matched subtype, targeting another subtype
+  final class RenamedTo[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
@@ -8,7 +8,7 @@ class CodecProductSpec extends ChimneySpec {
   test("""setting .withFieldRenamed(_.from, _.to) should be correctly forwarded to Transformer/PartialTransformer""") {
     import products.Renames.{User, UserPLStd}
 
-    implicit val iso: Codec[User, UserPLStd] = Codec
+    implicit val codec: Codec[User, UserPLStd] = Codec
       .define[User, UserPLStd]
       .withFieldRenamed(_.name, _.imie)
       .withFieldRenamed(_.age, _.wiek)
@@ -16,6 +16,40 @@ class CodecProductSpec extends ChimneySpec {
 
     User(1, "John", Some(27)).transformInto[UserPLStd] ==> UserPLStd(1, "John", Some(27))
     UserPLStd(1, "John", Some(27)).transformIntoPartial[User].asOption ==> Some(User(1, "John", Some(27)))
+  }
+
+  group(
+    "settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+  ) {
+
+    import fixtures.renames.Subtypes.*
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      implicit val codec: Codec[Foo3, Bar] =
+        Codec.define[Foo3, Bar].withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type].buildCodec
+
+      (Foo3.Baz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Foo3.Bazz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Bar.Baz: Bar).transformIntoPartial[Foo3].asOption ==> Some(Foo3.Bazz)
+    }
+  }
+
+  group(
+    "settings .withEnumCaseRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+  ) {
+
+    import fixtures.renames.Subtypes.*
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      implicit val codec: Codec[Foo3, Bar] =
+        Codec.define[Foo3, Bar].withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type].buildCodec
+
+      (Foo3.Baz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Foo3.Bazz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Bar.Baz: Bar).transformIntoPartial[Foo3].asOption ==> Some(Foo3.Bazz)
+    }
   }
 
   test("""flags should be correctly forwarded to Transformers""") {

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
@@ -19,6 +19,40 @@ class IsoProductSpec extends ChimneySpec {
     UserPLStd(1, "John", Some(27)).transformInto[User] ==> User(1, "John", Some(27))
   }
 
+  group(
+    "settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+  ) {
+
+    import fixtures.renames.Subtypes.*
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      implicit val iso: Iso[Foo3, Bar] =
+        Iso.define[Foo3, Bar].withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type].buildIso
+
+      (Foo3.Baz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Foo3.Bazz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Bar.Baz: Bar).transformInto[Foo3] ==> Foo3.Bazz
+    }
+  }
+
+  group(
+    "settings .withEnumCaseRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+  ) {
+
+    import fixtures.renames.Subtypes.*
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      implicit val iso: Iso[Foo3, Bar] =
+        Iso.define[Foo3, Bar].withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type].buildIso
+
+      (Foo3.Baz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Foo3.Bazz: Foo3).transformInto[Bar] ==> Bar.Baz
+      (Bar.Baz: Bar).transformInto[Foo3] ==> Foo3.Bazz
+    }
+  }
+
   test("""flags should be correctly forwarded to Transformers""") {
     import products.Defaults.{Target, Target2}
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
@@ -535,6 +535,58 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
     }
   }
 
+  group("settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype]") {
+
+    import fixtures.renames.Subtypes.*
+
+    test(
+      """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""
+    ) {
+
+      compileErrors("""(Foo3.Baz: Foo3).intoPartial[Bar].transform""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Foo3 to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "derivation from bazz: io.scalaland.chimney.fixtures.renames.Subtypes.Foo3.Bazz to io.scalaland.chimney.fixtures.renames.Subtypes.Bar is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Foo3.Bazz to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      (Foo3.Baz: Foo3)
+        .intoPartial[Bar]
+        .withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .transform
+        .asOption ==> Some(Bar.Baz)
+      (Foo3.Bazz: Foo3)
+        .intoPartial[Bar]
+        .withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .transform
+        .asOption ==> Some(Bar.Baz)
+    }
+  }
+
+  group("settings .withEnumCaseRenamed[FromSubtype, ToSubtype]") {
+
+    import fixtures.renames.Subtypes.*
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      (Foo3.Baz: Foo3)
+        .intoPartial[Bar]
+        .withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .transform
+        .asOption ==> Some(Bar.Baz)
+      (Foo3.Bazz: Foo3)
+        .intoPartial[Bar]
+        .withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .transform
+        .asOption ==> Some(Bar.Baz)
+    }
+  }
+
   group("flag .enableCustomSubtypeNameComparison") {
 
     import fixtures.renames.Subtypes.*

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -279,6 +279,42 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
     }
   }
 
+  group("settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype]") {
+
+    import fixtures.renames.Subtypes.*
+
+    test(
+      """should be absent by default and not allow transforming "superset" of case class to "subset" of case objects"""
+    ) {
+
+      compileErrors("""(Foo3.Baz: Foo3).into[Bar].transform""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.renames.Subtypes.Foo3 to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "derivation from bazz: io.scalaland.chimney.fixtures.renames.Subtypes.Foo3.Bazz to io.scalaland.chimney.fixtures.renames.Subtypes.Bar is not supported in Chimney!",
+        "io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "can't transform coproduct instance io.scalaland.chimney.fixtures.renames.Subtypes.Foo3.Bazz to io.scalaland.chimney.fixtures.renames.Subtypes.Bar",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+    }
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      (Foo3.Baz: Foo3).into[Bar].withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
+      (Foo3.Bazz: Foo3).into[Bar].withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
+    }
+  }
+
+  group("settings .withEnumCaseRenamed[FromSubtype, ToSubtype]") {
+
+    import fixtures.renames.Subtypes.*
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      (Foo3.Baz: Foo3).into[Bar].withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
+      (Foo3.Bazz: Foo3).into[Bar].withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
+    }
+  }
+
   group("flag .enableCustomSubtypeNameComparison") {
 
     import fixtures.renames.Subtypes.*

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/renames/Subtypes.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/renames/Subtypes.scala
@@ -22,4 +22,10 @@ object Subtypes {
     case object getBaz extends BarAmbiguous
     case object baz extends BarAmbiguous
   }
+
+  sealed trait Foo3
+  object Foo3 {
+    case object Baz extends Foo3
+    case object Bazz extends Foo3
+  }
 }

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -587,7 +587,7 @@ Now, let's take a look what Chimney does, and why the behavior is different.
     from some config or context and for better debugging experience (e.g. using fail fast for normal operations, but letting
     us change a switch in the deployed app without recompiling and redeploying everything to test just one call).
 
-What does it means for us?
+What does it mean to us?
 
 !!! warning
 
@@ -648,7 +648,7 @@ What does it means for us?
     ```
 
 Notice that this is not an issue if we are transforming one value into another value in a non-fallible way, e.g. through
-`map`, `contramap`, `dimap`. There is also no issie if we chain sevaral `flatMap`s for something more like Kleisli
+`map`, `contramap`, `dimap`. There is also no issie if we chain several `flatMap`s for something more like Kleisli
 composition (`result.flatMap(f).flatMap(g)`) but becomes an issue when we use `flatMap` and `flatMap`-based operations
 for building products (`result.flatMap(a => result2.map(b => (a, b))`).
 
@@ -668,7 +668,7 @@ By default, ScalaPB would generate in a case class an additional field
 `unknownFields: UnknownFieldSet = UnknownFieldSet()`. This field
 could be used if you want to somehow log/trace some extra values -
 perhaps from another version of the schema - were passed but your current
-version's parser didn't need it.
+version's parser did not need it.
 
 The automatic conversion into a protobuf with such a field can be problematic:
 
@@ -705,7 +705,7 @@ The automatic conversion into a protobuf with such a field can be problematic:
 
 There are 2 ways in which Chimney could handle this issue:
 
-  - using [default values](supported-transformations.md#allowing-constructors-defaults)
+  - using [default values](supported-transformations.md#allowing-fallback-to-the-constructors-default-values)
   
     !!! example
   
@@ -717,7 +717,7 @@ There are 2 ways in which Chimney could handle this issue:
           .transform
         ```
 
-  - manually [setting this one field](supported-transformations.md#wiring-constructors-parameter-to-raw-value)_
+  - manually [setting this one field](supported-transformations.md#wiring-the-constructors-parameter-to-a-provided-value)_
 
     !!! example
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -63,7 +63,7 @@ and this domain model:
   - you'd have to wrap and unwrap `AnyVal`
   - you'd have to convert a collection
   - in transformation in one way you'd have to wrap with `Option`, and on the way back handle `None`
-  - in one transformation you'd have to manually flatten ADT, and on the way back you have'd to unflatten it
+  - in one transformation you'd have to manually flatten ADT, and on the way back you have had to unflatten it
 
 Can you imagine all the code you'd have to write? For now! And the necessity to carefully update when the model changes?
 The silly mistakes with using the wrong field you'll inevitably make while copy-pasting a lot of repetitive, boring

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -21,7 +21,7 @@ While looking at code examples you're going to see these 2 terms: **Total Transf
 
 Chimney's job is to generate the code that will convert the value of one type (often called a **source** type, or `From`)
 into another type (often called a **target** type, or `To`). When Chimney has enough information to generate
-the transformation, most of the time it could do it for **every** value of the source type. In Chimney we called such
+the transformation, most of the time it could do it for **every** value of the source type. In Chimney, we called such
 transformations Total (because they are virtually **total functions**). One way in which Chimney allows you to use such
 transformation is through `Transformer[From, To]`:
 
@@ -855,8 +855,8 @@ It is disabled by default for the same reasons as default values - being potenti
 
 ### Writing to non-`Unit` Bean setters
 
-By default only unary methods returning `Unit` and starting with `set*` are considered setters. But this would exclude
-e.g. some builder methods which return `this.type` despite mutating. Such methods are siently ignored.
+By default, only unary methods returning `Unit` and starting with `set*` are considered setters. But this would exclude
+e.g. some builder methods which return `this.type` despite mutating. Such methods are silently ignored.
 
 To consider such methods (and fail compilation if they are not matched) you can enable them with a flag:
 
@@ -1045,7 +1045,7 @@ The `None` value is used as a fallback, meaning:
     could be found - if a source value type can be converted into a target argument/setter type then the value provision
     succeeds, but if Chimney fails to convert the value then the whole derivation fails rather than falls back to
     the `None` value
-  - it will not be used if a default value is present and [the support for default values has been enabled](#allowing-the-constructors-default-values)
+  - it will not be used if a default value is present and [the support for default values has been enabled](#allowing-fallback-to-the-constructors-default-values)
     (the fallback to `None` has a lower priority than the fallback to a default value) 
 
 !!! example
@@ -1595,11 +1595,11 @@ We are also able to compute values in nested structure:
 
 Be default names are matched in a Java-Bean-aware way - `fieldName` would be considered a match for another `fieldName`
 but also for `isFieldName`, `getFieldName` and `setFieldName`. This allows the macro to read both normal `val`s and
-Bean getters and write into constructor arguments and Bean setters. (Whether such getters/setters would we admited
+Bean getters and write into constructor arguments and Bean setters. (Whether such getters/setters would we admitted
 for matching is controlled by dedicated flags: [`.enableBeanGetters`](#reading-from-bean-getters) and 
 [`.enableBeanSetters`](#writing-to-bean-setters)).
 
-The field name matching predicate can be overrided with a flag:
+The field name matching predicate can be overridden with a flag:
 
 !!! example
 
@@ -2037,7 +2037,7 @@ Java's `enum` can also be converted this way to/from `sealed`/Scala 3's `enum`/a
 
 ### Handling a specific `sealed` subtype by a specific target subtype
 
-Sometimes a corresponding subtype of the target type has a unrelated name, that cannot be matched by simple comparison.
+Sometimes a corresponding subtype of the target type has an unrelated name, that cannot be matched by simple comparison.
 Or we might want to redirect two subtypes into the same target subtype. For that we have `.withSealedSubtypeRenamed`:
 
 !!! example
@@ -2071,6 +2071,7 @@ Or we might want to redirect two subtypes into the same target subtype. For that
     when dealing with `enum`s. For that reason we provide an aliases to this methods - `withEnumCaseRenamed`:
 
     ```scala
+    // file: snippet.scala - part of withEnumCaseRenamed example
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     //> using scala {{ scala.3 }}
     import io.scalaland.chimney.dsl._
@@ -2085,10 +2086,12 @@ Or we might want to redirect two subtypes into the same target subtype. For that
       case Bar(a: Int)
     }
     
+    @main def example: Unit = {
     (Source.Baz(10): Source)
       .into[Target]
       .withEnumCaseRenamed[Source.Baz, Target.Bar]
       .transform // Target.Bar(10)
+    }
     ```
     
     These methods are only aliases and there is no difference in behavior between `withSealedSubtypeRenamed` and
@@ -2391,7 +2394,7 @@ If the computation needs to allow failure, there is `.withSealedSubtypeHandledPa
 Be default names are matched with a `String` equality - `Subtype` would be considered a match for another `Subtype`
 but not for `SUBTYPE` or any other capitalization.
 
-The subtype name matching predicate can be overrided with a flag:
+The subtype name matching predicate can be overridden with a flag:
 
 !!! example
 
@@ -3435,7 +3438,7 @@ Arguments taken by both `.enableCustomFieldNameComparison` and `.enableCustomSub
 `TransformedNamesComparison`. Out of the box, Chimney provides:
 
  - `TransformedNamesComparison.StrictEquality` - 2 names are considered equal only if they are identical `String`s.
-   This is the default matching strategy for subtype names conparison
+   This is the default matching strategy for subtype names comparison
  - `TransformedNamesComparison.BeanAware` - 2 names are considered equal if they are identical `String`s OR if they are
    identical after you convert them from Java Bean naming convention: 
     - if a name starts with `is`/`get`/`set` prefix (e.g. `isField`, `getField`, `setField`) then
@@ -3445,7 +3448,7 @@ Arguments taken by both `.enableCustomFieldNameComparison` and `.enableCustomSub
  - `TransformedNamesComparison.CaseInsensitiveEquality` - 2 names are considered equal if `equalsIgnoreCase` returns
   `true`
 
-However, these 3 does not exhaust all possible comparisons and you might need to provide one yourself. 
+However, these 3 do not exhaust all possible comparisons and you might need to provide one yourself. 
 
 !!! warning
 
@@ -3460,7 +3463,7 @@ but Chimney has a specific solution for this:
  - your have to define this `object` as top-level definition or within another object - object defined within a `class`,
    a `trait` or locally, does need some logic for instantiation
  - you have to define your `object` in a module/subproject that is compiled _before_ the module where you need to use
-   it, so that the bytecode would already be accesible on the classpath.
+   it, so that the bytecode would already be accessible on the classpath.
 
 !!! example
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -162,7 +162,7 @@ To migrate your code from Lifted Transformers to Partial Transformers, you may t
     - `partial.Result.fromEither`
     - `partial.Result.fromTry`
     - and so on...
-  - the resulting type of a call to `.transform` is also a `partial.Result[A]`. If you don't want to work with
+  - the resulting type of the call to `.transform` is also a `partial.Result[A]`. If you don't want to work with
     `partial.Result` directly, figure out ways to convert it to other, more familiar data structures.
     Some of the ways may include:
     - `result.asOption`
@@ -1377,7 +1377,7 @@ would allow user to fix the data in one go). It calls such transformations `Fall
 
 Chimney uses one blessed error type: `partial.Result[_]`. It used to have a similar approach with `TransformerF`, but it
 was decided that users most of the time used: `Option`s (value absence), `Either[String, _]`s (validation with `String`
-error message),`Try` (or another `Throwable`-based error handling) or non-empty collection of any of these. 
+error message),`Try` (or another `Throwable`-based error handling) or non-empty collection of these. 
 `partial.Result` allows storing errors representing each of these, showing which field produced particular error and
 deciding between error accumulating and fail-fast in runtime. It provides utilities to convert to and from
 `partial.Result`.

--- a/docs/docs/under-the-hood.md
+++ b/docs/docs/under-the-hood.md
@@ -514,7 +514,7 @@ The derivation has a few stages:
  
   - lists of subtypes of both the source type and the target type are made
   - manual overrides are applied
-  - the source type's subtypes that didn't have a manual override are being resolved by macro, matching is done by name
+  - the source type's subtypes that did not have a manual override are being resolved by macro, matching is done by name
   - if no derivation failed, we can combine expressions for each argument into an exhaustive pattern-matching
     - if the transformation is Total (or all expressions are Total), we only need to upcast each result to
       the target type


### PR DESCRIPTION
TODO:

 - [x] `RenameTo` for handling subtype names
 - [x] `withSealedSubtypeRenamed` DSL
 - [x] parsing new config in `Configurations`
 - [x] update SealedToSealed rule 
 - [x] test
   - [x] `TransformerInto` + `TransformerDefinition`
   - [x] `PartialTransformerInto` + `PartialTransformerDefinition`
   - [x] `CodecDefinition`
   - [x] `IsoDefinition`
 - [x] docs
