### PR TITLE
Add checks ensuring that typeSymbol is initialized in Scala 2, add <init> symbols to the list of possible default values

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -144,7 +144,11 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
           .value
           .asInstanceOf[String]
       )
-      .getOrElse(assertionFailed(s"Invalid string literal type: ${prettyPrint(S)}"))
+      .getOrElse {
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
+        assertionFailed(s"Invalid string literal type: ${prettyPrint(S)}")
+        // $COVERAGE-ON$
+      }
 
     def isTuple[A](A: Type[A]): Boolean = A.tpe.typeSymbol.fullName.startsWith("scala.Tuple")
 

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -29,7 +29,7 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
 
       /** Applies type arguments from supertype to subtype if there are any */
       def subtypeTypeOf[A: Type](subtype: TypeSymbol): ?<[A] = {
-        subtype.typeSignature // Workaround for <https://issues.scala-lang.org/browse/SI-7755>
+        forceTypeSymbolInitialization(subtype)
 
         val sEta = subtype.toType.etaExpand
         fromUntyped[A](
@@ -57,6 +57,11 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
       // everyone has the same baseClasses, everyone reports to have public primaryConstructor (which is <none>).
       // The only different in behavior is that one prints com.my.Enum and another com.my.Enum(MyValue).
       val javaEnumRegexpFormat = raw"^(.+)\((.+)\)$$".r
+
+      // Workaround for <https://issues.scala-lang.org/browse/SI-7755>
+      // and <https://github.com/scalalandio/chimney/issues/562> and similar
+      def forceTypeSymbolInitialization[A: Type]: Unit = forceTypeSymbolInitialization(Type[A].tpe.typeSymbol)
+      def forceTypeSymbolInitialization(s: Symbol): Unit = s.typeSignature
     }
 
     import platformSpecific.*

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -29,6 +29,7 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
         .toList
 
     private def extractSealedSubtypes[A: Type]: List[(String, ?<[A])] = {
+      forceTypeSymbolInitialization[A]
 
       def extractRecursively(t: TypeSymbol): List[TypeSymbol] =
         if (t.asClass.isSealed) t.asClass.knownDirectSubclasses.toList.map(_.asType).flatMap(extractRecursively)

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -13,6 +13,7 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
 
     def parse[A: Type]: Option[Existential[WrapperClass[A, *]]] = {
       val A = Type[A].tpe
+      forceTypeSymbolInitialization[A]
 
       val getterOpt: Option[Symbol] = A.decls.to(List).find(m => m.isPublic && m.isMethod && m.asMethod.isGetter)
       val primaryConstructorOpt: Option[Symbol] = Option(A.typeSymbol)

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -62,9 +62,11 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
             typeArgumentByName
           // unknown
           case out =>
+            // $COVERAGE-OFF$should never happen unless we messed up
             assertionFailed(
               s"Constructor of ${Type.prettyPrint(fromUntyped[Any](tpe))} has unrecognized/unsupported format of type: $out"
             )
+          // $COVERAGE-ON$
         }
 
       /** Applies type arguments from supertype to subtype if there are any */
@@ -215,7 +217,10 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
 
     def extractStringSingleton[S <: String](S: Type[S]): String = quoted.Type.valueOfConstant[S](using S) match {
       case Some(str) => str
-      case None      => assertionFailed(s"Invalid string literal type: ${prettyPrint(S)}")
+      case None      =>
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
+        assertionFailed(s"Invalid string literal type: ${prettyPrint(S)}")
+      // $COVERAGE-ON$
     }
 
     def isTuple[A](A: Type[A]): Boolean = TypeRepr.of(using A).typeSymbol.fullName.startsWith("scala.Tuple")

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -143,7 +143,9 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
         val primaryConstructor =
           Option(sym.primaryConstructor).filter(_.isPublic).getOrElse {
+            // $COVERAGE-OFF$should never happen unless we messed up
             assertionFailed(s"Expected public constructor of ${Type.prettyPrint[A]}")
+            // $COVERAGE-ON$
           }
         val paramss = paramListsOf(A, primaryConstructor)
         val paramNames = paramss.flatMap(_.map(param => param -> param.name)).toMap
@@ -155,9 +157,11 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
             val scala3default = caseClassApplyDefaultScala3(idx + 1)
             val default =
               (mod.declaredMethod(scala2default) ++ mod.declaredMethod(scala3default)).headOption.getOrElse {
+                // $COVERAGE-OFF$should never happen unless we messed up
                 assertionFailed(
                   s"Expected that ${Type.prettyPrint[A]}'s constructor parameter `$param` would have default value: attempted `$scala2default` and `$scala3default`, found: ${mod.declaredMethods}"
                 )
+                // $COVERAGE-ON$
               }
             paramNames(param) -> Ref(mod).select(default)
         }.toMap
@@ -262,7 +266,9 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
           val fnType = fnTypeByArity.getOrElse(
             paramList.size,
             // TODO: handle FunctionXXL
+            // $COVERAGE-OFF$should never happen unless we messed up
             assertionFailed(s"Expected arity between 0 and 22 into ${Type.prettyPrint[A]}, got: ${paramList.size}")
+            // $COVERAGE-ON$
           )
           val paramTypes = paramList.view.values.map(p => TypeRepr.of(using p.Underlying)).toVector
 

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -115,7 +115,9 @@ private[compiletime] trait Exprs { this: Definitions =>
 
     def summonImplicit[A: Type]: Option[Expr[A]]
     def summonImplicitUnsafe[A: Type]: Expr[A] = summonImplicit[A].getOrElse {
+      // $COVERAGE-OFF$should never happen unless we messed up
       assertionFailed(s"Implicit not found: ${Type.prettyPrint[A]}")
+      // $COVERAGE-ON$
     }
 
     // Implementations of Expr extension methods

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -114,6 +114,7 @@ trait ProductTypes { this: Definitions =>
     def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A]
 
     // defaults methods are 1-indexed
+    protected def classNewDefaultScala2(idx: Int): String = "<init>>$default$" + idx
     protected def caseClassApplyDefaultScala2(idx: Int): String = "apply$default$" + idx
     protected def caseClassApplyDefaultScala3(idx: Int): String = "$lessinit$greater$default$" + idx
 

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -114,7 +114,7 @@ trait ProductTypes { this: Definitions =>
     def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A]
 
     // defaults methods are 1-indexed
-    protected def classNewDefaultScala2(idx: Int): String = "<init>>$default$" + idx
+    protected def classNewDefaultScala2(idx: Int): String = "<init>$default$" + idx
     protected def caseClassApplyDefaultScala2(idx: Int): String = "apply$default$" + idx
     protected def caseClassApplyDefaultScala3(idx: Int): String = "$lessinit$greater$default$" + idx
 

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -128,11 +128,13 @@ trait ProductTypes { this: Definitions =>
     ): (Product.Arguments, Product.Arguments) = {
       val missingArguments = parameters.filter(settersCanBeIgnored).keySet diff arguments.keySet
       if (missingArguments.nonEmpty) {
+        // $COVERAGE-OFF$should never happen unless we messed up
         val missing = missingArguments.mkString(", ")
         val provided = arguments.keys.mkString(", ")
         assertionFailed(
           s"Constructor of ${Type.prettyPrint[A]} expected arguments: $missing but they were not provided, what was provided: $provided"
         )
+        // $COVERAGE-ON$
       }
 
       parameters.foreach { case (name, param) =>
@@ -140,10 +142,12 @@ trait ProductTypes { this: Definitions =>
         // setter might be absent, so we cannot assume that argument for it is in a map
         arguments.get(name).foreach { argument =>
           if (!(argument.Underlying <:< Param)) {
+            // $COVERAGE-OFF$should never happen unless we messed up
             assertionFailed(
               s"Constructor of ${Type.prettyPrint[A]} expected expr for parameter $param of type ${Type
                   .prettyPrint[param.Underlying]}, instead got ${Expr.prettyPrint(argument.value)} ${Type.prettyPrint(argument.Underlying)}"
             )
+            // $COVERAGE-ON$
           }
         }
       }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -102,7 +102,7 @@ final class CodecMacros(val c: blackbox.Context) extends DerivationPlatform with
         )
 
       Expr.summonImplicit(transformerConfigurationType).getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit TransformerConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -102,7 +102,7 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
         )
 
       Expr.summonImplicit(transformerConfigurationType).getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit TransformerConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -79,7 +79,7 @@ final class PatcherMacros(val c: blackbox.Context) extends DerivationPlatform wi
         )
 
       Expr.summonImplicit(patcherConfigurationType).getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit PatcherConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -175,7 +175,7 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
         )
 
       Expr.summonImplicit(transformerConfigurationType).getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit TransformerConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -74,7 +74,7 @@ final class CodecMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
     val implicitScopeConfig = scala.quoted.Expr
       .summon[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]]
       .getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit TransformerConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -74,7 +74,7 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
     val implicitScopeConfig = scala.quoted.Expr
       .summon[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]]
       .getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit TransformerConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -35,7 +35,7 @@ final class PatcherMacros(q: Quotes) extends DerivationPlatform(q) with Gateway 
     val implicitScopeConfig = scala.quoted.Expr
       .summon[io.scalaland.chimney.dsl.PatcherConfiguration[? <: runtime.PatcherFlags]]
       .getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit PatcherConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -75,7 +75,7 @@ final class TransformerMacros(q: Quotes) extends DerivationPlatform(q) with Gate
     val implicitScopeConfig = scala.quoted.Expr
       .summon[io.scalaland.chimney.dsl.TransformerConfiguration[? <: runtime.TransformerFlags]]
       .getOrElse {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError("Can't locate implicit TransformerConfiguration!")
         // $COVERAGE-ON$
       }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
