### PR TITLE
Better singleton types support

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -11,7 +11,12 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     val Null: Expr[Null] = c.Expr[Null](q"null")
     val Unit: Expr[Unit] = c.Expr[Unit](q"()")
 
+    def Boolean(value: Boolean): Expr[Boolean] = c.Expr[Boolean](q"$value")
     def Int(value: Int): Expr[Int] = c.Expr[Int](q"$value")
+    def Long(value: Long): Expr[Long] = c.Expr[Long](q"$value")
+    def Float(value: Float): Expr[Float] = c.Expr[Float](q"$value")
+    def Double(value: Double): Expr[Double] = c.Expr[Double](q"$value")
+    def Char(value: Char): Expr[Char] = c.Expr[Char](q"$value")
     def String(value: String): Expr[String] = c.Expr[String](q"$value")
 
     def Tuple2[A: Type, B: Type](a: Expr[A], b: Expr[B]): Expr[(A, B)] = c.Expr[(A, B)](q"($a, $b)")

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -57,6 +57,25 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
       // everyone has the same baseClasses, everyone reports to have public primaryConstructor (which is <none>).
       // The only different in behavior is that one prints com.my.Enum and another com.my.Enum(MyValue).
       val javaEnumRegexpFormat = raw"^(.+)\((.+)\)$$".r
+
+      abstract class LiteralImpl[U: Type] extends Literal[U] {
+        def apply[A <: U](value: A): Type[A] =
+          // fromUntyped(c.universe.internal.UniqueConstantType(Constant(value.asInstanceOf[AnyVal])))
+          fromUntyped(c.universe.internal.constantType(Constant(value.asInstanceOf[AnyVal])))
+        def unapply[A](A: Type[A]): Option[Existential.UpperBounded[U, Id]] =
+          if (A <:< Type[U]) {
+            scala.util
+              .Try(
+                A.tpe
+                  .asInstanceOf[scala.reflect.internal.Types#UniqueConstantType]
+                  .value // Constant
+                  .value // scala.Any
+                  .asInstanceOf[U]
+              )
+              .toOption
+              .map(Existential.UpperBounded[U, Id, U](_))
+          } else None
+      }
     }
 
     import platformSpecific.*
@@ -130,6 +149,16 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
     }
 
     def Factory[A: Type, C: Type]: Type[Factory[A, C]] = weakTypeTag[Factory[A, C]]
+
+    import platformSpecific.LiteralImpl
+
+    object BooleanLiteral extends LiteralImpl[Boolean] with BooleanLiteralModule
+    object IntLiteral extends LiteralImpl[Int] with IntLiteralModule
+    object LongLiteral extends LiteralImpl[Long] with LongLiteralModule
+    object FloatLiteral extends LiteralImpl[Float] with FloatLiteralModule
+    object DoubleLiteral extends LiteralImpl[Double] with DoubleLiteralModule
+    object CharLiteral extends LiteralImpl[Char] with CharLiteralModule
+    object StringLiteral extends LiteralImpl[String] with StringLiteralModule
 
     def extractStringSingleton[S <: String](S: Type[S]): String = scala.util
       .Try(

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -22,7 +22,12 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     val Null: Expr[Null] = '{ null }
     val Unit: Expr[Unit] = '{ () }
 
+    def Boolean(value: Boolean): Expr[Boolean] = scala.quoted.Expr(value)
     def Int(value: Int): Expr[Int] = scala.quoted.Expr(value)
+    def Long(value: Long): Expr[Long] = scala.quoted.Expr(value)
+    def Float(value: Float): Expr[Float] = scala.quoted.Expr(value)
+    def Double(value: Double): Expr[Double] = scala.quoted.Expr(value)
+    def Char(value: Char): Expr[Char] = scala.quoted.Expr(value)
     def String(value: String): Expr[String] = scala.quoted.Expr(value)
 
     def Tuple2[A: Type, B: Type](a: Expr[A], b: Expr[B]): Expr[(A, B)] = '{ (${ a }, ${ b }) }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -87,6 +87,17 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
           case _ =>
             fromUntyped[A](subtype.typeRef).as_?<[A]
         }
+
+      abstract class LiteralImpl[U: Type](lift: U => Constant) extends Literal[U] {
+        final def apply[A <: U](value: A): Type[A] =
+          ConstantType(lift(value)).asType.asInstanceOf[Type[A]]
+        final def unapply[A](A: Type[A]): Option[Existential.UpperBounded[U, Id]] =
+          if A <:< Type[U] then
+            quoted.Type
+              .valueOfConstant[U](using A.asInstanceOf[Type[U]])
+              .map(Existential.UpperBounded[U, Id, U](_))
+          else None
+      }
     }
 
     val Nothing: Type[Nothing] = quoted.Type.of[Nothing]
