### PR TITLE
Add the `Transformer#apply` for intuitive implicit summoning

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -43,6 +43,12 @@ trait Transformer[From, To] extends Transformer.AutoDerived[From, To] {
   */
 object Transformer extends TransformerCompanionPlatform {
 
+  /** Access an implicit `Transformer[From, To]`.
+    *
+    * @since 1.5.0
+    */
+  def apply[From, To](implicit t: Transformer[From, To]): Transformer[From, To] = t
+
   /** Creates an empty [[io.scalaland.chimney.dsl.TransformerDefinition]] that you can customize to derive
     * [[io.scalaland.chimney.Transformer]].
     *

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSpec.scala
@@ -1,0 +1,12 @@
+package io.scalaland.chimney
+
+class TotalTransformerSpec extends ChimneySpec {
+
+  test("implicit summon") {
+    implicit val stringTransformer = new Transformer[String, Int] {
+      override def transform(src: String): Int = src.length
+    }
+
+    Transformer[String, Int].transform("foo") ==> 3
+  }
+}


### PR DESCRIPTION
That way of summoning is commonly used in the projects I used to work on. In conjunction with #591, it might give a great experience of writing Transformers:
```scala
object CommonTransformers {
  implicit val strIntTransformer: Transformer[String, Int] = _.length
}

case class Id(value: String)

object DomainTransformers {
  import CommonTransformers._

  implicit val idTransformer: Transformer[Id, Int] = Transformer[String, Int].contramap(_.value)
}
```