### PR TITLE
Enable defaults for specific type, allow providing default values for type when absent in constructor

### DIFF
--- a/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufTransformerImplicits.scala
+++ b/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufTransformerImplicits.scala
@@ -6,6 +6,8 @@ import io.scalaland.chimney.Transformer
 import scala.collection.compat._
 // format: on
 
+// FIXME: when we would do some 2.0.0 release, we should align the naming (Protobuf -> Protobufs)
+
 /** @since 0.8.0 */
 trait ProtobufTransformerImplicits extends ProtobufTransformerImplicitsLowPriorityImplicits1 {}
 

--- a/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufsDefaultValuesImplicits.scala
+++ b/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufsDefaultValuesImplicits.scala
@@ -1,0 +1,10 @@
+package io.scalaland.chimney.protobufs
+
+import io.scalaland.chimney.integrations.DefaultValue
+
+/** @since 1.2.0 */
+trait ProtobufsDefaultValuesImplicits {
+
+  implicit val defaultValueForUnknownFieldSet: DefaultValue[scalapb.UnknownFieldSet] =
+    () => scalapb.UnknownFieldSet.empty
+}

--- a/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/package.scala
+++ b/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/package.scala
@@ -1,4 +1,7 @@
 package io.scalaland.chimney
 
 /** @since 0.8.0 */
-package object protobufs extends ProtobufTransformerImplicits with ProtobufsPartialTransformerImplicits
+package object protobufs
+    extends ProtobufsDefaultValuesImplicits
+    with ProtobufTransformerImplicits
+    with ProtobufsPartialTransformerImplicits

--- a/chimney-protobufs/src/test/protobuf/user.proto
+++ b/chimney-protobufs/src/test/protobuf/user.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package io.scalaland.chimney.examples.pb;
+
+import "scalapb/scalapb.proto";
+import "addressbook.proto";
+
+option (scalapb.options) = {
+  no_default_values_in_constructor: true
+  preserve_unknown_fields: true
+};
+
+message User {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+  repeated PhoneNumber phones = 4;
+}

--- a/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufMessageSpec.scala
+++ b/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufMessageSpec.scala
@@ -4,7 +4,7 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl._
 // format: on
 import io.scalaland.chimney.examples.pb
-import io.scalaland.chimney.fixtures.{addressbook, order}
+import io.scalaland.chimney.fixtures.{addressbook, order, user}
 
 class ProtobufMessageSpec extends ChimneySpec {
 
@@ -137,6 +137,25 @@ class ProtobufMessageSpec extends ChimneySpec {
           )
         }
       }
+    }
+
+    test("User") {
+
+      val domainUser = user.User(
+        addressbook.PersonName("Susan"),
+        addressbook.PersonId(321),
+        addressbook.Email("susan@example.com"),
+        List(addressbook.PhoneNumber("200300400", addressbook.MOBILE))
+      )
+
+      val pbUser = pb.user.User(
+        "Susan",
+        321,
+        "susan@example.com",
+        Seq(pb.addressbook.PhoneNumber("200300400", pb.addressbook.PhoneType.MOBILE))
+      )
+
+      domainUser.into[pb.user.User].enableDefaultValueOfType[scalapb.UnknownFieldSet].transform ==> pbUser
     }
   }
 }

--- a/chimney-protobufs/src/test/scala/io/scalaland/chimney/fixtures/user/User.scala
+++ b/chimney-protobufs/src/test/scala/io/scalaland/chimney/fixtures/user/User.scala
@@ -1,0 +1,5 @@
+package io.scalaland.chimney.fixtures.user
+
+import io.scalaland.chimney.fixtures.addressbook.{Email, PersonId, PersonName, PhoneNumber}
+
+case class User(name: PersonName, id: PersonId, email: Email, phones: List[PhoneNumber])

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -209,6 +209,13 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
       }
     }
 
