### PR TITLE
Test output in docs using pprint

### DIFF
--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -538,7 +538,7 @@ explanation:
 !!! example
 
     ```scala
-    //> using dep org.typelevel::cats-core::2.10.0
+    //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import cats.syntax.all._
@@ -568,7 +568,7 @@ Similarly, there exists instances for `PartialTransformer` and `partial.Result`:
 !!! example
 
     ```scala
-    //> using dep org.typelevel::cats-core::2.10.0
+    //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import cats.syntax.all._
@@ -658,7 +658,7 @@ What does it mean to us?
        but to NOT disable parallel semantics for some transformations when we would pass `failFast = false` later on
     
     ```scala
-    //> using dep org.typelevel::cats-core::2.10.0
+    //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import cats.syntax.all._
@@ -687,7 +687,7 @@ What does it mean to us?
     And `partial.Result`s have to use explicit combinators to decide whether it's sequential or parallel semantics:
 
     ```scala
-    //> using dep org.typelevel::cats-core::2.10.0
+    //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import cats.syntax.all._

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -76,9 +76,10 @@ From now on, forget about it! Encoding domain object with an infallible transfor
     ```scala
     // file: conversion.sc - part of the demo
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import io.scalaland.chimney.dsl._
 
-    println(
+    pprint.pprintln(
       User(
         Username("John"),
         List(Address("Paper St", "Somewhere")),
@@ -86,7 +87,11 @@ From now on, forget about it! Encoding domain object with an infallible transfor
       ).transformInto[UserDTO]
     )
     // expected output:
-    // UserDTO(John,List(AddressDTO(Paper St,Somewhere)),Some(Email(EmailDTO(john@example.com))))
+    // UserDTO(
+    //   name = "John",
+    //   addresses = List(AddressDTO(street = "Paper St", city = "Somewhere")),
+    //   recovery = Some(value = Email(value = EmailDTO(email = "john@example.com")))
+    // )
     ```
 
 ??? example "Curious about the generated code?"
@@ -127,9 +132,10 @@ Done! Decoding Protobuf into domain object with a fallible transformation, like 
     ```scala
     // file: conversion.sc - part of the demo
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import io.scalaland.chimney.dsl._
 
-    println(
+    pprint.pprintln(
       UserDTO(
         "John",
         Seq(AddressDTO("Paper St", "Somewhere")),
@@ -141,9 +147,15 @@ Done! Decoding Protobuf into domain object with a fallible transformation, like 
         .map(_.asErrorPathMessages)
     )
     // expected output:
-    // Right(User(Username(John),List(Address(Paper St,Somewhere)),Email(john@example.com)))
+    // Right(
+    //   value = User(
+    //     name = Username(name = "John"),
+    //     addresses = List(Address(street = "Paper St", city = "Somewhere")),
+    //     recovery = Email(email = "john@example.com")
+    //   )
+    // )
 
-    println(
+    pprint.pprintln(
       UserDTO(
         "John",
         Seq(AddressDTO("Paper St", "Somewhere")),
@@ -155,7 +167,7 @@ Done! Decoding Protobuf into domain object with a fallible transformation, like 
         .map(_.asErrorPathMessages)
     )
     // expected output:
-    // Left(List((recovery,EmptyValue)))
+    // Left(value = List(("recovery", EmptyValue)))
     ```
 
 ??? example "Curious about the generated code?"

--- a/docs/docs/supported-patching.md
+++ b/docs/docs/supported-patching.md
@@ -11,6 +11,7 @@ Currently, the only supported case is updating one `case class` with another:
 
     ```scala
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import io.scalaland.chimney.dsl._
 
     case class Email(address: String) extends AnyVal
@@ -22,8 +23,11 @@ Currently, the only supported case is updating one `case class` with another:
     val user = User(10, Email("abc@@domain.com"), Phone(1234567890L))
     val updateForm = UserUpdateForm("xyz@@domain.com", 123123123L)
 
-    user.patchUsing(updateForm)
-    // User(10, Email("xyz@@domain.com"), Phone(123123123L))
+    pprint.pprintln(
+      user.patchUsing(updateForm)
+    )
+    // expected output:
+    // User(id = 10, email = Email(address = "xyz@@domain.com"), phone = Phone(number = 123123123L))
     ```
 
 As we see the values from the "patch" aren't always of the same type as the values they are supposed to update.
