### PR TITLE
Provide Scala-version-agnostic way of reading macro settings

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/DefinitionsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/DefinitionsPlatform.scala
@@ -11,5 +11,8 @@ trait DefinitionsPlatform
 
   val c: blackbox.Context
 
-  protected val isScala212 = scala.util.Properties.versionNumberString < "2.13"
+  protected val XMacroSettings: List[String] = c.settings
+
+  /** Useful for distinction between 2.12 and 2.13, when necessary. */
+  protected val isScala212: Boolean = scala.util.Properties.versionNumberString < "2.13"
 }

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -8,6 +8,13 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
 
   protected object ExprPromise extends ExprPromiseModule {
 
+    object platformSpecific {
+
+      def freshTermName(prefix: String): TermName =
+        // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
+        c.internal.reificationSupport.freshTermName(prefix.toLowerCase + "$macro$")
+    }
+
     // made public for ChimneyExprsPlatform: Transformer.lift and PartialTransformer.lift
     def provideFreshName[From: Type](
         nameGenerationStrategy: NameGenerationStrategy,
@@ -36,8 +43,7 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
       c.Expr[(From, From2) => To](q"($fromName: ${Type[From]}, $from2Name: ${Type[From2]}) => $to")
 
     private def freshTermName(prefix: String): ExprPromiseName =
-      // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
-      c.internal.reificationSupport.freshTermName(prefix.toLowerCase + "$macro$")
+      platformSpecific.freshTermName(prefix)
     private def freshTermName(tpe: c.Type): ExprPromiseName =
       freshTermName(tpe.typeSymbol.name.decodedName.toString.toLowerCase)
     private def freshTermName(srcPrefixTree: Expr[?]): ExprPromiseName =

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -166,7 +166,7 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
         }
       )
     }