+    object DefaultValue extends DefaultValueModule {
+
+      def provide[Value: Type](
+          defaultValue: Expr[integrations.DefaultValue[Value]]
+      ): Expr[Value] = c.Expr[Value](q"$defaultValue.provide()")
+    }
+
     object OptionalValue extends OptionalValueModule {
 
       def empty[Optional: Type, Value: Type](

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -404,6 +404,12 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       }
     }
 
+    object DefaultValue extends DefaultValueModule {
+      def apply[Value: Type]: Type[integrations.DefaultValue[Value]] =
+        weakTypeTag[integrations.DefaultValue[Value]]
+      def unapply[A](A: Type[A]): Option[??] =
+        A.asCtor[integrations.DefaultValue[?]].map(A0 => A0.param(0))
+    }
     object OptionalValue extends OptionalValueModule {
       def apply[Optional: Type, Value: Type]: Type[integrations.OptionalValue[Optional, Value]] =
         weakTypeTag[integrations.OptionalValue[Optional, Value]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -280,6 +280,12 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           weakTypeTag[runtime.TransformerFlags.MethodAccessors]
         val DefaultValues: Type[runtime.TransformerFlags.DefaultValues] =
           weakTypeTag[runtime.TransformerFlags.DefaultValues]
+        object DefaultValueOfType extends DefaultValueOfTypeModule {
+          def apply[T: Type]: Type[runtime.TransformerFlags.DefaultValueOfType[T]] =
+            weakTypeTag[runtime.TransformerFlags.DefaultValueOfType[T]]
+          def unapply[A](A: Type[A]): Option[??] =
+            A.asCtor[runtime.TransformerFlags.DefaultValueOfType[?]].map(A0 => A0.param(0))
+        }
         val BeanGetters: Type[runtime.TransformerFlags.BeanGetters] =
           weakTypeTag[runtime.TransformerFlags.BeanGetters]
         val BeanSetters: Type[runtime.TransformerFlags.BeanSetters] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -174,7 +174,8 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FromSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -163,7 +163,8 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
     *
     * @see
-    *   [[https://chimney.readthedocs.io/supported-transformations/#TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
+    *   for more details
     *
     * @tparam FromSubtype
     *   type of sealed/enum instance

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -197,6 +197,13 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
         }
     }
 
+    object DefaultValue extends DefaultValueModule {
+
+      def provide[Value: Type](
+          defaultValue: Expr[integrations.DefaultValue[Value]]
+      ): Expr[Value] = '{ ${ defaultValue }.provide() }
+    }
+
     object OptionalValue extends OptionalValueModule {
 
       def empty[Optional: Type, Value: Type](

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -376,6 +376,13 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       }
     }
 
+    object DefaultValue extends DefaultValueModule {
+      def apply[Value: Type]: Type[integrations.DefaultValue[Value]] =
+        quoted.Type.of[integrations.DefaultValue[Value]]
+      def unapply[A](tpe: Type[A]): Option[??] = tpe match
+        case '[integrations.DefaultValue[value]] => Some(Type[value].as_??)
+        case _                                   => scala.None
+    }
     object OptionalValue extends OptionalValueModule {
       def apply[Optional: Type, Value: Type]: Type[integrations.OptionalValue[Optional, Value]] =
         quoted.Type.of[integrations.OptionalValue[Optional, Value]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -239,6 +239,13 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           quoted.Type.of[runtime.TransformerFlags.MethodAccessors]
         val DefaultValues: Type[runtime.TransformerFlags.DefaultValues] =
           quoted.Type.of[runtime.TransformerFlags.DefaultValues]
+        object DefaultValueOfType extends DefaultValueOfTypeModule {
+          def apply[T: Type]: Type[runtime.TransformerFlags.DefaultValueOfType[T]] =
+            quoted.Type.of[runtime.TransformerFlags.DefaultValueOfType[T]]
+          def unapply[A](tpe: Type[A]): Option[??] = tpe match
+            case '[runtime.TransformerFlags.DefaultValueOfType[t]] => Some(Type[t].as_??)
+            case _                                                 => scala.None
+        }
         val BeanGetters: Type[runtime.TransformerFlags.BeanGetters] =
           quoted.Type.of[runtime.TransformerFlags.BeanGetters]
         val BeanSetters: Type[runtime.TransformerFlags.BeanSetters] =

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -63,6 +63,9 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
     *
     * By default in such case derivation will fail. By enabling this flag, derivation will fallback to default value.
     *
+    * This flag can be set in parallel to enabling default values for specific field type with
+    * [[enableDefaultValueOfType]].
+    *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#allowing-fallback-to-the-constructors-default-values]]
     *   for more details
@@ -74,6 +77,9 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Fail derivation if `From` type is missing field even if `To` has default value for it.
     *
+    * This flag can be set in parallel to enabling default values for specific field type with *
+    * [[disableDefaultValueOfType]].
+    *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#allowing-fallback-to-the-constructors-default-values]]
     *   for more details
@@ -82,6 +88,34 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
     */
   def disableDefaultValues: UpdateFlag[Disable[DefaultValues, Flags]] =
     disableFlag[DefaultValues]
+
+  /** Enable fallback to default case class values in `To` type for fields of `T` type.
+    *
+    * By default in such case derivation will fail. By enabling this flag, derivation will fallback to default value.
+    *
+    * This flag can be set in parallel to globally enabling default values with [[enableDefaultValues]].
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#allowing-fallback-to-the-constructors-default-values]]
+    *   for more details
+    *
+    * @since 1.2.0
+    */
+  def enableDefaultValueOfType[T]: UpdateFlag[Enable[DefaultValueOfType[T], Flags]] =
+    enableFlag[DefaultValueOfType[T]]
+
+  /** Fail derivation if `From` type is missing field even if `To` has default value type for fields of `T` type.
+    *
+    * This flag can be set in parallel to globally enabling default values with [[disableDefaultValues]].
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#allowing-fallback-to-the-constructors-default-values]]
+    *   for more details
+    *
+    * @since 1.2.0
+    */
+  def disableDefaultValueOfType[T]: UpdateFlag[Disable[DefaultValueOfType[T], Flags]] =
+    disableFlag[DefaultValueOfType[T]]
 
   /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`.
     *

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/DefaultValue.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/DefaultValue.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.integrations
+
+@FunctionalInterface
+trait DefaultValue[Value] {
+
+  def provide(): Value
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/DefaultValue.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/DefaultValue.scala
@@ -1,7 +1,18 @@
 package io.scalaland.chimney.integrations
 
+/** Tells Chimney how to provide default value of type `Value` if flag allows them but field does not define it.
+  *
+  * @see
+  *   [[https://chimney.readthedocs.io/cookbook/#custom-default-values]] for more details TODO
+  *
+  * @tparam Value
+  *   type of default value
+  *
+  * @since 1.2.0
+  */
 @FunctionalInterface
 trait DefaultValue[Value] {
 
+  /** Provide the default value. */
   def provide(): Value
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/DefaultValue.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/DefaultValue.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.integrations
 /** Tells Chimney how to provide default value of type `Value` if flag allows them but field does not define it.
   *
   * @see
-  *   [[https://chimney.readthedocs.io/cookbook/#custom-default-values]] for more details TODO
+  *   [[https://chimney.readthedocs.io/cookbook/#custom-default-values]] for more details
   *
   * @tparam Value
   *   type of default value

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
@@ -137,6 +137,12 @@ private[compiletime] trait ChimneyExprs { this: ChimneyDefinitions =>
       ): Expr[io.scalaland.chimney.Patcher[A, Patch]]
     }
 
+    val DefaultValue: DefaultValueModule
+    trait DefaultValueModule { this: DefaultValue.type =>
+
+      def provide[Value: Type](defaultValue: Expr[integrations.DefaultValue[Value]]): Expr[Value]
+    }
+
     val OptionalValue: OptionalValueModule
     trait OptionalValueModule { this: OptionalValue.type =>
 
@@ -260,6 +266,13 @@ private[compiletime] trait ChimneyExprs { this: ChimneyDefinitions =>
 
     def patch(obj: Expr[A], patch: Expr[Patch]): Expr[A] =
       ChimneyExpr.Patcher.patch(patcherExpr, obj, patch)
+  }
+
+  implicit final protected class DefaultValueOps[Value: Type](
+      private val defaultValueExpr: Expr[integrations.DefaultValue[Value]]
+  ) {
+
+    def provide(): Expr[Value] = ChimneyExpr.DefaultValue.provide(defaultValueExpr)
   }
 
   implicit final protected class OptionalValueOps[Optional: Type, Value: Type](

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -178,6 +178,11 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
         val InheritedAccessors: Type[runtime.TransformerFlags.InheritedAccessors]
         val MethodAccessors: Type[runtime.TransformerFlags.MethodAccessors]
         val DefaultValues: Type[runtime.TransformerFlags.DefaultValues]
+        val DefaultValueOfType: DefaultValueOfTypeModule
+        trait DefaultValueOfTypeModule
+            extends Type.Ctor1[
+              runtime.TransformerFlags.DefaultValueOfType
+            ] { this: DefaultValueOfType.type => }
         val BeanGetters: Type[runtime.TransformerFlags.BeanGetters]
         val BeanSetters: Type[runtime.TransformerFlags.BeanSetters]
         val BeanSettersIgnoreUnmatched: Type[runtime.TransformerFlags.BeanSettersIgnoreUnmatched]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -288,6 +288,9 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
           ] { this: EveryMapValue.type => }
     }
 
+    val DefaultValue: DefaultValueModule
+    trait DefaultValueModule extends Type.Ctor1[integrations.DefaultValue] { this: DefaultValue.type => }
+
     val OptionalValue: OptionalValueModule
     trait OptionalValueModule extends Type.Ctor2[integrations.OptionalValue] { this: OptionalValue.type =>
       def inferred[Optional: Type]: ExistentialType
@@ -336,6 +339,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
 
       implicit val RuntimeDataStoreType: Type[dsls.TransformerDefinitionCommons.RuntimeDataStore] = RuntimeDataStore
 
+      implicit def DefaultValueType[Value: Type]: Type[integrations.DefaultValue[Value]] = DefaultValue[Value]
       implicit def OptionalValueType[Optional: Type, Value: Type]: Type[integrations.OptionalValue[Optional, Value]] =
         OptionalValue[Optional, Value]
       implicit def PartiallyBuildIterableType[Optional: Type, Value: Type]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/TransformerDerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/TransformerDerivationError.scala
@@ -144,7 +144,7 @@ object TransformerDerivationError {
         val defaultValueHint = prettyFieldList(errors.collect {
           case MissingConstructorArgument(toField, _, _, _, true, _) => s"$MAGENTA$toField$RESET"
         }.sorted) { fields =>
-          s"\n\nThere are default values for $fields in $toType. Consider using $MAGENTA.enableDefaultValues$RESET."
+          s"\n\nThere are default values for $fields in $toType. Consider using $MAGENTA.enableDefaultValues$RESET or $MAGENTA.enableDefaultValueForType$RESET."
         }
 
         val noneValueHint = prettyFieldList(errors.collect {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -62,6 +62,9 @@ private[compiletime] trait Configurations { this: Derivation =>
     def getDefaultValueOfType[A: Type]: Boolean =
       processDefaultValuesOfType.exists(_.Underlying =:= Type[A])
 
+    def isDefaultValueEnabledGloballyOrFor[A: Type]: Boolean =
+      processDefaultValues || getDefaultValueOfType[A]
+
     def setImplicitConflictResolution(preference: Option[ImplicitTransformerPreference]): TransformerFlags =
       copy(implicitConflictResolution = preference)
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
@@ -26,6 +26,10 @@ private[compiletime] trait ImplicitSummoning { this: Derivation =>
       : Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
     Expr.summonImplicit[io.scalaland.chimney.PartialTransformer[From, To]]
 
+  final protected def summonDefaultValue[Value: Type]
+      : Option[Expr[io.scalaland.chimney.integrations.DefaultValue[Value]]] =
+    Expr.summonImplicit[io.scalaland.chimney.integrations.DefaultValue[Value]]
+
   final protected type OptionalValueExpr[Optional, Value] =
     Expr[io.scalaland.chimney.integrations.OptionalValue[Optional, Value]]
   final protected def summonOptionalValue[Optional: Type]: Option[Existential[OptionalValueExpr[Optional, *]]] = {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -116,7 +116,9 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
                         }
                       )
                     case _ =>
-                      DerivationResult.assertionError("TODO")
+                      // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
+                      DerivationResult.assertionError(s"Unexpected path: $targetPath")
+                    // $COVERAGE-ON$
                   })
               }
             }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
@@ -12,6 +12,7 @@ object TransformerFlags {
   final class InheritedAccessors extends Flag
   final class MethodAccessors extends Flag
   final class DefaultValues extends Flag
+  final class DefaultValueOfType[T] extends Flag
   final class BeanSetters extends Flag
   final class BeanSettersIgnoreUnmatched extends Flag
   final class NonUnitBeanSetters extends Flag

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -541,6 +541,23 @@ class TotalTransformerProductSpec extends ChimneySpec {
         "There are default values for x, y, constructor arguments/setters in io.scalaland.chimney.fixtures.products.Defaults.Target. Consider using .enableDefaultValues or .enableDefaultValueForType.",
         "Consult https://chimney.readthedocs.io for usage examples."
       )
+
+      import products.Renames.*
+      @unused implicit val defaultInt: integrations.DefaultValue[Int] = () => 0
+
+      compileErrors("""User(1, "Adam", None).transformInto[User2ID]""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Renames.User to io.scalaland.chimney.fixtures.products.Renames.User2ID",
+        "io.scalaland.chimney.fixtures.products.Renames.User2ID",
+        "extraID: scala.Int - no accessor named extraID in source type io.scalaland.chimney.fixtures.products.Renames.User",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
+
+      compileErrors("""User(1, "Adam", None).into[User2ID].transform""").check(
+        "Chimney can't derive transformation from io.scalaland.chimney.fixtures.products.Renames.User to io.scalaland.chimney.fixtures.products.Renames.User2ID",
+        "io.scalaland.chimney.fixtures.products.Renames.User2ID",
+        "extraID: scala.Int - no accessor named extraID in source type io.scalaland.chimney.fixtures.products.Renames.User",
+        "Consult https://chimney.readthedocs.io for usage examples."
+      )
     }
 
     test("should not be needed if all target fields with default values have their values provided in other way") {
@@ -644,6 +661,21 @@ class TotalTransformerProductSpec extends ChimneySpec {
 
         Source(1, "yy", 1.0).transformInto[Target2] ==> Target2(1L, "yy", 1.0)
         Source(1, "yy", 1.0).into[Target2].transform ==> Target2(1L, "yy", 1.0)
+      }
+    }
+
+    test("should use default value provided with DefaultValue[A] when the constructor is missing one") {
+      import products.Renames.*
+
+      implicit val defaultInt: integrations.DefaultValue[Int] = () => 0
+
+      User(1, "Adam", None).into[User2ID].enableDefaultValues.transform ==> User2ID(1, "Adam", None, 0)
+
+      locally {
+        implicit val config = TransformerConfiguration.default.enableDefaultValues
+
+        User(1, "Adam", None).transformInto[User2ID] ==> User2ID(1, "Adam", None, 0)
+        User(1, "Adam", None).into[User2ID].transform ==> User2ID(1, "Adam", None, 0)
       }
     }
   }
@@ -803,6 +835,21 @@ class TotalTransformerProductSpec extends ChimneySpec {
 
         Source(1, "yy", 1.0).transformInto[Target2] ==> Target2(1L, "yy", 1.0)
         Source(1, "yy", 1.0).into[Target2].transform ==> Target2(1L, "yy", 1.0)
+      }
+    }
+
+    test("should use default value provided with DefaultValue[A] when the constructor is missing one") {
+      import products.Renames.*
+
+      implicit val defaultInt: integrations.DefaultValue[Int] = () => 0
+
+      User(1, "Adam", None).into[User2ID].enableDefaultValueOfType[Int].transform ==> User2ID(1, "Adam", None, 0)
+
+      locally {
+        implicit val config = TransformerConfiguration.default.enableDefaultValueOfType[Int]
+
+        User(1, "Adam", None).transformInto[User2ID] ==> User2ID(1, "Adam", None, 0)
+        User(1, "Adam", None).into[User2ID].transform ==> User2ID(1, "Adam", None, 0)
       }
     }
   }

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -1001,11 +1001,30 @@ If the flag was enabled in the implicit config it can be disabled with `.disable
     // Target
     //   c: scala.Long - no accessor named c in source type Source
     //
-    // There are default values for c, the constructor argument/setter in Target. Consider using .enableDefaultValues.
+    // There are default values for c, the constructor argument/setter in Target. Consider using .enableDefaultValues or .enableDefaultValueForType.
     //
     // Consult https://chimney.readthedocs.io for usage examples.
     ```
 
+If enabling global values globally, seems too dangerous, you can also limit the scope of their usage, by enabling only
+default values of one particular type:
+
+!!! example
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    import io.scalaland.chimney.dsl._
+
+    case class Source(a: String, b: Int)
+    case class Target(a: String, b: Int = 0, c: Long = 0L)
+
+    Source("value", 128).into[Target].enableDefaultValueOfType[Long].transform
+    // val source = Source("value", 128)
+    // Target(source.a, source.b /* c is filled by the default value */)
+    Source("value", 128).intoPartial[Target].enableDefaultValueOfType[Long].transform
+    // val source = Source("value", 128)
+    // partial.Result.fromValue(Target(source.a, source.b /* c is filled by the default value */))
+    ```
 
 ### Allowing fallback to `None` as the constructor's argument
 
@@ -1099,7 +1118,7 @@ If the flag was enabled in the implicit config it can be disabled with `.disable
     // Bar
     //   b: scala.Option[java.lang.String] - no accessor named b in source type Foo
     //
-    // There are default values for b, the constructor argument/setter in Bar. Consider using .enableDefaultValues.
+    // There are default values for b, the constructor argument/setter in Bar. Consider using .enableDefaultValues or .enableDefaultValueForType.
     //
     // There are default optional values available for b, the constructor argument/setter in Bar. Consider using .enableOptionDefaultsToNone.
     //


### PR DESCRIPTION
TODO:

 - [x] define `trait DefaultValue[A]`
   - [x] provide summoning in internals
 - [x] define flag `DefaultValueOfType[A]`
   - [x] parse config in internals
   - [x] allow setting it with DLS
 - [x] use flag and type class in `ProductToPoduct` rule
 - [x] provide `DefaultValue` for `UnknownFieldSet`
 - [x] tests
   - [x] `defaultValueOfType[A]` tests
   - [x] `DefaultValue[A]` tests
   - [x] `DefaultValue[UnknownFieldSet]` tests
 - [x] docs
   - [x] providing custom default values (when constructor is missing them)
   - [x] Protobufs and `UnknownFieldSet`
   - [x] Scaladoc