### PR TITLE
Support derivation to non-sealed trait

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -16,11 +16,9 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
       (Type[From], Type[To]) match {
         case (SealedHierarchy(Enum(fromElements)), SealedHierarchy(Enum(toElements))) =>
           mapEachSealedElementToAnotherSealedElement(fromElements, toElements)
-        case (SealedHierarchy(_), _) =>
-          DerivationResult.attemptNextRuleBecause(
-            s"Type ${Type.prettyPrint[From]} is a sealed/enum type but ${Type.prettyPrint[To]} is not"
-          )
-        case (_, SealedHierarchy(_)) =>
+        case (SealedHierarchy(Enum(fromElements)), _) if !ctx.config.areOverridesEmpty =>
+          mapEachSealedElementToAnotherSealedElement(fromElements, List.empty)
+        case (SealedHierarchy(Enum(fromElements)), _) =>
           DerivationResult.attemptNextRuleBecause(
             s"Type ${Type.prettyPrint[To]} is a sealed/enum type but ${Type.prettyPrint[From]} is not"
           )

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -760,4 +760,14 @@ class IssuesSpec extends ChimneySpec {
     import Issue498.*
     (Foo.Sub1("test"): Foo).into[Bar].withFieldConst(_.b, 1).transform ==> Bar.Sub1("test", 1)
   }
+
+  test("support non-sealed trait destination") {
+    (colors1.Green: colors1.Color)
+      .into[String]
+      .withSealedSubtypeHandled[colors1.Red.type](_ => "red")
+      .withSealedSubtypeHandled[colors1.Green.type](_ => "green")
+      .withSealedSubtypeHandled[colors1.Blue.type](_ => "blue")
+      .transform ==> "green"
+
+  }
 }


### PR DESCRIPTION
allow derivation to non-sealed trait, but require runtime that some runtime overrides exists to evaluate the rule