@@ -18,7 +18,7 @@ private[compiletime] trait Configurations { this: Derivation =>
       } else if (Type[Flag] =:= ChimneyType.PatcherFlags.Flags.MacrosLogging) {
         copy(displayMacrosLogging = value)
       } else {
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError(s"Invalid internal PatcherFlags type shape: ${Type[Flag]}!")
         // $COVERAGE-ON$
       }
@@ -79,7 +79,7 @@ private[compiletime] trait Configurations { this: Derivation =>
           import flag.Underlying as Flag, flags.Underlying as Flags2
           extractTransformerFlags[Flags2](defaultFlags).setBoolFlag[Flag](value = false)
         case _ =>
-          // $COVERAGE-OFF$
+          // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
           reportError(s"Invalid internal PatcherFlags type shape: ${Type.prettyPrint[Flags]}!")
         // $COVERAGE-ON$
       }
@@ -87,8 +87,10 @@ private[compiletime] trait Configurations { this: Derivation =>
     private def extractPatcherConfig[Tail <: runtime.PatcherOverrides: Type](): PatcherConfiguration =
       Type[Tail] match {
         case empty if empty =:= ChimneyType.PatcherOverrides.Empty => PatcherConfiguration()
-        case _ =>
+        case _                                                     =>
+          // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
           reportError(s"Invalid internal PatcherOverrides type shape: ${Type.prettyPrint[Tail]}!!")
+        // $COVERAGE-ON$
       }
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
@@ -105,9 +105,11 @@ private[compiletime] trait Derivation
                   )
                 }
             case _ =>