@@ -66,6 +70,7 @@ But there is a way to ignore redundant patcher fields explicitly with `.ignoreRe
 
     ```scala
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import io.scalaland.chimney.dsl._
 
     case class User(id: Int, email: String, phone: Long)
@@ -73,18 +78,24 @@ But there is a way to ignore redundant patcher fields explicitly with `.ignoreRe
 
     val user = User(10, "abc@@domain.com", 1234567890L)
 
-    user
-      .using(UserUpdateForm("xyz@@domain.com", 123123123L, "some address"))
-      .ignoreRedundantPatcherFields
-      .patch
-    // User(10, "xyz@@domain.com", 123123123L)
+    pprint.pprintln(
+      user
+        .using(UserUpdateForm("xyz@@domain.com", 123123123L, "some address"))
+        .ignoreRedundantPatcherFields
+        .patch
+    )
+    // expected output:
+    // User(id = 10, email = "xyz@@domain.com", phone = 123123123L)
 
     locally {
       // All patching derived in this scope will see these new flags (Scala 2-only syntax, see cookbook for Scala 3)
       implicit val cfg = PatcherConfiguration.default.ignoreRedundantPatcherFields
 
-      user.patchUsing(UserUpdateForm("xyz@@domain.com", 123123123L, "some address"))
-      // User(10, "xyz@@domain.com", 123123123L)
+      pprint.pprintln(
+        user.patchUsing(UserUpdateForm("xyz@@domain.com", 123123123L, "some address"))
+      )
+      // expected output:
+      // User(id = 10, email = "xyz@@domain.com", phone = 123123123L)
     }
     ```
 
@@ -131,6 +142,7 @@ Let’s consider the following patch:
 
     ```scala
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import io.scalaland.chimney.dsl._
 
     case class User(id: Int, email: String, phone: Long)
@@ -139,8 +151,11 @@ Let’s consider the following patch:
     val user = User(10, "abc@@domain.com", 1234567890L)
     val update = UserPatch(email = Some("updated@@example.com"), phone = None)
 
-    user.patchUsing(update)
-    // User(10, "updated@@example.com", 1234567890L)
+    pprint.pprintln(
+      user.patchUsing(update)
+    )
+    // expected output:
+    // User(id = 10, email = "updated@@example.com", phone = 1234567890L)
     ```
 
 The field `phone` remained the same as in the original `user`, while the optional e-mail string got updated from
@@ -173,6 +188,7 @@ but it also gives a simple way to always ignore `None` from the patch with `.ign
 
     ```scala
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import io.scalaland.chimney.dsl._
 
     case class User(name: Option[String], age: Option[Int])
@@ -180,22 +196,34 @@ but it also gives a simple way to always ignore `None` from the patch with `.ign
 
     val user = User(Some("John"), Some(30))
     val userPatch = UserPatch(None, None)
+     
+    pprint.pprintln(
+      user.patchUsing(userPatch)
+    )
+    // clears both fields:
+    // expected output:
+    // User(name = None, age = None)
 
-    user.patchUsing(userPatch)
-    // clears both fields: User(None, None)
-
-    user
-      .using(userPatch)
-      .ignoreNoneInPatch
-      .patch
-    // ignores updating both fields: User(Some("John"), Some(30))
+    pprint.pprintln(
+      user
+        .using(userPatch)
+        .ignoreNoneInPatch
+        .patch
+    )
+    // ignores updating both fields:
+    // expected output:
+    // User(name = Some(value = "John"), age = Some(value = 30))
 
     locally {
       // All patching derived in this scope will see these new flags (Scala 2-only syntax, see cookbook for Scala 3)
       implicit val cfg = PatcherConfiguration.default.ignoreNoneInPatch
 
-      user.patchUsing(userPatch)
-      // ignores updating both fields: User(Some("John"), Some(30))
+      pprint.pprintln(
+        user.patchUsing(userPatch)
+      )
+      // ignores updating both fields:
+      // expected output:
+      // User(name = Some(value = "John"), age = Some(value = 30))
     }
     ```
 