-    def suppressWarnings[A: Type](warnings: List[String])(expr: Expr[A]): Expr[A] = {
+    def SuppressWarnings[A: Type](warnings: List[String])(expr: Expr[A]): Expr[A] = {
       val name = ExprPromise.platformSpecific.freshTermName("suppressWarningsResult")
       c.Expr[A](
         q"""

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/DefinitionsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/DefinitionsPlatform.scala
@@ -7,4 +7,11 @@ abstract class DefinitionsPlatform(using val quotes: quoted.Quotes)
     with TypesPlatform
     with ExprsPlatform
     with ExprPromisesPlatform
-    with ResultsPlatform
+    with ResultsPlatform {
+
+  protected val XMacroSettings: List[String] = {
+    // workaround to contain @experimental from polluting the whole codebase
+    val info = quotes.reflect.CompilationInfo
+    info.getClass.getMethod("XmacroSettings").invoke(info).asInstanceOf[List[String]]
+  }
+}

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -169,7 +169,7 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
         Ref(name)
       ).asExprOf[A]
     }
-    def suppressWarnings[A: Type](warnings: List[String])(expr: Expr[A]): Expr[A] = {
+    def SuppressWarnings[A: Type](warnings: List[String])(expr: Expr[A]): Expr[A] = {
       val annotationSymbol: Symbol = TypeRepr.of[java.lang.SuppressWarnings].typeSymbol
       val annotation = Apply(
         Select(New(TypeIdent(annotationSymbol)), annotationSymbol.primaryConstructor),

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Definitions.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Definitions.scala
@@ -1,3 +1,7 @@
 package io.scalaland.chimney.internal.compiletime
 
-trait Definitions extends Types with Existentials with Exprs with ExprPromises with Results
+trait Definitions extends Types with Existentials with Exprs with ExprPromises with Results {
+
+  /** Values passed into scalacOptions with "-Xmacro-settings:...", can be used to define global settings. */
+  protected def XMacroSettings: List[String]
+}

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -126,6 +126,11 @@ private[compiletime] trait Exprs { this: Definitions =>
       // $COVERAGE-ON$
     }
 
+    def nowarn[A: Type](warnings: Option[String])(expr: Expr[A]): Expr[A]
+    def suppressWarnings[A: Type](warnings: List[String])(expr: Expr[A]): Expr[A]
+
+    def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit]
+
     // Implementations of Expr extension methods
 
     def eq[A: Type, B: Type](a: Expr[A], b: Expr[B]): Expr[Boolean]
@@ -133,8 +138,6 @@ private[compiletime] trait Exprs { this: Definitions =>
     def asInstanceOf[A: Type, B: Type](expr: Expr[A]): Expr[B]
 
     def upcast[A: Type, B: Type](expr: Expr[A]): Expr[B]
-
-    def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit]
 
     def prettyPrint[A](expr: Expr[A]): String
 

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Exprs.scala
@@ -127,7 +127,7 @@ private[compiletime] trait Exprs { this: Definitions =>
     }
 
     def nowarn[A: Type](warnings: Option[String])(expr: Expr[A]): Expr[A]
-    def suppressWarnings[A: Type](warnings: List[String])(expr: Expr[A]): Expr[A]
+    def SuppressWarnings[A: Type](warnings: List[String])(expr: Expr[A]): Expr[A]
 
     def suppressUnused[A: Type](expr: Expr[A]): Expr[Unit]
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -122,16 +122,4 @@ final class CodecMacros(val c: blackbox.Context) extends DerivationPlatform with
   catch {
     case scala.reflect.macros.TypecheckException(_, msg) => c.abort(c.enclosingPosition, msg)
   }
-
-  private def suppressWarnings[A: Type](expr: c.Expr[A]): c.Expr[A] = {
-    // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
-    val result = c.internal.reificationSupport.freshTermName("result$macro$")
-    c.Expr[A](
-      q"""{
-          @_root_.java.lang.SuppressWarnings(_root_.scala.Array("org.wartremover.warts.All", "all"))
-          val $result = $expr
-          $result
-        }"""
-    )
-  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -14,34 +14,31 @@ final class CodecMacros(val c: blackbox.Context) extends DerivationPlatform with
   def deriveCodecWithDefaults[
       Domain: WeakTypeTag,
       Dto: WeakTypeTag
-  ]: c.universe.Expr[Codec[Domain, Dto]] =
-    retypecheck(
-      suppressWarnings(
-        resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-          import implicitScopeFlagsType.Underlying
-          c.Expr(
-            q"""
-            io.scalaland.chimney.Codec[${Type[Domain]}, ${Type[Dto]}](
-              encode = ${deriveTotalTransformer[
-                Domain,
-                Dto,
-                runtime.TransformerOverrides.Empty,
-                runtime.TransformerFlags.Default,
-                implicitScopeFlagsType.Underlying
-              ](ChimneyExpr.RuntimeDataStore.empty)},
-              decode = ${derivePartialTransformer[
-                Dto,
-                Domain,
-                runtime.TransformerOverrides.Empty,
-                runtime.TransformerFlags.Default,
-                implicitScopeFlagsType.Underlying
-              ](ChimneyExpr.RuntimeDataStore.empty)}
-            )
-            """
-          )
-        }
+  ]: c.universe.Expr[Codec[Domain, Dto]] = retypecheck(
+    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+      import implicitScopeFlagsType.Underlying
+      c.Expr(
+        q"""
+        io.scalaland.chimney.Codec[${Type[Domain]}, ${Type[Dto]}](
+          encode = ${deriveTotalTransformer[
+            Domain,
+            Dto,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            implicitScopeFlagsType.Underlying
+          ](ChimneyExpr.RuntimeDataStore.empty)},
+          decode = ${derivePartialTransformer[
+            Dto,
+            Domain,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            implicitScopeFlagsType.Underlying
+          ](ChimneyExpr.RuntimeDataStore.empty)}
+        )
+        """
       )
-    )
+    }
+  )
 
   def deriveCodecWithConfig[
       Domain: WeakTypeTag,
@@ -53,35 +50,33 @@ final class CodecMacros(val c: blackbox.Context) extends DerivationPlatform with
   ](
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[Codec[Domain, Dto]] = retypecheck(
-    suppressWarnings(
-      Expr.block(
-        List(Expr.suppressUnused(tc)),
-        c.Expr(
-          q"""
-          io.scalaland.chimney.Codec[${Type[Domain]}, ${Type[Dto]}](
-            encode = ${deriveTotalTransformer[
-              Domain,
-              Dto,
-              EncodeOverrides,
-              InstanceFlags,
-              ImplicitScopeFlags
-            ](
-              // Called by CodecDefinition => prefix is CodecDefinition
-              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.encode.runtimeData")
-            )},
-            decode = ${derivePartialTransformer[
-              Dto,
-              Domain,
-              DecodeOverrides,
-              InstanceFlags,
-              ImplicitScopeFlags
-            ](
-              // Called by CodecDefinition => prefix is CodecDefinition
-              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.decode.runtimeData")
-            )}
-          )
-          """
+    Expr.block(
+      List(Expr.suppressUnused(tc)),
+      c.Expr(
+        q"""
+        io.scalaland.chimney.Codec[${Type[Domain]}, ${Type[Dto]}](
+          encode = ${deriveTotalTransformer[
+            Domain,
+            Dto,
+            EncodeOverrides,
+            InstanceFlags,
+            ImplicitScopeFlags
+          ](
+            // Called by CodecDefinition => prefix is CodecDefinition
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.encode.runtimeData")
+          )},
+          decode = ${derivePartialTransformer[
+            Dto,
+            Domain,
+            DecodeOverrides,
+            InstanceFlags,
+            ImplicitScopeFlags
+          ](
+            // Called by CodecDefinition => prefix is CodecDefinition
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.decode.runtimeData")
+          )}
         )
+        """
       )
     )
   )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -122,16 +122,4 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
   catch {
     case scala.reflect.macros.TypecheckException(_, msg) => c.abort(c.enclosingPosition, msg)
   }
-
-  private def suppressWarnings[A: Type](expr: c.Expr[A]): c.Expr[A] = {
-    // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
-    val result = c.internal.reificationSupport.freshTermName("result$macro$")
-    c.Expr[A](
-      q"""{
-          @_root_.java.lang.SuppressWarnings(_root_.scala.Array("org.wartremover.warts.All", "all"))
-          val $result = $expr
-          $result
-        }"""
-    )
-  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -14,34 +14,31 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
   def deriveIsoWithDefaults[
       First: WeakTypeTag,
       Second: WeakTypeTag
-  ]: c.universe.Expr[Iso[First, Second]] =
-    retypecheck(
-      suppressWarnings(
-        resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-          import implicitScopeFlagsType.Underlying
-          c.Expr(
-            q"""
-            io.scalaland.chimney.Iso[${Type[First]}, ${Type[Second]}](
-              first = ${deriveTotalTransformer[
-                First,
-                Second,
-                runtime.TransformerOverrides.Empty,
-                runtime.TransformerFlags.Default,
-                implicitScopeFlagsType.Underlying
-              ](ChimneyExpr.RuntimeDataStore.empty)},
-              second = ${deriveTotalTransformer[
-                Second,
-                First,
-                runtime.TransformerOverrides.Empty,
-                runtime.TransformerFlags.Default,
-                implicitScopeFlagsType.Underlying
-              ](ChimneyExpr.RuntimeDataStore.empty)}
-            )
-            """
-          )
-        }
+  ]: c.universe.Expr[Iso[First, Second]] = retypecheck(
+    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+      import implicitScopeFlagsType.Underlying
+      c.Expr(
+        q"""
+        io.scalaland.chimney.Iso[${Type[First]}, ${Type[Second]}](
+          first = ${deriveTotalTransformer[
+            First,
+            Second,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            implicitScopeFlagsType.Underlying
+          ](ChimneyExpr.RuntimeDataStore.empty)},
+          second = ${deriveTotalTransformer[
+            Second,
+            First,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            implicitScopeFlagsType.Underlying
+          ](ChimneyExpr.RuntimeDataStore.empty)}
+        )
+        """
       )
-    )
+    }
+  )
 
   def deriveIsoWithConfig[
       First: WeakTypeTag,
@@ -53,35 +50,33 @@ final class IsoMacros(val c: blackbox.Context) extends DerivationPlatform with G
   ](
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[Iso[First, Second]] = retypecheck(
-    suppressWarnings(
-      Expr.block(
-        List(Expr.suppressUnused(tc)),
-        c.Expr(
-          q"""
-          io.scalaland.chimney.Iso[${Type[First]}, ${Type[Second]}](
-            first = ${deriveTotalTransformer[
-              First,
-              Second,
-              FirstOverrides,
-              InstanceFlags,
-              ImplicitScopeFlags
-            ](
-              // Called by IsoDefinition => prefix is IsoDefinition
-              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.first.runtimeData")
-            )},
-            second = ${deriveTotalTransformer[
-              Second,
-              First,
-              SecondOverrides,
-              InstanceFlags,
-              ImplicitScopeFlags
-            ](
-              // Called by IsoDefinition => prefix is IsoDefinition
-              c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.second.runtimeData")
-            )}
+    Expr.block(
+      List(Expr.suppressUnused(tc)),
+      c.Expr(
+        q"""
+        io.scalaland.chimney.Iso[${Type[First]}, ${Type[Second]}](
+          first = ${deriveTotalTransformer[
+            First,
+            Second,
+            FirstOverrides,
+            InstanceFlags,
+            ImplicitScopeFlags
+          ](
+            // Called by IsoDefinition => prefix is IsoDefinition
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.first.runtimeData")
+          )},
+          second = ${deriveTotalTransformer[
+            Second,
+            First,
+            SecondOverrides,
+            InstanceFlags,
+            ImplicitScopeFlags
+          ](
+            // Called by IsoDefinition => prefix is IsoDefinition
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.second.runtimeData")
+          )}
           )
-          """
-        )
+        """
       )
     )
   )

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -18,18 +18,16 @@ final class PatcherMacros(val c: blackbox.Context) extends DerivationPlatform wi
   ](
       tc: Expr[io.scalaland.chimney.dsl.PatcherConfiguration[ImplicitScopeFlags]]
   ): c.Expr[A] = retypecheck(
-    suppressWarnings(
-      // Called by PatcherUsing => prefix is PatcherUsing
-      cacheDefinition(c.Expr[dsl.PatcherUsing[A, Patch, Overrides, Flags]](c.prefix.tree)) { pu =>
-        Expr.block(
-          List(Expr.suppressUnused(pu)),
-          derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
-            obj = c.Expr[A](q"$pu.obj"),
-            patch = c.Expr[Patch](q"$pu.objPatch")
-          )
+    // Called by PatcherUsing => prefix is PatcherUsing
+    cacheDefinition(c.Expr[dsl.PatcherUsing[A, Patch, Overrides, Flags]](c.prefix.tree)) { pu =>
+      Expr.block(
+        List(Expr.suppressUnused(pu)),
+        derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
+          obj = c.Expr[A](q"$pu.obj"),
+          patch = c.Expr[Patch](q"$pu.objPatch")
         )
-      }
-    )
+      )
+    }
   )
 
   def derivePatcherWithConfig[
@@ -41,26 +39,22 @@ final class PatcherMacros(val c: blackbox.Context) extends DerivationPlatform wi
   ](
       tc: Expr[io.scalaland.chimney.dsl.PatcherConfiguration[ImplicitScopeFlags]]
   ): Expr[Patcher[A, Patch]] = retypecheck(
-    suppressWarnings(
-      cacheDefinition(c.Expr[dsl.PatcherDefinition[A, Patch, Overrides, InstanceFlags]](c.prefix.tree)) { pu =>
-        Expr.block(
-          List(Expr.suppressUnused(pu)),
-          derivePatcher[A, Patch, Overrides, InstanceFlags, ImplicitScopeFlags]
-        )
-      }
-    )
+    cacheDefinition(c.Expr[dsl.PatcherDefinition[A, Patch, Overrides, InstanceFlags]](c.prefix.tree)) { pu =>
+      Expr.block(
+        List(Expr.suppressUnused(pu)),
+        derivePatcher[A, Patch, Overrides, InstanceFlags, ImplicitScopeFlags]
+      )
+    }
   )
 
   def derivePatcherWithDefaults[
       A: WeakTypeTag,
       Patch: WeakTypeTag
   ]: Expr[Patcher[A, Patch]] = retypecheck(
-    suppressWarnings(
-      resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-        import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
-        derivePatcher[A, Patch, runtime.PatcherOverrides.Empty, runtime.PatcherFlags.Default, ImplicitScopeFlags]
-      }
-    )
+    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+      derivePatcher[A, Patch, runtime.PatcherOverrides.Empty, runtime.PatcherFlags.Default, ImplicitScopeFlags]
+    }
   )
 
   private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -99,16 +99,4 @@ final class PatcherMacros(val c: blackbox.Context) extends DerivationPlatform wi
   catch {
     case scala.reflect.macros.TypecheckException(_, msg) => c.abort(c.enclosingPosition, msg)
   }
-
-  private def suppressWarnings[A: Type](expr: c.Expr[A]): c.Expr[A] = {
-    // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
-    val result = c.internal.reificationSupport.freshTermName("result$macro$")
-    c.Expr[A](
-      q"""{
-        @_root_.java.lang.SuppressWarnings(_root_.scala.Array("org.wartremover.warts.All", "all"))
-        val $result = $expr
-        $result
-      }"""
-    )
-  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -197,16 +197,4 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   } catch {
     case scala.reflect.macros.TypecheckException(_, msg) => c.abort(c.enclosingPosition, msg)
   }
-
-  private def suppressWarnings[A: Type](expr: c.Expr[A]): c.Expr[A] = {
-    // Scala 3 generate prefix$macro$[n] while Scala 2 prefix[n] and we want to align the behavior
-    val result = c.internal.reificationSupport.freshTermName("result$macro$")
-    c.Expr[A](
-      q"""{
-        @_root_.java.lang.SuppressWarnings(_root_.scala.Array("org.wartremover.warts.All", "all"))
-        val $result = $expr
-        $result
-      }"""
-    )
-  }
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -20,37 +20,33 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   ](
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[To] = retypecheck(
-    suppressWarnings(
-      // Called by TransformerInto => prefix is TransformerInto
-      // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-      cacheDefinition(c.Expr[dsl.TransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { ti =>
-        Expr.block(
-          List(Expr.suppressUnused(tc)),
-          deriveTotalTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-            src = c.Expr[From](q"$ti.source"),
-            runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$ti.td.runtimeData")
-          )
+    // Called by TransformerInto => prefix is TransformerInto
+    // We're caching it because it is used twice: once for RuntimeDataStore and once for source
+    cacheDefinition(c.Expr[dsl.TransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { ti =>
+      Expr.block(
+        List(Expr.suppressUnused(tc)),
+        deriveTotalTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+          src = c.Expr[From](q"$ti.source"),
+          runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$ti.td.runtimeData")
         )
-      }
-    )
+      )
+    }
   )
 
   def deriveTotalTransformerWithDefaults[
       From: WeakTypeTag,
       To: WeakTypeTag
   ]: Expr[Transformer[From, To]] = retypecheck(
-    suppressWarnings(
-      resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-        import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
-        deriveTotalTransformer[
-          From,
-          To,
-          runtime.TransformerOverrides.Empty,
-          runtime.TransformerFlags.Default,
-          ImplicitScopeFlags
-        ](ChimneyExpr.RuntimeDataStore.empty)
-      }
-    )
+    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+      deriveTotalTransformer[
+        From,
+        To,
+        runtime.TransformerOverrides.Empty,
+        runtime.TransformerFlags.Default,
+        ImplicitScopeFlags
+      ](ChimneyExpr.RuntimeDataStore.empty)
+    }
   )
 
   def deriveTotalTransformerWithConfig[
@@ -59,18 +55,17 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
       Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
-  ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]): Expr[Transformer[From, To]] =
-    retypecheck(
-      suppressWarnings(
-        Expr.block(
-          List(Expr.suppressUnused(tc)),
-          deriveTotalTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-            // Called by TransformerDefinition => prefix is TransformerDefinition
-            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
-          )
-        )
+  ](
+      tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
+  ): Expr[Transformer[From, To]] = retypecheck(
+    Expr.block(
+      List(Expr.suppressUnused(tc)),
+      deriveTotalTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+        // Called by TransformerDefinition => prefix is TransformerDefinition
+        c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
       )
     )
+  )
 
   def derivePartialTransformationWithConfigNoFailFast[
       From: WeakTypeTag,
@@ -78,23 +73,22 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
       Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
-  ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]): Expr[partial.Result[To]] =
-    retypecheck(
-      suppressWarnings(
-        // Called by PartialTransformerInto => prefix is PartialTransformerInto
-        // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-        cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
-          Expr.block(
-            List(Expr.suppressUnused(tc)),
-            derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-              src = c.Expr[From](q"$pti.source"),
-              failFast = c.Expr[Boolean](q"false"),
-              runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
-            )
-          )
-        }
+  ](
+      tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
+  ): Expr[partial.Result[To]] = retypecheck(
+    // Called by PartialTransformerInto => prefix is PartialTransformerInto
+    // We're caching it because it is used twice: once for RuntimeDataStore and once for source
+    cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
+      Expr.block(
+        List(Expr.suppressUnused(tc)),
+        derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+          src = c.Expr[From](q"$pti.source"),
+          failFast = c.Expr[Boolean](q"false"),
+          runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
+        )
       )
-    )
+    }
+  )
 
   def derivePartialTransformationWithConfigFailFast[
       From: WeakTypeTag,
@@ -102,42 +96,38 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
       Overrides <: runtime.TransformerOverrides: WeakTypeTag,
       InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
-  ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]): Expr[partial.Result[To]] =
-    retypecheck(
-      suppressWarnings(
-        // Called by PartialTransformerInto => prefix is PartialTransformerInto
-        // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-        cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
-          Expr.block(
-            List(Expr.suppressUnused(tc)),
-            derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-              src = c.Expr[From](q"$pti.source"),
-              failFast = c.Expr[Boolean](q"true"),
-              runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
-            )
-          )
-        }
+  ](
+      tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
+  ): Expr[partial.Result[To]] = retypecheck(
+    // Called by PartialTransformerInto => prefix is PartialTransformerInto
+    // We're caching it because it is used twice: once for RuntimeDataStore and once for source
+    cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
+      Expr.block(
+        List(Expr.suppressUnused(tc)),
+        derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+          src = c.Expr[From](q"$pti.source"),
+          failFast = c.Expr[Boolean](q"true"),
+          runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
+        )
       )
-    )
+    }
+  )
 
   def derivePartialTransformerWithDefaults[
       From: WeakTypeTag,
       To: WeakTypeTag
-  ]: c.universe.Expr[PartialTransformer[From, To]] =
-    retypecheck(
-      suppressWarnings(
-        resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-          import implicitScopeFlagsType.Underlying
-          derivePartialTransformer[
-            From,
-            To,
-            runtime.TransformerOverrides.Empty,
-            runtime.TransformerFlags.Default,
-            implicitScopeFlagsType.Underlying
-          ](ChimneyExpr.RuntimeDataStore.empty)
-        }
-      )
-    )
+  ]: c.universe.Expr[PartialTransformer[From, To]] = retypecheck(
+    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+      import implicitScopeFlagsType.Underlying
+      derivePartialTransformer[
+        From,
+        To,
+        runtime.TransformerOverrides.Empty,
+        runtime.TransformerFlags.Default,
+        implicitScopeFlagsType.Underlying
+      ](ChimneyExpr.RuntimeDataStore.empty)
+    }
+  )
 
   def derivePartialTransformerWithConfig[
       From: WeakTypeTag,
@@ -148,13 +138,11 @@ final class TransformerMacros(val c: blackbox.Context) extends DerivationPlatfor
   ](
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[PartialTransformer[From, To]] = retypecheck(
-    suppressWarnings(
-      Expr.block(
-        List(Expr.suppressUnused(tc)),
-        derivePartialTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-          // Called by PartialTransformerDefinition => prefix is PartialTransformerDefinition
-          c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
-        )
+    Expr.block(
+      List(Expr.suppressUnused(tc)),
+      derivePartialTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+        // Called by PartialTransformerDefinition => prefix is PartialTransformerDefinition
+        c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
       )
     )
   )

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -14,31 +14,29 @@ final class CodecMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
   def deriveCodecWithDefaults[
       Domain: Type,
       Dto: Type
-  ]: Expr[Codec[Domain, Dto]] = suppressWarnings {
-    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
-      '{
-        Codec[Domain, Dto](
-          encode = ${
-            deriveTotalTransformer[
-              Domain,
-              Dto,
-              runtime.TransformerOverrides.Empty,
-              runtime.TransformerFlags.Default,
-              ImplicitScopeFlags
-            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
-          },
-          decode = ${
-            derivePartialTransformer[
-              Dto,
-              Domain,
-              runtime.TransformerOverrides.Empty,
-              runtime.TransformerFlags.Default,
-              ImplicitScopeFlags
-            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
-          }
-        )
-      }
+  ]: Expr[Codec[Domain, Dto]] = resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+    import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+    '{
+      Codec[Domain, Dto](
+        encode = ${
+          deriveTotalTransformer[
+            Domain,
+            Dto,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            ImplicitScopeFlags
+          ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+        },
+        decode = ${
+          derivePartialTransformer[
+            Dto,
+            Domain,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            ImplicitScopeFlags
+          ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+        }
+      )
     }
   }
 
@@ -51,7 +49,7 @@ final class CodecMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
       cd: Expr[CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags]]
-  ): Expr[Codec[Domain, Dto]] = suppressWarnings {
+  ): Expr[Codec[Domain, Dto]] =
     '{
       Codec[Domain, Dto](
         encode = ${
@@ -66,7 +64,6 @@ final class CodecMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
         }
       )
     }
-  }
 
   private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
       useImplicitScopeFlags: ?<[runtime.TransformerFlags] => Expr[A]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/codec/CodecMacros.scala
@@ -87,12 +87,6 @@ final class CodecMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
       useImplicitScopeFlags(implicitScopeFlagsType)
     )
   }
-
-  private def suppressWarnings[A: Type](expr: Expr[A]): Expr[A] = '{
-    @SuppressWarnings(Array("org.wartremover.warts.All", "all"))
-    val result = ${ expr }
-    result
-  }
 }
 
 object CodecMacros {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -87,12 +87,6 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
       useImplicitScopeFlags(implicitScopeFlagsType)
     )
   }
-
-  private def suppressWarnings[A: Type](expr: Expr[A]): Expr[A] = '{
-    @SuppressWarnings(Array("org.wartremover.warts.All", "all"))
-    val result = ${ expr }
-    result
-  }
 }
 
 object IsoMacros {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/iso/IsoMacros.scala
@@ -14,31 +14,29 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
   def deriveIsoWithDefaults[
       First: Type,
       Second: Type
-  ]: Expr[Iso[First, Second]] = suppressWarnings {
-    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
-      '{
-        Iso[First, Second](
-          first = ${
-            deriveTotalTransformer[
-              First,
-              Second,
-              runtime.TransformerOverrides.Empty,
-              runtime.TransformerFlags.Default,
-              ImplicitScopeFlags
-            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
-          },
-          second = ${
-            deriveTotalTransformer[
-              Second,
-              First,
-              runtime.TransformerOverrides.Empty,
-              runtime.TransformerFlags.Default,
-              ImplicitScopeFlags
-            ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
-          }
-        )
-      }
+  ]: Expr[Iso[First, Second]] = resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+    import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+    '{
+      Iso[First, Second](
+        first = ${
+          deriveTotalTransformer[
+            First,
+            Second,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            ImplicitScopeFlags
+          ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+        },
+        second = ${
+          deriveTotalTransformer[
+            Second,
+            First,
+            runtime.TransformerOverrides.Empty,
+            runtime.TransformerFlags.Default,
+            ImplicitScopeFlags
+          ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
+        }
+      )
     }
   }
 
@@ -51,7 +49,7 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
       id: Expr[IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags]]
-  ): Expr[Iso[First, Second]] = suppressWarnings {
+  ): Expr[Iso[First, Second]] =
     '{
       Iso[First, Second](
         first = ${
@@ -66,7 +64,6 @@ final class IsoMacros(q: Quotes) extends DerivationPlatform(q) with Gateway {
         }
       )
     }
-  }
 
   private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
       useImplicitScopeFlags: ?<[runtime.TransformerFlags] => Expr[A]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -48,12 +48,6 @@ final class PatcherMacros(q: Quotes) extends DerivationPlatform(q) with Gateway 
       useImplicitScopeFlags(implicitScopeFlagsType)
     )
   }
-
-  private def suppressWarnings[A: Type](expr: Expr[A]): Expr[A] = '{
-    @SuppressWarnings(Array("org.wartremover.warts.All", "all"))
-    val result = ${ expr }
-    result
-  }
 }
 
 object PatcherMacros {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -15,18 +15,14 @@ final class PatcherMacros(q: Quotes) extends DerivationPlatform(q) with Gateway 
       Overrides <: runtime.PatcherOverrides: Type,
       Flags <: runtime.PatcherFlags: Type,
       ImplicitScopeFlags <: runtime.PatcherFlags: Type
-  ]: Expr[Patcher[A, Patch]] = suppressWarnings {
-    derivePatcher[A, Patch, Overrides, Flags, ImplicitScopeFlags]
-  }
+  ]: Expr[Patcher[A, Patch]] = derivePatcher[A, Patch, Overrides, Flags, ImplicitScopeFlags]
 
   def derivePatcherWithDefaults[
       A: Type,
       Patch: Type
-  ]: Expr[Patcher[A, Patch]] = suppressWarnings {
-    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
-      derivePatcher[A, Patch, runtime.PatcherOverrides.Empty, runtime.PatcherFlags.Default, ImplicitScopeFlags]
-    }
+  ]: Expr[Patcher[A, Patch]] = resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+    import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+    derivePatcher[A, Patch, runtime.PatcherOverrides.Empty, runtime.PatcherFlags.Default, ImplicitScopeFlags]
   }
 
   private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -19,40 +19,35 @@ final class TransformerMacros(q: Quotes) extends DerivationPlatform(q) with Gate
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]]
-  ): Expr[Transformer[From, To]] = suppressWarnings {
+  ): Expr[Transformer[From, To]] =
     deriveTotalTransformer[From, To, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{ ${ td }.runtimeData })
-  }
 
   def deriveTotalTransformerWithDefaults[
       From: Type,
       To: Type
-  ]: Expr[Transformer[From, To]] = suppressWarnings {
-    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
-      deriveTotalTransformer[
-        From,
-        To,
-        runtime.TransformerOverrides.Empty,
-        runtime.TransformerFlags.Default,
-        ImplicitScopeFlags
-      ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
-    }
+  ]: Expr[Transformer[From, To]] = resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+    import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+    deriveTotalTransformer[
+      From,
+      To,
+      runtime.TransformerOverrides.Empty,
+      runtime.TransformerFlags.Default,
+      ImplicitScopeFlags
+    ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
   }
 
   def derivePartialTransformerWithDefaults[
       From: Type,
       To: Type
-  ]: Expr[PartialTransformer[From, To]] = suppressWarnings {
-    resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
-      import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
-      derivePartialTransformer[
-        From,
-        To,
-        runtime.TransformerOverrides.Empty,
-        runtime.TransformerFlags.Default,
-        ImplicitScopeFlags
-      ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
-    }
+  ]: Expr[PartialTransformer[From, To]] = resolveImplicitScopeConfigAndMuteUnusedWarnings { implicitScopeFlagsType =>
+    import implicitScopeFlagsType.Underlying as ImplicitScopeFlags
+    derivePartialTransformer[
+      From,
+      To,
+      runtime.TransformerOverrides.Empty,
+      runtime.TransformerFlags.Default,
+      ImplicitScopeFlags
+    ](runtimeDataStore = ChimneyExpr.RuntimeDataStore.empty)
   }
 
   def derivePartialTransformerWithConfig[
@@ -63,11 +58,10 @@ final class TransformerMacros(q: Quotes) extends DerivationPlatform(q) with Gate
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]]
-  ): Expr[PartialTransformer[From, To]] = suppressWarnings {
+  ): Expr[PartialTransformer[From, To]] =
     derivePartialTransformer[From, To, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
       ${ td }.runtimeData
     })
-  }
 
   private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
       useImplicitScopeFlags: ?<[runtime.TransformerFlags] => Expr[A]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -88,12 +88,6 @@ final class TransformerMacros(q: Quotes) extends DerivationPlatform(q) with Gate
       useImplicitScopeFlags(implicitScopeFlagsType)
     )
   }
-
-  private def suppressWarnings[A: Type](expr: Expr[A]): Expr[A] = '{
-    @SuppressWarnings(Array("org.wartremover.warts.All", "all"))
-    val result = ${ expr }
-    result
-  }
 }
 
 object TransformerMacros {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyDefinitions.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyDefinitions.scala
@@ -1,3 +1,140 @@
 package io.scalaland.chimney.internal.compiletime
 
-private[compiletime] trait ChimneyDefinitions extends Definitions with ChimneyTypes with ChimneyExprs
+private[compiletime] trait ChimneyDefinitions extends Definitions with ChimneyTypes with ChimneyExprs {
+
+  // $COVERAGE-OFF$It's testable in snippets not not really in normal tests with coverage
+  implicit protected class FlagOps(sc: StringContext) {
+
+    /** Usage
+      * {{{
+      * "chimney.SuppressWarnings=none" match {
+      *   case chimneyFlag"SuppressWarnings=$value => value // "none"
+      * }
+      * }}}
+      */
+    object chimneyFlag {
+      def unapplySeq(s: String): Option[Seq[String]] =
+        if (s.startsWith(chimneyPrefix)) glob(sc.parts, s.drop(chimneyPrefix.length))
+        else None
+    }
+
+    /** Usage
+      * {{{
+      * "chimney.transformer.MacrosLogging=false" match {
+      *   case transformerFlag"MacrosLogging=$value => value // "false"
+      * }
+      * }}}
+      */
+    object transformerFlag {
+      def unapplySeq(s: String): Option[Seq[String]] =
+        if (s.startsWith(transformerPrefix)) glob(sc.parts, s.drop(transformerPrefix.length))
+        else None
+    }
+
+    /** Usage
+      * {{{
+      * "chimney.patcher.MacrosLogging=false" match {
+      *   case patcherFlag"MacrosLogging=$value => value // "false"
+      * }
+      * }}}
+      */
+    object patcherFlag {
+      def unapplySeq(s: String): Option[Seq[String]] =
+        if (s.startsWith(patcherPrefix)) glob(sc.parts, s.drop(patcherPrefix.length))
+        else None
+    }
+  }
+  private val chimneyPrefix = "chimney."
+  private val transformerPrefix = chimneyPrefix + "transformer."
+  private val patcherPrefix = chimneyPrefix + "patcher."
+
+  // Copy-pasted from scala.StringContext.glob, because 2.12 has no pattern matching on s"...".
+  private def glob(patternChunks: Seq[String], input: String): Option[Seq[String]] = {
+    var patternIndex = 0
+    var inputIndex = 0
+    var nextPatternIndex = 0
+    var nextInputIndex = 0
+
+    val numWildcards = patternChunks.length - 1
+    val matchStarts = Array.fill(numWildcards)(-1)
+    val matchEnds = Array.fill(numWildcards)(-1)
+
+    val nameLength = input.length
+    // The final pattern is as long as all the chunks, separated by 1-character
+    // glob-wildcard placeholders
+    val patternLength = patternChunks.iterator.map(_.length).sum + numWildcards
+
+    // Convert the input pattern chunks into a single sequence of shorts; each
+    // non-negative short represents a character, while -1 represents a glob wildcard
+    val pattern = {
+      val b = new scala.collection.mutable.ArrayBuilder.ofShort; b.sizeHint(patternLength)
+      patternChunks.head.foreach(c => b.+=(c.toShort))
+      patternChunks.tail.foreach { s => b.+=(-1); s.foreach(c => b.+=(c.toShort)) }
+      b.result()
+    }
+
+    // Lookup table for each character in the pattern to check whether or not
+    // it refers to a glob wildcard; a non-negative integer indicates which
+    // glob wildcard it represents, while -1 means it doesn't represent any
+    val matchIndices = {
+      val arr = Array.fill(patternLength + 1)(-1)
+      val _ = patternChunks.init.zipWithIndex.foldLeft(0) { case (ttl, (chunk, i)) =>
+        val sum = ttl + chunk.length
+        arr(sum) = i
+        sum + 1
+      }
+      arr
+    }
+
+    while (patternIndex < patternLength || inputIndex < nameLength) {
+      matchIndices(patternIndex) match {
+        case -1 => // do nothing
+        case n =>
+          matchStarts(n) = matchStarts(n) match {
+            case -1 => inputIndex
+            case s  => math.min(s, inputIndex)
+          }
+          matchEnds(n) = matchEnds(n) match {
+            case -1 => inputIndex
+            case s  => math.max(s, inputIndex)
+          }
+      }
+
+      val continue = if (patternIndex < patternLength) {
+        val c = pattern(patternIndex)
+        c match {
+          case -1 => // zero-or-more-character wildcard
+            // Try to match at nx. If that doesn't work out, restart at nx+1 next.
+            nextPatternIndex = patternIndex
+            nextInputIndex = inputIndex + 1
+            patternIndex += 1
+            true
+          case _ => // ordinary character
+            if (inputIndex < nameLength && input(inputIndex) == c) {
+              patternIndex += 1
+              inputIndex += 1
+              true
+            } else {
+              false
+            }
+        }
+      } else false
+
+      // Mismatch. Maybe restart.
+      if (!continue) {
+        if (0 < nextInputIndex && nextInputIndex <= nameLength) {
+          patternIndex = nextPatternIndex
+          inputIndex = nextInputIndex
+        } else {
+          return None
+        }
+      }
+    }
+
+    // Matched all of pattern to all of name. Success.
+    Some(
+      Array.tabulate(patternChunks.length - 1)(n => input.slice(matchStarts(n), matchEnds(n))).toSeq
+    )
+  }
+  // $COVERAGE-ON$
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyDefinitions.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyDefinitions.scala
@@ -2,7 +2,7 @@ package io.scalaland.chimney.internal.compiletime
 
 private[compiletime] trait ChimneyDefinitions extends Definitions with ChimneyTypes with ChimneyExprs {
 
-  // $COVERAGE-OFF$It's testable in snippets not not really in normal tests with coverage
+  // $COVERAGE-OFF$It's testable in (Scala-CLI) snippets and not really in normal tests with coverage
   implicit protected class FlagOps(sc: StringContext) {
 
     /** Usage

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/GatewayCommons.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/GatewayCommons.scala
@@ -57,12 +57,12 @@ private[compiletime] trait GatewayCommons { this: ChimneyDefinitions =>
     // - by default use: "org.wartremover.warts.All" (WartRemover) and "all" (Scapegoat)
     // - overridden with "-Xmacro-settings:chimney.SuppressWarnings=value"
     //   - "-Xmacro-settings:chimney.SuppressWarnings=none" skips the annotation
-    //   - "-Xmacro-settings:chimney.SuppressWarnings=a,b,c" would create @SuppressWarnings(Array("a", "b", "c"))
+    //   - "-Xmacro-settings:chimney.SuppressWarnings=a;b;c" would create @SuppressWarnings(Array("a", "b", "c"))
     val suppressWarningsCfg = XMacroSettings.foldLeft(Option(List("org.wartremover.warts.All", "all"))) {
-      case (_, chimneyFlag"SuppressWarnings=$value") => if (value == "none") None else Option(value.split(",").toList)
+      case (_, chimneyFlag"SuppressWarnings=$value") => if (value == "none") None else Option(value.split(";").toList)
       case (cfg, _)                                  => cfg
     }
-    val suppressWarningsExpr = suppressWarningsCfg.fold(expr)(Expr.suppressWarnings(_)(expr))
+    val suppressWarningsExpr = suppressWarningsCfg.fold(expr)(Expr.SuppressWarnings(_)(expr))
 
     // Add @nowarn(...) to the expr:
     // - by default annotation is not added

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
@@ -31,6 +31,7 @@ private[compiletime] trait Configurations { this: Derivation =>
   }
   object PatcherFlags {
 
+    // $COVERAGE-OFF$It's testable in snippets not not really in normal tests with coverage
     def global: PatcherFlags = XMacroSettings.foldLeft(PatcherFlags()) {
       case (cfg, patcherFlag"IgnoreNoneInPatch=$value") => cfg.copy(ignoreNoneInPatch = value.toBoolean)
       case (cfg, patcherFlag"IgnoreRedundantPatcherFields=$value") =>
@@ -38,6 +39,7 @@ private[compiletime] trait Configurations { this: Derivation =>
       case (cfg, patcherFlag"MacrosLogging=$value") => cfg.copy(displayMacrosLogging = value.toBoolean)
       case (cfg, _)                                 => cfg
     }
+    // $COVERAGE-ON$
   }
 
   final protected case class PatcherConfiguration(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
@@ -29,6 +29,16 @@ private[compiletime] trait Configurations { this: Derivation =>
         if (displayMacrosLogging) Vector("displayMacrosLogging") else Vector.empty
       ).flatten.mkString(", ")})"
   }
+  object PatcherFlags {
+
+    def global: PatcherFlags = XMacroSettings.foldLeft(PatcherFlags()) {
+      case (cfg, patcherFlag"IgnoreNoneInPatch=$value") => cfg.copy(ignoreNoneInPatch = value.toBoolean)
+      case (cfg, patcherFlag"IgnoreRedundantPatcherFields=$value") =>
+        cfg.copy(ignoreRedundantPatcherFields = value.toBoolean)
+      case (cfg, patcherFlag"MacrosLogging=$value") => cfg.copy(displayMacrosLogging = value.toBoolean)
+      case (cfg, _)                                 => cfg
+    }
+  }
 
   final protected case class PatcherConfiguration(
       flags: PatcherFlags = PatcherFlags(),
@@ -64,7 +74,7 @@ private[compiletime] trait Configurations { this: Derivation =>
         Flags <: runtime.PatcherFlags: Type,
         ImplicitScopeFlags <: runtime.PatcherFlags: Type
     ]: PatcherConfiguration = {
-      val implicitScopeFlags = extractTransformerFlags[ImplicitScopeFlags](PatcherFlags())
+      val implicitScopeFlags = extractTransformerFlags[ImplicitScopeFlags](PatcherFlags.global)
       val allFlags = extractTransformerFlags[Flags](implicitScopeFlags)
       extractPatcherConfig[Tail]().copy(flags = allFlags)
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Configurations.scala
@@ -31,7 +31,7 @@ private[compiletime] trait Configurations { this: Derivation =>
   }
   object PatcherFlags {
 
-    // $COVERAGE-OFF$It's testable in snippets not not really in normal tests with coverage
+    // $COVERAGE-OFF$It's testable in (Scala-CLI) snippets and not really in normal tests with coverage
     def global: PatcherFlags = XMacroSettings.foldLeft(PatcherFlags()) {
       case (cfg, patcherFlag"IgnoreNoneInPatch=$value") => cfg.copy(ignoreNoneInPatch = value.toBoolean)
       case (cfg, patcherFlag"IgnoreRedundantPatcherFields=$value") =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -101,6 +101,15 @@ private[compiletime] trait Configurations { this: Derivation =>
         if (displayMacrosLogging) Vector("displayMacrosLogging") else Vector.empty
       ).flatten.mkString(", ")})"
   }
+  object TransformerFlags {
+
+    def global: TransformerFlags =
+      XMacroSettings.foldLeft(TransformerFlags()) {
+        case (cfg, transformerFlag"InheritedAccessors=$value") => cfg.copy(inheritedAccessors = value.toBoolean)
+        // TODO: the rest
+        case (cfg, _) => cfg
+      }
+  }
 
   final protected class Path private (private val segments: Vector[Path.Segment]) {
 
@@ -346,7 +355,7 @@ private[compiletime] trait Configurations { this: Derivation =>
         InstanceFlags <: runtime.TransformerFlags: Type,
         ImplicitScopeFlags <: runtime.TransformerFlags: Type
     ](runtimeDataStore: Expr[TransformerDefinitionCommons.RuntimeDataStore]): TransformerConfiguration = {
-      val implicitScopeFlags = extractTransformerFlags[ImplicitScopeFlags](TransformerFlags())
+      val implicitScopeFlags = extractTransformerFlags[ImplicitScopeFlags](TransformerFlags.global)
       val allFlags = extractTransformerFlags[InstanceFlags](implicitScopeFlags)
       val cfg = extractTransformerConfig[Tail](runtimeDataIdx = 0, runtimeDataStore).copy(flags = allFlags)
       if (Type[InstanceFlags] =:= ChimneyType.TransformerFlags.Default) cfg else cfg.setLocalFlagsOverriden

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -103,6 +103,7 @@ private[compiletime] trait Configurations { this: Derivation =>
   }
   object TransformerFlags {
 
+    // $COVERAGE-OFF$It's testable in snippets not not really in normal tests with coverage
     def global: TransformerFlags = XMacroSettings.foldLeft(TransformerFlags()) {
       case (cfg, transformerFlag"InheritedAccessors=$value") => cfg.copy(inheritedAccessors = value.toBoolean)
       case (cfg, transformerFlag"MethodAccessors=$value")    => cfg.copy(methodAccessors = value.toBoolean)
@@ -124,6 +125,7 @@ private[compiletime] trait Configurations { this: Derivation =>
       case (cfg, transformerFlag"MacrosLogging=$value") => cfg.copy(displayMacrosLogging = value.toBoolean)
       case (cfg, _)                                     => cfg
     }
+    // $COVERAGE-ON$
   }
 
   final protected class Path private (private val segments: Vector[Path.Segment]) {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -103,7 +103,7 @@ private[compiletime] trait Configurations { this: Derivation =>
   }
   object TransformerFlags {
 
-    // $COVERAGE-OFF$It's testable in snippets not not really in normal tests with coverage
+    // $COVERAGE-OFF$It's testable in (Scala-CLI) snippets and not really in normal tests with coverage
     def global: TransformerFlags = XMacroSettings.foldLeft(TransformerFlags()) {
       case (cfg, transformerFlag"InheritedAccessors=$value") => cfg.copy(inheritedAccessors = value.toBoolean)
       case (cfg, transformerFlag"MethodAccessors=$value")    => cfg.copy(methodAccessors = value.toBoolean)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -103,12 +103,27 @@ private[compiletime] trait Configurations { this: Derivation =>
   }
   object TransformerFlags {
 
-    def global: TransformerFlags =
-      XMacroSettings.foldLeft(TransformerFlags()) {
-        case (cfg, transformerFlag"InheritedAccessors=$value") => cfg.copy(inheritedAccessors = value.toBoolean)
-        // TODO: the rest
-        case (cfg, _) => cfg
-      }
+    def global: TransformerFlags = XMacroSettings.foldLeft(TransformerFlags()) {
+      case (cfg, transformerFlag"InheritedAccessors=$value") => cfg.copy(inheritedAccessors = value.toBoolean)
+      case (cfg, transformerFlag"MethodAccessors=$value")    => cfg.copy(methodAccessors = value.toBoolean)
+      case (cfg, transformerFlag"DefaultValues=$value")      => cfg.copy(processDefaultValues = value.toBoolean)
+      case (cfg, transformerFlag"BeanSetters=$value")        => cfg.copy(beanSetters = value.toBoolean)
+      case (cfg, transformerFlag"BeanSettersIgnoreUnmatched=$value") =>
+        cfg.copy(beanSettersIgnoreUnmatched = value.toBoolean)
+      case (cfg, transformerFlag"NonUnitBeanSetters=$value")   => cfg.copy(nonUnitBeanSetters = value.toBoolean)
+      case (cfg, transformerFlag"BeanGetters=$value")          => cfg.copy(beanGetters = value.toBoolean)
+      case (cfg, transformerFlag"OptionDefaultsToNone=$value") => cfg.copy(optionDefaultsToNone = value.toBoolean)
+      case (cfg, transformerFlag"PartialUnwrapsOption=$value") => cfg.copy(partialUnwrapsOption = value.toBoolean)
+      case (cfg, transformerFlag"NonAnyValWrappers=$value")    => cfg.copy(nonAnyValWrappers = value.toBoolean)
+      case (cfg, transformerFlag"ImplicitConflictResolution=$value") =>
+        cfg.copy(implicitConflictResolution = value match {
+          case "Total"   => Some(dsls.PreferTotalTransformer)
+          case "Partial" => Some(dsls.PreferPartialTransformer)
+          case "none"    => None
+        })
+      case (cfg, transformerFlag"MacrosLogging=$value") => cfg.copy(displayMacrosLogging = value.toBoolean)
+      case (cfg, _)                                     => cfg
+    }
   }
 
   final protected class Path private (private val segments: Vector[Path.Segment]) {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -118,9 +118,9 @@ private[compiletime] trait Configurations { this: Derivation =>
       case (cfg, transformerFlag"NonAnyValWrappers=$value")    => cfg.copy(nonAnyValWrappers = value.toBoolean)
       case (cfg, transformerFlag"ImplicitConflictResolution=$value") =>
         cfg.copy(implicitConflictResolution = value match {
-          case "Total"   => Some(dsls.PreferTotalTransformer)
-          case "Partial" => Some(dsls.PreferPartialTransformer)
-          case "none"    => None
+          case "PreferTotalTransformer"   => Some(dsls.PreferTotalTransformer)
+          case "PreferPartialTransformer" => Some(dsls.PreferPartialTransformer)
+          case "none"                     => None
         })
       case (cfg, transformerFlag"MacrosLogging=$value") => cfg.copy(displayMacrosLogging = value.toBoolean)
       case (cfg, _)                                     => cfg

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -61,6 +61,85 @@ If we do not want to enable the same flag(s) in several places, we can define sh
     an implicit `TransformerConfiguration` would be considerd new default settings in new derivations, but would not
     cause `.into.transform` to ignore an implicit if one is present. 
 
+## Changing the flags for every derivation in the project
+
+While `TransformerConfiguration` let us share configs (flags) between several derivations, we might also want to set up
+some of them globally, for the whole project. Luckily, Scala 2.12, 2.13 and 3.3 give us `-Xmacro-settings` flag, which
+is intended to pass configuration into the macros.
+
+!!! example
+
+    ```scala
+    // in build.sbt:
+    
+    // log the derivation of every Transformer in project
+    scalacOptions += "-Xmacro-settings:chimney.transformer.MacrosLogging=true"
+    ```
+
+!!! notice
+
+    `-Xmacro-settings:...` is comma-separated, so if you want to pass multiple options, then either
+    
+      * provide this option more than once (`-Xmacro-settings:option-a -Xmacro-settings:option-b`)
+      * provide this option one separating then with a coma (`-Xmacro-settings:option-a,option-b`)
+
+As you can see `Transformer`'s flags have the prefix `chimney.transformer.`:
+
+| Flag in DSL                                                   | Option for `-Xmacro-settings:...`                                         | Description                                                                                                                                                                               |
+|---------------------------------------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.enableMethodAccessors`                                      | `chimney.transformer.MethodAccessors=true`                                | turn on [Reading from methods](supported-transformations.md#reading-from-methods)                                                                                                         |
+| `.disableMethodAccessors`                                     | `chimney.transformer.MethodAccessors=false`                               | turn off [Reading from methods](supported-transformations.md#reading-from-methods) (default)                                                                                              |
+| `.enableInheritedAccessors`                                   | `chimney.transformer.InheritedAccessors=true`                             | turn on [Reading from inherited values/methods](supported-transformations.md#reading-from-inherited-valuesmethods)                                                                        |
+| `.disableInheritedAccessors`                                  | `chimney.transformer.InheritedAccessors=false`                            | turn off [Reading from inherited values/methods](supported-transformations.md#reading-from-inherited-valuesmethods) (default)                                                             |
+| `.enableBeanGetters`                                          | `chimney.transformer.BeanGetters=true`                                    | turn on [Reading from Bean getters](supported-transformations.md#reading-from-bean-getters)                                                                                               |
+| `.disableBeanGetters`                                         | `chimney.transformer.BeanGetters=false`                                   | turn off [Reading from Bean getters](supported-transformations.md#reading-from-bean-getters) (default)                                                                                    |
+| `.enableBeanSetters`                                          | `chimney.transformer.BeanSetters=true`                                    | turn on [Writing to Bean setters](supported-transformations.md#writing-to-bean-setters)                                                                                                   |
+| `.disableBeanSetters`                                         | `chimney.transformer.BeanSetters=false`                                   | turn off [Writing to Bean setters](supported-transformations.md#writing-to-bean-setters) (default)                                                                                        |
+| `.enableBeanSettersIgnoreUnmatched`                           | `chimney.transformer.BeanSettersIgnoreUnmatched=true`                     | turn on [Ignoring unmatched Bean setters](supported-transformations.md#ignoring-unmatched-bean-setters)                                                                                   |
+| `.disableBeanSettersIgnoreUnmatched`                          | `chimney.transformer.BeanSettersIgnoreUnmatched=false`                    | turn off [Ignoring unmatched Bean setters](supported-transformations.md#ignoring-unmatched-bean-setters) (default)                                                                        |
+| `.enableNonUnitBeanSetters`                                   | `chimney.transformer.NonUnitBeanSetters=true`                             | turn on [Writing to non-`Unit` Bean setters](supported-transformations.md#writing-to-non-unit-bean-setters)                                                                               |
+| `.disableNonUnitBeanSetters`                                  | `chimney.transformer.NonUnitBeanSetters=false`                            | turn off [Writing to non-`Unit` Bean setters](supported-transformations.md#writing-to-non-unit-bean-setters) (default)                                                                    |
+| `.enableDefaultValues`                                        | `chimney.transformer.DefaultValues=true`                                  | turn on [Allowing fallback to the constructor's default values](supported-transformations.md#allowing-fallback-to-the-constructors-default-values)                                        |
+| `.disableDefaultValues`                                       | `chimney.transformer.DefaultValues=false`                                 | turn off [Allowing fallback to the constructor's default values](supported-transformations.md#allowing-fallback-to-the-constructors-default-values) (default)                             |
+| `.enableOptionDefaultsToNone`                                 | `chimney.transformer.OptionDefaultsToNone=true`                           | turn on [Allowing fallback to `None` as the constructor's argument](supported-transformations.md#allowing-fallback-to-none-as-the-constructors-argument)                                  |
+| `.disableOptionDefaultsToNone`                                | `chimney.transformer.OptionDefaultsToNone=false`                          | turn off [Allowing fallback to `None` as the constructor's argument](supported-transformations.md#allowing-fallback-to-none-as-the-constructors-argument) (default)                       |
+| `.enableNonAnyValWrappers`                                    | `chimney.transformer.NonAnyValWrappers=true`                              | turn on [Transformation from/into a wrapper type](supported-transformations.md#frominto-a-wrapper-type)                                                                                   |
+| `.disableNonAnyValWrappers`                                   | `chimney.transformer.NonAnyValWrappers=false`                             | turn off [Transformation from/into a wrapper type](supported-transformations.md#frominto-a-wrapper-type) (default)                                                                        |
+| `.enablePartialUnwrapsOption`                                 | `chimney.transformer.PartialUnwrapsOption=true`                           | turn on [Controlling automatic `Option` unwrapping](supported-transformations.md#controlling-automatic-option-unwrapping)  (default)                                                      |
+| `.disablePartialUnwrapsOption`                                | `chimney.transformer.PartialUnwrapsOption=false`                          | turn off [Controlling automatic `Option` unwrapping](supported-transformations.md#controlling-automatic-option-unwrapping)                                                                |
+| `.enableImplicitConflictResolution(PreferTotalTransformer)`   | `chimney.transformer.ImplicitConflictResolution=PreferTotalTransformer`   | turn on [Resolving priority of implicit Total vs Partial Transformers](supported-transformations.md#resolving-priority-of-implicit-total-vs-partial-transformers) to Total Transformers   |
+| `.enableImplicitConflictResolution(PreferPartialTransformer)` | `chimney.transformer.ImplicitConflictResolution=PreferPartialTransformer` | turn on [Resolving priority of implicit Total vs Partial Transformers](supported-transformations.md#resolving-priority-of-implicit-total-vs-partial-transformers) to Partial Transformers |
+| `.disableImplicitConflictResolution`                          | `chimney.transformer.ImplicitConflictResolution=none`                     | turn off [Resolving priority of implicit Total vs Partial Transformers](supported-transformations.md#resolving-priority-of-implicit-total-vs-partial-transformers) (default)              |
+| `.enableMacrosLogging`                                        | `chimney.transformer.MacrosLogging=true`                                  | turn on [Debugging macros](troubleshooting.md#debugging-macros)                                                                                                                           |
+| `.disableMacrosLogging`                                       | `chimney.transformer.MacrosLogging=false`                                 | turn off [Debugging macros](troubleshooting.md#debugging-macros) (default)                                                                                                                |
+
+`Patcher`'s flags have the prefix`chimney.patcher.`:
+
+| Flag in DSL                     | Option for `-Xmacro-settings:...`                    | Description                                                                                                                                           |
+|---------------------------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.ignoreRedundantPatcherFields` | `chimney.patcher.IgnoreRedundantPatcherFields=true`  | turn on [Ignoring fields in patches](supported-patching.md#ignoring-fields-in-patches)                                                                |
+| `.failRedundantPatcherFields`   | `chimney.patcher.IgnoreRedundantPatcherFields=false` | turn off [Ignoring fields in patches](supported-patching.md#ignoring-fields-in-patches) (default)                                                     |
+| `.ignoreNoneInPatch`            | `chimney.patcher.IgnoreNoneInPatch=true`             | turn on [Treating `None` as no-update instead of "set to `None`"](supported-patching.md#treating-none-as-no-update-instead-of-set-to-none)            |
+| `.clearOnNoneInPatch`           | `chimney.patcher.IgnoreNoneInPatch=false`            | turn off [Treating `None` as no-update instead of "set to `None`"](supported-patching.md#treating-none-as-no-update-instead-of-set-to-none) (default) |
+| `.enableMacrosLogging`          | `chimney.patcher.MacrosLogging=true`                 | turn on [Debugging macros](troubleshooting.md#debugging-macros)                                                                                       |
+| `.disableMacrosLogging`         | `chimney.patcher.MacrosLogging=false`                | turn off [Debugging macros](troubleshooting.md#debugging-macros) (default)                                                                            |
+
+### Suppressing warnings in macros
+
+There are additional global options only available through `-Xmacro-settings`. They can be used to add annotations
+`@java.lang.SuppressWarnings` and `@scala.annotation.nowarn`, which is useful in suppressing warnings from plug-ins
+like [WartRemover](https://www.wartremover.org/) or [Scapegoat](https://github.com/scapegoat-scala/scapegoat).
+
+| Option for `-Xmacro-settings:...`            | Description                                                                   |
+|----------------------------------------------|-------------------------------------------------------------------------------|
+| `chimney.SuppressWarnings=warning1;warning2` | annotates the generated code with `@SuppressWarnings("warning1", "warning2")` |
+| `chimney.SuppressWarnings=none`              | does not annotate the generated code with `@SuppressWarnings`                 |
+| `chimney.nowarn=msg`                         | annotates the generated code with `@nowarn("msg")`                            |
+| `chimney.nowarn=true`                        | annotates the generated code with `@nowarn`                                   |
+| `chimney.nowarn=none`                        | does not annotate the generated code with `@nowarn`                           |
+
+By default, code is annotated with`@SuppressWarnings("org.wartremover.warts.All", "all")` and without `@nowarn`. 
+
 ## Automatic, Semiautomatic and Inlined derivation
 
 When you use the standard way of working with Chimney, but `import io.scalaland.chimney.dsl._`


### PR DESCRIPTION
- [x] Scala-version-agnostic `-Xmacro-settings`
- [x] allow overriding every single `Transformer` (`Boolean`) flag
  - [x] `chimney.transformer.InheritedAccessors=boolean`
  - [x] `chimney.transformer.MethodAccessors=boolean`
  - [x] `chimney.transformer.DefaultValues=boolean`
  - [x] `chimney.transformer.BeanSetters=boolean`
  - [x] `chimney.transformer.BeanSettersIgnoreUnmatched=boolean`
  - [x] `chimney.transformer.NonUnitBeanSetters=boolean`
  - [x] `chimney.transformer.BeanGetters=boolean`
  - [x] `chimney.transformer.OptionDefaultsToNone=boolean`
  - [x] `chimney.transformer.PartialUnwrapsOption=boolean`
  - [x] `chimney.transformer.NonAnyValWrappers=boolean`
  - [x] `chimney.transformer.ImplicitConflictResolution=Total/Partial/false`
  - [x] `chimney.transformer.MacrosLogging=boolean`
- [x] allow overriding every single `Patcher` (`Boolean`) flag
  - [x] `chimney.patcher.IgnoreRedundantPatcherFields=boolean`
  - [x] `chimney.patcher.IgnoreNoneInPatch=boolean`
  - [x] `chimney.patcher.MacrosLogging=boolean`
- [x] allow providing comma-separated list of values to `@SuppressWarnings(Array(...))` and `@NoWarn(...)`
  - [x] `chimney.SuppressWarnings=false/list`
  - [x] `chimney.NoWarn=false/true/msg`
- [x] docs
  - [x] add a section about global flags override under scope-flags
  - [x] add a section about all possible settings and default values
