### PR TITLE
Fix ClassCastException for lowercase objects in Scala 3

### DIFF
--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprPromisesPlatform.scala
@@ -140,10 +140,6 @@ private[compiletime] trait ExprPromisesPlatform extends ExprPromises { this: Def
         // Scala 3's enums' parameterless cases are vals with type erased, so w have to match them by value
         // case arg @ Enum.Value => ...
         CaseDef(Bind(bindName, Ident(sym.termRef)), None, body)
-        else if sym.flags.is(Flags.Module) then
-        // case objects are also matched by value but the tree for them is generated in a slightly different way
-        // case arg @ Enum.Value => ...
-        CaseDef(Bind(bindName, Ident(sym.companionModule.termRef)), None, body)
         else
           // case arg : Enum.Value => ...
           CaseDef(Bind(bindName, Typed(Wildcard(), TypeTree.of[SomeFrom])), None, body)

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -769,4 +769,23 @@ class IssuesSpec extends ChimneySpec {
       .withFieldConst(_.bar.matchingSome.baz.everyItem.b, "new")
       .transform ==> Foo(Some(Bar(List(Baz(a = 10, b = "new", c = 10.0), Baz(a = 10, b = "new", c = 20.0)))))
   }
+
+  test("fix-issue #479") {
+    import Issue479.*
+    val orangeTarget = Target.Impl("orange")
+    val pinkTarget = Target.Impl("pink")
+    val yellowTarget = Target.Impl("yellow")
+
+    val writer: Transformer[color, Target] = Transformer
+      .define[color, Target]
+      .withCoproductInstance[color.orange.type](_ => orangeTarget)
+      .withCoproductInstance[color.pink.type](_ => pinkTarget)
+      .withCoproductInstance[color.yellow.type](_ => yellowTarget)
+      .enableMacrosLogging
+      .buildTransformer
+
+    assert(writer.transform(color.pink) == pinkTarget)
+    assert(writer.transform(color.yellow) == yellowTarget)
+    assert(writer.transform(color.orange) == orangeTarget)
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -214,3 +214,17 @@ object Issue579 {
   case class Bar(baz: List[Baz])
   case class Baz(a: Int, b: String, c: Double)
 }
+
+object Issue479 {
+  sealed trait color
+  object color {
+    case object orange extends color
+    case object pink extends color
+    case object yellow extends color
+  }
+
+  sealed trait Target
+  object Target {
+    case class Impl(value: String) extends Target
+  }
+}


### PR DESCRIPTION
(presumably) fixes #479

I haven't seen anything being broken by this change locally, but let's see if CI agrees...