+              // $COVERAGE-OFF$should never happen unless we messed up
               assertionFailed(
                 s"Expected both types to be options, got ${Type.prettyPrint[PatchGetter]} and ${Type.prettyPrint[TargetParam]}"
               )
+            // $COVERAGE-ON$
           }
         } else if (PatchGetter <:< TargetParam) {
           DerivationResult.pure(Some(patchGetterExpr))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -384,7 +384,7 @@ private[compiletime] trait Configurations { this: Derivation =>
                 Some(dsls.PreferPartialTransformer)
               )
             else {
-              // $COVERAGE-OFF$
+              // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
               reportError("Invalid ImplicitTransformerPreference type!!")
               // $COVERAGE-ON$
             }
@@ -417,7 +417,7 @@ private[compiletime] trait Configurations { this: Derivation =>
             extractTransformerFlags[Flags2](defaultFlags).setBoolFlag[Flag](value = false)
         }
       case _ =>
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError(s"Invalid internal TransformerFlags type shape: ${Type.prettyPrint[Flags]}!")
       // $COVERAGE-ON$
     }
@@ -498,7 +498,7 @@ private[compiletime] trait Configurations { this: Derivation =>
             TransformerOverride.RenamedTo(extractPath[ToPath])
           )
       case _ =>
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError(s"Invalid internal TransformerOverrides type shape: ${Type.prettyPrint[Tail]}!!")
       // $COVERAGE-ON$
     }
@@ -525,7 +525,7 @@ private[compiletime] trait Configurations { this: Derivation =>
         import init.Underlying as PathType2
         extractPath[PathType2].everyMapValue
       case _ =>
-        // $COVERAGE-OFF$
+        // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
         reportError(s"Invalid internal Path shape: ${Type.prettyPrint[PathType]}!!")
       // $COVERAGE-ON$
     }
