### PR TITLE
Improve protobuf support for sealed

### DIFF
--- a/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufTransformerImplicits.scala
+++ b/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufTransformerImplicits.scala
@@ -69,6 +69,8 @@ private[protobufs] trait ProtobufTransformerImplicitsLowPriorityImplicits1 { thi
 
   // com.google.protobuf.ByteString
 
+  // FIXME (2.0.0 cleanup): ByteString should be TotallyBuildIterable
+
   /** @since 0.8.0 */
   implicit def totalTransformerFromByteStringToByteCollection[Coll[A] <: IterableOnce[A]](implicit
       factory: Factory[Byte, Coll[Byte]]
@@ -91,6 +93,8 @@ private[protobufs] trait ProtobufTransformerImplicitsLowPriorityImplicits1 { thi
     bool => com.google.protobuf.wrappers.BoolValue.of(bool)
 
   // com.google.protobuf.wrappers.BytesValue
+
+  // FIXME (2.0.0 cleanup): BytesValue should be TotallyBuildIterable
 
   /** @since 0.8.0 */
   implicit def totalTransformerFromBytesValueToByteCollection[Coll[A] <: IterableOnce[A]](implicit

--- a/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufsPartialTransformerImplicits.scala
+++ b/chimney-protobufs/src/main/scala/io/scalaland/chimney/protobufs/ProtobufsPartialTransformerImplicits.scala
@@ -9,6 +9,16 @@ trait ProtobufsPartialTransformerImplicits extends ProtobufsPartialTransformerIm
   implicit def partialTransformerFromEmptyOneOfInstance[From <: scalapb.GeneratedOneof { type ValueType = Nothing }, To]
       : PartialTransformer[From, To] =
     PartialTransformer(_ => partial.Result.fromEmpty)
+
+  /** @since 1.3.0 */
+  implicit def partialTransformerFromEmptySealedOneOfInstance[From <: scalapb.GeneratedSealedOneof with Singleton, To]
+      : PartialTransformer[From, To] =
+    PartialTransformer(_ => partial.Result.fromEmpty)
+
+  /** @since 1.3.0 */
+  implicit def partialTransformerFromUnrecognizedEnumInstance[From <: scalapb.UnrecognizedEnum, To]
+      : PartialTransformer[From, To] =
+    PartialTransformer(_ => partial.Result.fromEmpty)
 }
 
 private[protobufs] trait ProtobufsPartialTransformerImplicitsLowPriorityImplicits1 {

--- a/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufEnumSpec.scala
+++ b/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufEnumSpec.scala
@@ -5,7 +5,6 @@ import io.scalaland.chimney.dsl._
 // format: on
 import io.scalaland.chimney.examples.pb
 import io.scalaland.chimney.fixtures.{addressbook, order}
-import io.scalaland.chimney.partial
 
 class ProtobufEnumSpec extends ChimneySpec {
 
@@ -40,6 +39,25 @@ class ProtobufEnumSpec extends ChimneySpec {
         .intoPartial[addressbook.PhoneType]
         .withEnumCaseHandledPartial[pb.addressbook.PhoneType.Unrecognized](_ => partial.Result.fromEmpty)
         .transform
+        .asOption ==> None
+    }
+
+    test("partially transform into sealed trait hierarchy of case objects (handling Unrecognized with implicit)") {
+      // format: off
+      import protobufs._
+      // format: on
+
+      (pb.addressbook.PhoneType.MOBILE: pb.addressbook.PhoneType)
+        .transformIntoPartial[addressbook.PhoneType]
+        .asOption ==> Some(addressbook.MOBILE)
+      (pb.addressbook.PhoneType.HOME: pb.addressbook.PhoneType)
+        .transformIntoPartial[addressbook.PhoneType]
+        .asOption ==> Some(addressbook.HOME)
+      (pb.addressbook.PhoneType.WORK: pb.addressbook.PhoneType)
+        .transformIntoPartial[addressbook.PhoneType]
+        .asOption ==> Some(addressbook.WORK)
+      (pb.addressbook.PhoneType.Unrecognized(0): pb.addressbook.PhoneType)
+        .transformIntoPartial[addressbook.PhoneType]
         .asOption ==> None
     }
   }

--- a/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufEnumSpec.scala
+++ b/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufEnumSpec.scala
@@ -5,14 +5,42 @@ import io.scalaland.chimney.dsl._
 // format: on
 import io.scalaland.chimney.examples.pb
 import io.scalaland.chimney.fixtures.{addressbook, order}
+import io.scalaland.chimney.partial
 
 class ProtobufEnumSpec extends ChimneySpec {
 
-  test("transform enum represented as sealed trait hierarchy") {
+  group("PB enum") {
 
-    (addressbook.MOBILE: addressbook.PhoneType)
-      .transformInto[pb.addressbook.PhoneType] ==> pb.addressbook.PhoneType.MOBILE
-    (addressbook.HOME: addressbook.PhoneType).transformInto[pb.addressbook.PhoneType] ==> pb.addressbook.PhoneType.HOME
-    (addressbook.WORK: addressbook.PhoneType).transformInto[pb.addressbook.PhoneType] ==> pb.addressbook.PhoneType.WORK
+    test("totally transform from sealed trait hierarchy of case objects") {
+      (addressbook.MOBILE: addressbook.PhoneType)
+        .transformInto[pb.addressbook.PhoneType] ==> pb.addressbook.PhoneType.MOBILE
+      (addressbook.HOME: addressbook.PhoneType)
+        .transformInto[pb.addressbook.PhoneType] ==> pb.addressbook.PhoneType.HOME
+      (addressbook.WORK: addressbook.PhoneType)
+        .transformInto[pb.addressbook.PhoneType] ==> pb.addressbook.PhoneType.WORK
+    }
+
+    test("partially transform into sealed trait hierarchy of case objects (with manual handling of unrecognized)") {
+      (pb.addressbook.PhoneType.MOBILE: pb.addressbook.PhoneType)
+        .intoPartial[addressbook.PhoneType]
+        .withEnumCaseHandledPartial[pb.addressbook.PhoneType.Unrecognized](_ => partial.Result.fromEmpty)
+        .transform
+        .asOption ==> Some(addressbook.MOBILE)
+      (pb.addressbook.PhoneType.HOME: pb.addressbook.PhoneType)
+        .intoPartial[addressbook.PhoneType]
+        .withEnumCaseHandledPartial[pb.addressbook.PhoneType.Unrecognized](_ => partial.Result.fromEmpty)
+        .transform
+        .asOption ==> Some(addressbook.HOME)
+      (pb.addressbook.PhoneType.WORK: pb.addressbook.PhoneType)
+        .intoPartial[addressbook.PhoneType]
+        .withEnumCaseHandledPartial[pb.addressbook.PhoneType.Unrecognized](_ => partial.Result.fromEmpty)
+        .transform
+        .asOption ==> Some(addressbook.WORK)
+      (pb.addressbook.PhoneType.Unrecognized(0): pb.addressbook.PhoneType)
+        .intoPartial[addressbook.PhoneType]
+        .withEnumCaseHandledPartial[pb.addressbook.PhoneType.Unrecognized](_ => partial.Result.fromEmpty)
+        .transform
+        .asOption ==> None
+    }
   }
 }

--- a/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufMessageSpec.scala
+++ b/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufMessageSpec.scala
@@ -90,14 +90,14 @@ class ProtobufMessageSpec extends ChimneySpec {
     }
 
     test("partially transform into case classes unwrapping present optional values") {
-      pbPhone.intoPartial[addressbook.PhoneNumber].transform.asOption ==> Some(domainPhone)
-      pbPerson.intoPartial[addressbook.Person].transform.asOption ==> Some(domainPerson)
-      pbAddressBook.intoPartial[addressbook.AddressBook].transform.asOption ==> Some(domainAddressBook)
-      pbOrder.intoPartial[order.Order].transform.asOption ==> Some(domainOrder)
+      pbPhone.transformIntoPartial[addressbook.PhoneNumber].asOption ==> Some(domainPhone)
+      pbPerson.transformIntoPartial[addressbook.Person].asOption ==> Some(domainPerson)
+      pbAddressBook.transformIntoPartial[addressbook.AddressBook].asOption ==> Some(domainAddressBook)
+      pbOrder.transformIntoPartial[order.Order].asOption ==> Some(domainOrder)
     }
 
     test("partially transform into case classes failing absent optional values with Empty") {
-      val result = pbOrderInvalid.intoPartial[order.Order].transform
+      val result = pbOrderInvalid.transformIntoPartial[order.Order]
       result.asOption ==> None
       result.asErrorPathMessageStrings ==> Iterable(
         "lines(1).item" -> "empty value",
@@ -127,7 +127,7 @@ class ProtobufMessageSpec extends ChimneySpec {
     }
 
     test("partially transform into cases classes") {
-      pbUser.intoPartial[user.User].transform.asOption ==> Some(domainUser)
+      pbUser.transformIntoPartial[user.User].asOption ==> Some(domainUser)
     }
   }
 }

--- a/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufOneOfSpec.scala
+++ b/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufOneOfSpec.scala
@@ -31,6 +31,7 @@ class ProtobufOneOfSpec extends ChimneySpec {
       // format: off
       import protobufs._
       // format: on
+
       pbType.value.intoPartial[addressbook.AddressBookType].transform.asOption ==> Some(domainType)
     }
   }
@@ -50,6 +51,18 @@ class ProtobufOneOfSpec extends ChimneySpec {
         .withSealedSubtypeHandled[pb.order.CustomerStatus.NonEmpty](_.transformInto[order.CustomerStatus])
         .transform
         .asOption ==> Some(domainStatus)
+    }
+
+    test("partially transform into sealed hierarchy (handling Value.Empty.type with implicit)") {
+      // format: off
+      //import protobufs._
+      // format: on
+
+      // TODO: figure that out: on Scala 3 macro cannot figure out this implicit while on Scala 2 it can :/
+      implicit val f: PartialTransformer[pb.order.CustomerStatus.Empty.type, order.CustomerStatus] =
+        protobufs.partialTransformerFromEmptySealedOneOfInstance
+
+      pbStatus.transformIntoPartial[order.CustomerStatus].asOption ==> Some(domainStatus)
     }
   }
 

--- a/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufOneOfSpec.scala
+++ b/chimney-protobufs/src/test/scala/io/scalaland/chimney/ProtobufOneOfSpec.scala
@@ -8,36 +8,42 @@ import io.scalaland.chimney.fixtures.{addressbook, order}
 
 class ProtobufOneOfSpec extends ChimneySpec {
 
-  group("transformer sealed traits generated from oneof") {
+  group("oneof value (represented with wrapped sealed hierarchy)") {
+    val domainType: addressbook.AddressBookType = addressbook.AddressBookType.Private("test")
+    val pbType: pb.addressbook.AddressBookType =
+      pb.addressbook.AddressBookType.of(
+        pb.addressbook.AddressBookType.Value.Private(pb.addressbook.AddressBookType.Private.of("test"))
+      )
 
-    test("AddressBookType (oneof value - sealed contains single-value wrappers around actual products)") {
-      val domainType: addressbook.AddressBookType = addressbook.AddressBookType.Private("test")
-      val pbType: pb.addressbook.AddressBookType =
-        pb.addressbook.AddressBookType.of(
-          pb.addressbook.AddressBookType.Value.Private(pb.addressbook.AddressBookType.Private.of("test"))
-        )
-
+    test("totally transform from sealed hierarchy") {
       domainType.into[pb.addressbook.AddressBookType.Value].transform ==> pbType.value
+    }
 
+    test("partially transform into sealed hierarchy (manually handling Value.Empty)") {
       pbType.value
         .intoPartial[addressbook.AddressBookType]
         .withSealedSubtypeHandledPartial[pb.addressbook.AddressBookType.Value.Empty.type](_ => partial.Result.fromEmpty)
         .transform
         .asOption ==> Some(domainType)
-      locally {
-        // format: off
-        import protobufs._
-        // format: on
-        pbType.value.intoPartial[addressbook.AddressBookType].transform.asOption ==> Some(domainType)
-      }
     }
 
-    test("CustomerStatus (oneof sealed_value - flat representation with additional Empty vase)") {
-      val domainStatus: order.CustomerStatus = order.CustomerStatus.CustomerRegistered
-      val pbStatus: pb.order.CustomerStatus = pb.order.CustomerRegistered()
+    test("partially transform into sealed hierarchy (handling Value.Empty.type with implicit)") {
+      // format: off
+      import protobufs._
+      // format: on
+      pbType.value.intoPartial[addressbook.AddressBookType].transform.asOption ==> Some(domainType)
+    }
+  }
 
+  group("oneof sealed_value (represented with flat sealed hierarchy with additional Empty case)") {
+    val domainStatus: order.CustomerStatus = order.CustomerStatus.CustomerRegistered
+    val pbStatus: pb.order.CustomerStatus = pb.order.CustomerRegistered()
+
+    test("totally transform from sealed hierarchy") {
       domainStatus.into[pb.order.CustomerStatus].transform ==> pbStatus
+    }
 
+    test("partially transform into sealed hierarchy (manually handling Empty and NonEmpty subtypes)") {
       pbStatus
         .intoPartial[order.CustomerStatus]
         .withSealedSubtypeHandledPartial[pb.order.CustomerStatus.Empty.type](_ => partial.Result.fromEmpty)
@@ -45,12 +51,17 @@ class ProtobufOneOfSpec extends ChimneySpec {
         .transform
         .asOption ==> Some(domainStatus)
     }
+  }
 
-    test("PaymentStatus (oneof sealed_value_optional - flat representation wrapped in Option)") {
-      val domainStatus: Option[order.PaymentStatus] = Option(order.PaymentStatus.PaymentRequested)
-      val pbStatus: Option[pb.order.PaymentStatus] = Option(pb.order.PaymentRequested())
+  group("oneof sealed_value_optional (represented with flat sealed hierarchy wrapped in Option)") {
+    val domainStatus: Option[order.PaymentStatus] = Option(order.PaymentStatus.PaymentRequested)
+    val pbStatus: Option[pb.order.PaymentStatus] = Option(pb.order.PaymentRequested())
 
+    test("totally transform from sealed hierarchy") {
       domainStatus.into[Option[pb.order.PaymentStatus]].transform ==> pbStatus
+    }
+
+    test("totally transform into sealed hierarchy") {
       pbStatus.into[Option[order.PaymentStatus]].transform ==> domainStatus
     }
   }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -298,6 +298,8 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           weakTypeTag[runtime.TransformerFlags.OptionDefaultsToNone]
         val PartialUnwrapsOption: Type[runtime.TransformerFlags.PartialUnwrapsOption] =
           weakTypeTag[runtime.TransformerFlags.PartialUnwrapsOption]
+        val NonAnyValWrappers: Type[runtime.TransformerFlags.NonAnyValWrappers] =
+          weakTypeTag[runtime.TransformerFlags.NonAnyValWrappers]
         object ImplicitConflictResolution extends ImplicitConflictResolutionModule {
           def apply[R <: dsls.ImplicitTransformerPreference: Type]
               : Type[runtime.TransformerFlags.ImplicitConflictResolution[R]] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -258,6 +258,8 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           quoted.Type.of[runtime.TransformerFlags.OptionDefaultsToNone]
         val PartialUnwrapsOption: Type[runtime.TransformerFlags.PartialUnwrapsOption] =
           quoted.Type.of[runtime.TransformerFlags.PartialUnwrapsOption]
+        val NonAnyValWrappers: Type[runtime.TransformerFlags.NonAnyValWrappers] =
+          quoted.Type.of[runtime.TransformerFlags.NonAnyValWrappers]
         object ImplicitConflictResolution extends ImplicitConflictResolutionModule {
           def apply[R <: dsls.ImplicitTransformerPreference: Type]
               : Type[runtime.TransformerFlags.ImplicitConflictResolution[R]] =

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -262,7 +262,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
     * By default in such case compilation fails.
     *
     * @see
-    *   [[TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#frominto-a-wrapper-type]] for more details
     *
     * @since 1.3.0
     */
@@ -273,7 +273,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
     * are not AnyVals.
     *
     * @see
-    *   [[TODO]] for more details
+    *   [[https://chimney.readthedocs.io/supported-transformations/#frominto-a-wrapper-type]] for more details
     *
     * @since 1.3.0
     */

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -256,6 +256,30 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
   def disablePartialUnwrapsOption: UpdateFlag[Disable[PartialUnwrapsOption, Flags]] =
     disableFlag[PartialUnwrapsOption]
 
+  /** Enable unpacking/wrapping with wrapper types (classes with have only 1 val, set in a constructor) even when they
+    * are not AnyVals.
+    *
+    * By default in such case compilation fails.
+    *
+    * @see
+    *   [[TODO]] for more details
+    *
+    * @since 1.3.0
+    */
+  def enableNonAnyValWrappers: UpdateFlag[Enable[NonAnyValWrappers, Flags]] =
+    enableFlag[NonAnyValWrappers]
+
+  /** Disable unpacking/wrapping with wrapper types (classes with have only 1 val, set in a constructor) even when they
+    * are not AnyVals.
+    *
+    * @see
+    *   [[TODO]] for more details
+    *
+    * @since 1.3.0
+    */
+  def disableNonAnyValWrappers: UpdateFlag[Disable[NonAnyValWrappers, Flags]] =
+    disableFlag[NonAnyValWrappers]
+
   /** Enable conflict resolution when both `Transformer` and `PartialTransformer` are available in the implicit scope.
     *
     * @param preference

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -189,6 +189,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
         val NonUnitBeanSetters: Type[runtime.TransformerFlags.NonUnitBeanSetters]
         val OptionDefaultsToNone: Type[runtime.TransformerFlags.OptionDefaultsToNone]
         val PartialUnwrapsOption: Type[runtime.TransformerFlags.PartialUnwrapsOption]
+        val NonAnyValWrappers: Type[runtime.TransformerFlags.NonAnyValWrappers]
         val ImplicitConflictResolution: ImplicitConflictResolutionModule
         trait ImplicitConflictResolutionModule
             extends Type.Ctor1UpperBounded[

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -20,6 +20,7 @@ private[compiletime] trait Configurations { this: Derivation =>
       beanGetters: Boolean = false,
       optionDefaultsToNone: Boolean = false,
       partialUnwrapsOption: Boolean = true,
+      nonAnyValWrappers: Boolean = false,
       implicitConflictResolution: Option[ImplicitTransformerPreference] = None,
       fieldNameComparison: Option[dsls.TransformedNamesComparison] = None,
       subtypeNameComparison: Option[dsls.TransformedNamesComparison] = None,
@@ -45,6 +46,8 @@ private[compiletime] trait Configurations { this: Derivation =>
         copy(optionDefaultsToNone = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.PartialUnwrapsOption) {
         copy(partialUnwrapsOption = value)
+      } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.NonAnyValWrappers) {
+        copy(nonAnyValWrappers = value)
       } else if (Type[Flag] =:= ChimneyType.TransformerFlags.Flags.MacrosLogging) {
         copy(displayMacrosLogging = value)
       } else {
@@ -91,6 +94,7 @@ private[compiletime] trait Configurations { this: Derivation =>
         if (nonUnitBeanSetters) Vector("nonUnitBeanSetters") else Vector.empty,
         if (beanGetters) Vector("beanGetters") else Vector.empty,
         if (optionDefaultsToNone) Vector("optionDefaultsToNone") else Vector.empty,
+        if (nonAnyValWrappers) Vector("nonAnyValWrappers") else Vector.empty,
         implicitConflictResolution.map(r => s"ImplicitTransformerPreference=$r").toList.toVector,
         fieldNameComparison.map(r => s"fieldNameComparison=$r").toList.toVector,
         subtypeNameComparison.map(r => s"subtypeNameComparison=$r").toList.toVector,

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
@@ -13,29 +13,38 @@ private[compiletime] trait TransformTypeToValueClassRuleModule {
         case ValueClassType(to2) =>
           if (ctx.config.areOverridesEmpty) {
             import to2.{Underlying as InnerTo, value as valueTo}
-            transformToInnerToAndWrap[From, To, InnerTo](valueTo)
+            transformToInnerToAndWrap[From, To, InnerTo](valueTo.fieldName, valueTo.wrap)
+          } else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
+        case WrapperClassType(to2) =>
+          if (ctx.config.areOverridesEmpty) {
+            if (ctx.config.flags.nonAnyValWrappers) {
+              import to2.{Underlying as InnerTo, value as valueTo}
+              transformToInnerToAndWrap[From, To, InnerTo](valueTo.fieldName, valueTo.wrap)
+            } else
+              DerivationResult.attemptNextRuleBecause("Wrapping in non-AnyVal wrapper types was disabled by a flag")
           } else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
         case _ => DerivationResult.attemptNextRule
       }
   }
 
   private def transformToInnerToAndWrap[From, To, InnerTo: Type](
-      valueTo: ValueClass[To, InnerTo]
+      innerToFieldName: String,
+      wrapInnerToIntoTo: Expr[InnerTo] => Expr[To]
   )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
     deriveRecursiveTransformationExpr[From, InnerTo](
       ctx.src,
-      Path.Root.select(valueTo.fieldName)
+      Path.Root.select(innerToFieldName)
     )
       .flatMap { derivedInnerTo =>
         // We're constructing:
         // '{ new $To(${ derivedInnerTo }) }
-        DerivationResult.expanded(derivedInnerTo.map(valueTo.wrap))
+        DerivationResult.expanded(derivedInnerTo.map(wrapInnerToIntoTo))
       }
       // fall back to case classes expansion; see https://github.com/scalalandio/chimney/issues/297 for more info
       .orElse(TransformProductToProductRule.expand(ctx))
       .orElse(
         DerivationResult
-          .notSupportedTransformerDerivationForField(valueTo.fieldName)(ctx)
+          .notSupportedTransformerDerivationForField(innerToFieldName)(ctx)
           .log(
             s"Failed to resolve derivation from ${Type.prettyPrint[From]} to ${Type
                 .prettyPrint[InnerTo]} (wrapped by ${Type.prettyPrint[To]})"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
@@ -13,23 +13,32 @@ private[compiletime] trait TransformValueClassToTypeRuleModule {
         case ValueClassType(from2) =>
           if (ctx.config.areOverridesEmpty) {
             import from2.{Underlying as InnerFrom, value as valueFrom}
-            unwrapAndTransform[From, To, InnerFrom](valueFrom)
+            unwrapAndTransform[From, To, InnerFrom](valueFrom.fieldName, valueFrom.unwrap)
+          } else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
+        case WrapperClassType(from2) =>
+          if (ctx.config.areOverridesEmpty) {
+            if (ctx.config.flags.nonAnyValWrappers) {
+              import from2.{Underlying as InnerFrom, value as valueFrom}
+              unwrapAndTransform[From, To, InnerFrom](valueFrom.fieldName, valueFrom.unwrap)
+            } else
+              DerivationResult.attemptNextRuleBecause("Unwrapping from non-AnyVal wrapper types was disabled by a flag")
           } else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
         case _ => DerivationResult.attemptNextRule
       }
 
     private def unwrapAndTransform[From, To, InnerFrom: Type](
-        valueFrom: ValueClass[From, InnerFrom]
+        innerFromFieldName: String,
+        unwrapFromIntoInnerFrom: Expr[From] => Expr[InnerFrom]
     )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       // We're constructing:
       // '{ ${ derivedTo } /* using ${ src }.from internally */ }
-      deriveRecursiveTransformationExpr[InnerFrom, To](valueFrom.unwrap(ctx.src), Path.Root)
+      deriveRecursiveTransformationExpr[InnerFrom, To](unwrapFromIntoInnerFrom(ctx.src), Path.Root)
         .flatMap(DerivationResult.expanded)
         // fall back to case classes expansion; see https://github.com/scalalandio/chimney/issues/297 for more info
         .orElse(TransformProductToProductRule.expand(ctx))
         .orElse(
           DerivationResult
-            .notSupportedTransformerDerivationForField(valueFrom.fieldName)(ctx)
+            .notSupportedTransformerDerivationForField(innerFromFieldName)(ctx)
             .log(
               s"Failed to resolve derivation from ${Type.prettyPrint[InnerFrom]} (wrapped by ${Type
                   .prettyPrint[From]}) to ${Type.prettyPrint[To]}"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
@@ -12,22 +12,35 @@ private[compiletime] trait TransformValueClassToValueClassRuleModule { this: Der
         case (ValueClassType(from2), ValueClassType(to2)) =>
           if (ctx.config.areOverridesEmpty) {
             import from2.{Underlying as InnerFrom, value as valueFrom}, to2.{Underlying as InnerTo, value as valueTo}
-            unwrapTransformAndWrapAgain[From, To, InnerFrom, InnerTo](valueFrom, valueTo)
+            unwrapTransformAndWrapAgain[From, To, InnerFrom, InnerTo](valueFrom.unwrap, valueTo.fieldName, valueTo.wrap)
+          } else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
+        case (WrapperClassType(from2), WrapperClassType(to2)) =>
+          if (ctx.config.areOverridesEmpty) {
+            if (ctx.config.flags.nonAnyValWrappers) {
+              import from2.{Underlying as InnerFrom, value as valueFrom}, to2.{Underlying as InnerTo, value as valueTo}
+              unwrapTransformAndWrapAgain[From, To, InnerFrom, InnerTo](
+                valueFrom.unwrap,
+                valueTo.fieldName,
+                valueTo.wrap
+              )
+            } else
+              DerivationResult.attemptNextRuleBecause("Rewrapping non-AnyVal wrapper types was disabled by a flag")
           } else DerivationResult.attemptNextRuleBecause("Configuration has defined overrides")
         case _ => DerivationResult.attemptNextRule
       }
   }
 
   private def unwrapTransformAndWrapAgain[From, To, InnerFrom: Type, InnerTo: Type](
-      valueFrom: ValueClass[From, InnerFrom],
-      valueTo: ValueClass[To, InnerTo]
+      unwrapFromIntoInnerFrom: Expr[From] => Expr[InnerFrom],
+      innerToFieldName: String,
+      wrapInnerToIntoIo: Expr[InnerTo] => Expr[To]
   )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
     deriveRecursiveTransformationExpr[InnerFrom, InnerTo](
-      valueFrom.unwrap(ctx.src),
-      Path.Root.select(valueTo.fieldName)
+      unwrapFromIntoInnerFrom(ctx.src),
+      Path.Root.select(innerToFieldName)
     ).flatMap { (derivedInnerTo: TransformationExpr[InnerTo]) =>
       // We're constructing:
       // '{ ${ new $To(${ derivedInnerTo }) } /* using ${ src }.$from internally */ }
-      DerivationResult.expanded(derivedInnerTo.map(valueTo.wrap))
+      DerivationResult.expanded(derivedInnerTo.map(wrapInnerToIntoIo))
     }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerFlags.scala
@@ -19,6 +19,7 @@ object TransformerFlags {
   final class BeanGetters extends Flag
   final class OptionDefaultsToNone extends Flag
   final class PartialUnwrapsOption extends Flag
+  final class NonAnyValWrappers extends Flag
   final class ImplicitConflictResolution[R <: ImplicitTransformerPreference] extends Flag
   final class FieldNameComparison[C <: TransformedNamesComparison] extends Flag
   final class SubtypeNameComparison[C <: TransformedNamesComparison] extends Flag

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -1037,6 +1037,13 @@ Decoding (with `PartialTransformer`s) requires handling of `Empty.Value` type
     Importing `import io.scalaland.chimney.protobufs._` works only for the default output. If you used `sealed_value` or
     `sealed_value_optional` read further sections. 
 
+!!! notice
+
+    As you may have notices transformation is between `addressbook.AddressBookType` and
+    `pb.addressbook.AddressBookType.Value`. If we wanted to automatically wrap/unwrap
+    `pb.addressbook.AddressBookType.Value` with `pb.addressbook.AddressBookType` we should
+    [enable non-AnyVal wrapper types](supported-transformations.md#frominto-a-wrapper-type).
+
 ### `sealed_value oneof` fields
 
 In case we can edit our protobuf definition, we can arrange the generated code

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -1589,6 +1589,7 @@ An example of such optional type is `java.util.Optional` for which support is pr
 ## Custom collection types
 
 In case your library/domain defines custom collections - which are:
+
  * NOT providing `scala.collection.Factory` (2.13/3) or `scala.collection.genric.CanBuildFrom` (2.12)
  * or NOT extending `Iterable`
 
@@ -1834,6 +1835,7 @@ For map types there are specialized versions of these type classes:
     ```
     
 The only 2 difference they make is that:
+
  - when we are converting with `PartialTransformer` failures will be reported on map keys instead of `_1` and `_2` field
    of a tuple in a sequence (e.g. `keys(myKey)` - if key conversion failed for `myKey` value or `(myKey)` if value
    conversion failed for `myKey` key, instead of `(0)._1` or `(0)._2`)

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -2356,7 +2356,7 @@ If the flag was enabled in the implicit config it can be disabled with `.disbleN
     
     case class UserName(value: String)
     
-    "user name".transformInto[UserName]
+    "user name".into[UserName].disableNonAnyValWrappers.transform
     // expected error:
     // Chimney can't derive transformation from java.lang.String to UserName
     // 

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -89,6 +89,7 @@ function was not defined, "empty value" when something was expected) and even th
     pprint.pprintln(
       transformer.transform(new MyType("10")).asEither.left.map(_.asErrorPathMessages)
     )
+    // expected output:
     // Right(value = MyOtherType(10))
     pprint.pprintln(
       transformer


### PR DESCRIPTION
- [x] refactor tests
- [x] add implicit handling empty `GeneratedSealedOneOf`
  - [ ] fix Scala 3 issue ( https://github.com/scala/scala3/issues/21122 :/)
- [x] add implicit handling empty `GeneratedEnum`
- [x] add flag allowing to handle non-AnyVal wrappers automatically
  - [x] tests
  - [x] docs