### PR TITLE
Add the `Result#fromCatchingNonFatal`

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Result.scala
@@ -591,6 +591,25 @@ object Result {
       case t: Throwable => fromErrorThrowable(t)
     }
 
+  /** Converts possibly throwing computation into [[io.scalaland.chimney.partial.Result]] by catching only
+    * [[scala.util.control.NonFatal NonFatal Exceptions]].
+    *
+    * @tparam A
+    *   type of successful result
+    * @param value
+    *   computation to run while catching its [[scala.util.control.NonFatal NonFatal Exceptions]]
+    * @return
+    *   successful [[io.scalaland.chimney.partial.Result.Value]] if computation didn't throw, failed
+    *   [[io.scalaland.chimney.partial.Result.Errors]] with caught Exception if it threw
+    * @since 1.5.0
+    */
+  final def fromCatchingNonFatal[A](value: => A): Result[A] =
+    try
+      fromValue(value)
+    catch {
+      case scala.util.control.NonFatal(t) => fromErrorThrowable(t)
+    }
+
   /** Converts an [[scala.collection.Iterator]] of input type into selected collection of output type, aggregating
     * errors from conversions of individual elements.
     *

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialResultSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialResultSpec.scala
@@ -266,6 +266,23 @@ class PartialResultSpec extends ChimneySpec {
     partial.Result.fromCatching(throw exception) ==> partial.Result.fromErrorThrowable(exception)
   }
 
+  test("fromCatchingNonFatal converts thunk to Result caching NonFatal Throwable as Error") {
+    val nseEx = new NoSuchElementException("oops")
+    partial.Result.fromCatchingNonFatal(1) ==> partial.Result.fromValue(1)
+    partial.Result.fromCatchingNonFatal(throw nseEx) ==> partial.Result.fromErrorThrowable(nseEx)
+  }
+
+  test("fromCatchingNonFatal propagates Fatal Throwable") {
+    try
+      partial.Result.fromCatchingNonFatal(throw new OutOfMemoryError("oops"))
+    catch {
+      case _: VirtualMachineError =>
+        ()
+      case th: Throwable =>
+        throw th
+    }
+  }
+
   test(
     "traverse with failFast = false preserves parallel semantics (both branches are executed even if one of them fails)"
   ) {


### PR DESCRIPTION
This PR adds one utility method which is similar to `cats.syntax.EitherObjectOps#catchNonFatal`.