### PR TITLE
Revert Scala 3 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ciRelease := {
 val versions = new {
   val scala212 = "2.12.20"
   val scala213 = "2.13.15"
-  val scala3 = "3.3.4"
+  val scala3 = "3.3.3"
 
   // Which versions should be cross-compiled for publishing
   val scalas = List(scala212, scala213, scala3)


### PR DESCRIPTION
Reverts https://github.com/scalalandio/chimney/pull/606 as Scala 3.3.4 fails to compile. (Bug report in progress, need to find a case which reproduces it).

https://github.com/scalalandio/chimney/actions/runs/11091447973/job/30815198166