@@ -205,6 +233,7 @@ If the flag was enabled in the implicit config it can be disabled with `.clearOn
 
     ```scala
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
     import io.scalaland.chimney.dsl._
 
     case class User(name: Option[String], age: Option[Int])
@@ -216,10 +245,14 @@ If the flag was enabled in the implicit config it can be disabled with `.clearOn
     // all patching derived in this scope will see these new flags
     implicit val cfg = PatcherConfiguration.default.ignoreNoneInPatch
 
-    user
-      .using(userPatch)
-      .clearOnNoneInPatch
-      .patch
-    // clears both fields: User(None, None)
+    pprint.pprintln(
+      user
+        .using(userPatch)
+        .clearOnNoneInPatch
+        .patch
+    )
+    // clears both fields:
+    // expected output:
+    // User(name = None, age = None)
     ```
  

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -4609,7 +4609,7 @@ but Chimney has a specific solution for this:
 
     ```scala
     // file: your/organization/PermissiveNamesComparison.test.scala - part of custom naming comparison example
-    //> using dep org.scalameta::munit::1.0.0-RC1
+    //> using dep org.scalameta::munit::1.0.0
     import io.scalaland.chimney.dsl._
 
     case class Foo(a_name: String, BName: String)

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -686,7 +686,7 @@ Here are some features it shares with Chimney (Henkan's code based on README):
     type you want:
     
     ```scala
-    //> using dep org.typelevel::cats-core::2.10.0
+    //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     

--- a/docs/docs/under-the-hood.md
+++ b/docs/docs/under-the-hood.md
@@ -333,7 +333,7 @@ as soon as we get it - by delaying the wrapping as long as possible we are avoid
 
     implicit val int2string: Transformer[Int, String] = _.toString
 
-    Foo(1, 2, 3).into[Bar].transform
+    Foo(1, 2, 3).intoPartial[Bar].transform
     ```
     
     would NOT generate anything similar to

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -98,5 +98,6 @@ extra:
     scala_automapper: "0.7.0"
     henkan:           "0.6.5"
     ducktape:         "0.2.0"
+    pprint:           "0.9.0"
   local:
     tag: !ENV [CI_LATEST_TAG, 'latest'] # used as git.tag fallback in Docker container

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -106,8 +106,9 @@ class ChimneyExtendedRunner(runner: Runner)(
   *
   * during development:
   * {{{
-  * # fix: version to use, tmp directory
-  * scala-cli run scripts/test-snippets.scala -- --extra "chimney-version=1.0.0-RC1" --test-only "supported-transformations.md*" "$PWD/docs/docs" "/var/folders/m_/sm90t09d5591cgz5h242bkm80000gn/T/docs-snippets13141962741435068727"
+  * # sbt publish-local-for-testsing
+  * # fix the version to what sbt generated, fix tmp directory to something to be able to preview generated files
+  * scala-cli run scripts/test-snippets.scala -- --extra "chimney-version=1.x.y-n-g1234567-SNAPSHOT" --test-only "supported-transformations.md*" "$PWD/docs/docs" "/var/folders/m_/sm90t09d5591cgz5h242bkm80000gn/T/docs-snippets13141962741435068727"
   * }}}
   */
 @main def testChimneySnippets(args: String*): Unit = testSnippets(args.toArray) { cfg =>


### PR DESCRIPTION
- [x] `cookbook.md`
- [x] `index.md`
- [x] `supported-patching.md`
- [x] `supported-transformations.md`
- [x] `troubleshooting.md`

We are not yet testing `.enableMacrosLogging` as https://github.com/VirtusLab/scala-cli/pull/2990 hasn't been yet released.