@@ -553,7 +553,7 @@ private[compiletime] trait Configurations { this: Derivation =>
         .reverse // ...and this is: "foo.bar.baz$", "foo.bar$baz$", "foo$bar$baz$"
         .collectFirst { case Comparison(value) => value } // attempts: top-level object, object in object, etc
         .getOrElse {
-          // $COVERAGE-OFF$
+          // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
           reportError(
             s"Invalid TransformerNamesComparison type - only (case) objects are allowed, and only the ones defined as top-level or in top-level objects, got: ${Type
                 .prettyPrint[Comparison]}!!!"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -516,7 +516,9 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
           import res1.{Underlying as Res1, value as result1Expr}, res2.{Underlying as Res2, value as result2Expr}
           ctx match {
             case TransformationContext.ForTotal(_) =>
+              // $COVERAGE-OFF$should never happen unless we messed up
               assertionFailed("Expected partial while got total")
+            // $COVERAGE-ON$
             case TransformationContext.ForPartial(_, failFast) =>
               TransformationExpr.fromPartial(
                 ChimneyExpr.PartialResult.map2(
@@ -667,7 +669,9 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
 
                 ctx match {
                   case TransformationContext.ForTotal(_) =>
+                    // $COVERAGE-OFF$should never happen unless we messed up
                     assertionFailed("Expected partial, got total")
+                  // $COVERAGE-ON$
                   case TransformationContext.ForPartial(_, failFast) =>
                     // Finally, we are combining:
                     // if (${ failFast }) {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformationRules.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformationRules.scala
@@ -103,9 +103,11 @@ private[compiletime] trait TransformationRules { this: Derivation =>
     final def isPartial: Boolean = fold(_ => false)(_ => true)
 
     final def ensureTotal: Expr[A] = fold(identity) { expr =>
+      // $COVERAGE-OFF$should never happen unless we messed up
       assertionFailed(
         s"Derived partial.Result expression where total Transformer expects direct value: ${Expr.prettyPrint(expr)}"
       )
+      // $COVERAGE-ON$
     }
     final def ensurePartial: Expr[partial.Result[A]] = fold { expr =>
       implicit val A: Type[A] = Expr.typeOf(expr)

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -1090,6 +1090,18 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result.asOption ==> Some(expected)
       result.asEither ==> Right(expected)
       result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val expected2 = new Target3(30L, "yy2", 1.0)
+
+      val result2 = Source(1, "yy", 1.0)
+        .intoPartial[Target3]
+        .withFieldConst(_.xx, 30L)
+        .withFieldComputed(_.yy, _.yy + "2")
+        .transform
+
+      result2.asOption ==> Some(expected2)
+      result2.asEither ==> Right(expected2)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
     }
 
     test("should enable using default values when no source value can be resolved in flat transformation") {

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -568,6 +568,13 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .withFieldConst(_.x, 30)
         .withFieldComputed(_.y, _.yy + "2")
         .transform ==> Target(30, "yy2", 1.0)
+
+      Source(1, "yy", 1.0)
+        .into[Target3]
+        .withFieldConst(_.xx, 30L)
+        .withFieldComputed(_.yy, _.yy + "2")
+        .withFieldConst(_.z, 1.0)
+        .transform ==> new Target3(30L, "yy2", 1.0)
     }
 
     test("should enable using default values when no source value can be resolved in flat transformation") {

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/products/products.scala
@@ -65,7 +65,14 @@ object Defaults {
 
   case class Source(xx: Int, yy: String, z: Double)
   case class Target(x: Int = 10, y: String = "y", z: Double)
-  case class Target2(xx: Long = 10, yy: String = "y", z: Double)
+  case class Target2(xx: Long = 10L, yy: String = "y", z: Double)
+  class Target3(val xx: Long = 10L, val yy: String = "y", val z: Double) {
+    override def toString: String = s"Target3($xx, $yy, $z)"
+    override def equals(obj: Any): Boolean = obj match {
+      case another: Target3 => xx == another.xx && yy == another.yy && z == another.z
+      case _                => false
+    }
+  }
 
   case class Nested[A](value: A)
 }


### PR DESCRIPTION
Scala 2: add `<init>$default$n` to potential default methods, run `tpe.typeSymbol.typeSignature` just in case more often on.