@@ -212,6 +223,16 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
     }
 
     def Factory[A: Type, C: Type]: Type[Factory[A, C]] = quoted.Type.of[Factory[A, C]]
+
+    import platformSpecific.LiteralImpl
+
+    object BooleanLiteral extends LiteralImpl[Boolean](BooleanConstant(_)) with BooleanLiteralModule
+    object IntLiteral extends LiteralImpl[Int](IntConstant(_)) with IntLiteralModule
+    object LongLiteral extends LiteralImpl[Long](LongConstant(_)) with LongLiteralModule
+    object FloatLiteral extends LiteralImpl[Float](FloatConstant(_)) with FloatLiteralModule
+    object DoubleLiteral extends LiteralImpl[Double](DoubleConstant(_)) with DoubleLiteralModule
+    object CharLiteral extends LiteralImpl[Char](CharConstant(_)) with CharLiteralModule
+    object StringLiteral extends LiteralImpl[String](StringConstant(_)) with StringLiteralModule
 
     def extractStringSingleton[S <: String](S: Type[S]): String = quoted.Type.valueOfConstant[S](using S) match {
       case Some(str) => str

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Existentials.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Existentials.scala
@@ -86,6 +86,9 @@ private[compiletime] trait Existentials { this: Types with Exprs =>
     type Underlying = A
   }
 
+  /** Convenient for literal singletons */
+  type Id[A] = A
+
   // aliases to make the (very common) existential types shorter
 
   type ?? = ExistentialType

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -13,7 +13,13 @@ private[compiletime] trait Exprs { this: Definitions =>
     val Null: Expr[Null]
     val Unit: Expr[Unit]
 
+    // FIXME: if we were ever doing 2.0 this would be following the pattern with apply, unapply and [A <: Type]: Expr[A]
+    def Boolean(value: Boolean): Expr[Boolean]
     def Int(value: Int): Expr[Int]
+    def Long(value: Long): Expr[Long]
+    def Float(value: Float): Expr[Float]
+    def Double(value: Double): Expr[Double]
+    def Char(value: Char): Expr[Char]
     def String(value: String): Expr[String]
 
     def Tuple2[A: Type, B: Type](a: Expr[A], b: Expr[B]): Expr[(A, B)]

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
@@ -105,6 +105,32 @@ private[compiletime] trait Types { this: Existentials =>
 
     def Factory[A: Type, C: Type]: Type[Factory[A, C]]
 
+    trait Literal[U] {
+      def apply[A <: U](value: A): Type[A]
+      def unapply[A](A: Type[A]): Option[Existential.UpperBounded[U, Id]]
+    }
+
+    val BooleanLiteral: BooleanLiteralModule
+    trait BooleanLiteralModule extends Literal[Boolean] { this: BooleanLiteral.type => }
+
+    val IntLiteral: IntLiteralModule
+    trait IntLiteralModule extends Literal[Int] { this: IntLiteral.type => }
+
+    val LongLiteral: LongLiteralModule
+    trait LongLiteralModule extends Literal[Long] { this: LongLiteral.type => }
+
+    val FloatLiteral: FloatLiteralModule
+    trait FloatLiteralModule extends Literal[Float] { this: FloatLiteral.type => }
+
+    val DoubleLiteral: DoubleLiteralModule
+    trait DoubleLiteralModule extends Literal[Double] { this: DoubleLiteral.type => }
+
+    val CharLiteral: CharLiteralModule
+    trait CharLiteralModule extends Literal[Char] { this: CharLiteral.type => }
+
+    val StringLiteral: StringLiteralModule
+    trait StringLiteralModule extends Literal[String] { this: StringLiteral.type => }
+
     // You can `import Type.Implicits.*` in your shared code to avoid providing types manually, while avoiding conflicts
     // with implicit types seen in platform-specific scopes (which would happen if those implicits were always used).
     object Implicits {


### PR DESCRIPTION
TODO:

 - [ ] utilities for literal singletons (`Boolean`, `Int`, `Long`, `Float`, `Double`, `Char`, `String`)
 - [ ] `Singleton` datatype aggregating: literal singletons, `()`, `null`, `.type` and `object`s
 - [ ] rule transforming into Singleton type
 - [ ] fallback on Singleton type (instead of just `Unit`, excluding `None` - document why)
 - [ ] tests
 - [ ] docs