### PR TITLE
Refactor path utility

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -140,6 +140,8 @@ private[compiletime] trait Configurations { this: Derivation =>
     def everyMapKey: Path = new Path(segments :+ EveryMapKey)
     def everyMapValue: Path = new Path(segments :+ EveryMapValue)
 
+    def concat(path: Path): Path = new Path(segments ++ path.segments)
+
     @scala.annotation.tailrec
     def drop(prefix: Path)(implicit ctx: TransformationContext[?, ?]): Option[Path] = (prefix, this) match {
       case (Root, result)                                                                         => Some(result)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -163,6 +163,8 @@ private[compiletime] trait Configurations { this: Derivation =>
 
     val Root = new Path(Vector())
 
+    def apply(selector: Path => Path): Path = selector(Root)
+
     object AtField {
       def unapply(path: Path): Option[(String, Path)] =
         path.segments.headOption.collect { case Segment.Select(name) => name -> new Path(path.segments.tail) }
@@ -232,7 +234,7 @@ private[compiletime] trait Configurations { this: Derivation =>
         case TargetPath(toPath)   => toPath.drop(droppedTo).map(TargetPath(_))
       }
   }
-  object SidedPath {
+  protected object SidedPath {
 
     def unapply(sidedPath: SidedPath): Some[Path] = sidedPath match {
       case SourcePath(fromPath) => Some(fromPath)

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -49,9 +49,7 @@ private[compiletime] trait Derivation
       updateRules: List[Rule] => List[Rule] = identity
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] = {
     val newCtx: TransformationContext[NewFrom, NewTo] =
-      ctx
-        .updateFromTo[NewFrom, NewTo](newSrc)
-        .updateConfig(_.prepareForRecursiveCall(followFrom, followTo))
+      ctx.updateFromTo[NewFrom, NewTo](newSrc, followFrom, followTo)
     deriveTransformationResultExprUpdatingRules(updateRules)(newCtx)
       .logSuccess {
         case TransformationExpr.TotalExpr(expr)   => s"Derived recursively total expression ${Expr.prettyPrint(expr)}"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -44,21 +44,14 @@ private[compiletime] trait Derivation
   /** Intended use case: recursive derivation within rules */
   final protected def deriveRecursiveTransformationExpr[NewFrom: Type, NewTo: Type](
       newSrc: Expr[NewFrom],
-      followFrom: Path,
-      followTo: Path
-  )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] =
-    deriveRecursiveTransformationExprUpdatingRules[NewFrom, NewTo](newSrc, followFrom, followTo)(identity)
-
-  /** Intended use case: recursive derivation within rules which should remove some rules from consideration */
-  final protected def deriveRecursiveTransformationExprUpdatingRules[NewFrom: Type, NewTo: Type](
-      newSrc: Expr[NewFrom],
-      followFrom: Path,
-      followTo: Path
-  )(
-      updateRules: List[Rule] => List[Rule]
+      followFrom: Path = Path.Root,
+      followTo: Path = Path.Root,
+      updateRules: List[Rule] => List[Rule] = identity
   )(implicit ctx: TransformationContext[?, ?]): DerivationResult[TransformationExpr[NewTo]] = {
     val newCtx: TransformationContext[NewFrom, NewTo] =
-      ctx.updateFromTo[NewFrom, NewTo](newSrc).updateConfig(_.prepareForRecursiveCall(followFrom, followTo))
+      ctx
+        .updateFromTo[NewFrom, NewTo](newSrc)
+        .updateConfig(_.prepareForRecursiveCall(followFrom, followTo))
     deriveTransformationResultExprUpdatingRules(updateRules)(newCtx)
       .logSuccess {
         case TransformationExpr.TotalExpr(expr)   => s"Derived recursively total expression ${Expr.prettyPrint(expr)}"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
@@ -31,8 +31,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
       useOverrideIfPresentOr("matchingLeft", ctx.config.filterCurrentOverridesForLeft) {
         deriveRecursiveTransformationExpr[FromL, ToL](
           ctx.src.upcastToExprOf[Left[FromL, FromR]].value,
-          Path.Root.matching[Left[FromL, FromR]],
-          Path.Root.matching[Left[ToL, ToR]]
+          Path(_.matching[Left[FromL, FromR]]),
+          Path(_.matching[Left[ToL, ToR]])
         )
       }
         .flatMap { (derivedToL: TransformationExpr[ToL]) =>
@@ -47,8 +47,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
       useOverrideIfPresentOr("matchingRight", ctx.config.filterCurrentOverridesForRight) {
         deriveRecursiveTransformationExpr[FromR, ToR](
           ctx.src.upcastToExprOf[Right[FromL, FromR]].value,
-          Path.Root.matching[Right[FromL, FromR]],
-          Path.Root.matching[Right[ToL, ToR]]
+          Path(_.matching[Right[FromL, FromR]]),
+          Path(_.matching[Right[ToL, ToR]])
         )
       }
         .flatMap { (derivedToR: TransformationExpr[ToR]) =>
@@ -66,8 +66,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
           useOverrideIfPresentOr("matchingLeft", ctx.config.filterCurrentOverridesForLeft) {
             deriveRecursiveTransformationExpr[FromL, ToL](
               leftExpr,
-              Path.Root.matching[Either[FromL, FromR]],
-              Path.Root.matching[Left[ToL, ToR]]
+              Path(_.matching[Either[FromL, FromR]]),
+              Path(_.matching[Left[ToL, ToR]])
             )
           }
         }
@@ -78,8 +78,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
           useOverrideIfPresentOr("matchingRight", ctx.config.filterCurrentOverridesForRight) {
             deriveRecursiveTransformationExpr[FromR, ToR](
               rightExpr,
-              Path.Root.matching[Either[FromL, FromR]],
-              Path.Root.matching[Right[ToL, ToR]]
+              Path(_.matching[Either[FromL, FromR]]),
+              Path(_.matching[Right[ToL, ToR]])
             )
           }
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -57,14 +57,14 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
         .promise[FromK](ExprPromise.NameGenerationStrategy.FromPrefix("key"))
         .traverse { key =>
           useOverrideIfPresentOr("everyMapKey", ctx.config.filterCurrentOverridesForEveryMapKey) {
-            deriveRecursiveTransformationExpr[FromK, ToK](key, Path.Root.everyMapKey, Path.Root.everyMapKey)
+            deriveRecursiveTransformationExpr[FromK, ToK](key, Path(_.everyMapKey), Path(_.everyMapKey))
           }.map(_.ensurePartial -> key)
         }
       val toValueResult = ExprPromise
         .promise[FromV](ExprPromise.NameGenerationStrategy.FromPrefix("value"))
         .traverse { value =>
           useOverrideIfPresentOr("everyMapValue", ctx.config.filterCurrentOverridesForEveryMapValue) {
-            deriveRecursiveTransformationExpr[FromV, ToV](value, Path.Root.everyMapValue, Path.Root.everyMapValue)
+            deriveRecursiveTransformationExpr[FromV, ToV](value, Path(_.everyMapValue), Path(_.everyMapValue))
           }.map(_.ensurePartial)
         }
 
@@ -119,7 +119,7 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
         .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromExpr(ctx.src))
         .traverse { (newFromSrc: Expr[InnerFrom]) =>
           useOverrideIfPresentOr("everyItem", ctx.config.filterCurrentOverridesForEveryItem) {
-            deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromSrc, Path.Root.everyItem, Path.Root.everyItem)
+            deriveRecursiveTransformationExpr[InnerFrom, InnerTo](newFromSrc, Path(_.everyItem), Path(_.everyItem))
           }
         }
         .flatMap { (to2P: ExprPromise[InnerFrom, TransformationExpr[InnerTo]]) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformMapToMapRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformMapToMapRuleModule.scala
@@ -76,14 +76,14 @@ private[compiletime] trait TransformMapToMapRuleModule {
         .promise[FromK](ExprPromise.NameGenerationStrategy.FromPrefix("key"))
         .traverse { key =>
           useOverrideIfPresentOr("everyMapKey", ctx.config.filterCurrentOverridesForEveryMapKey) {
-            deriveRecursiveTransformationExpr[FromK, ToK](key, Path.Root.everyMapKey, Path.Root.everyMapKey)
+            deriveRecursiveTransformationExpr[FromK, ToK](key, Path(_.everyMapKey), Path(_.everyMapKey))
           }.map(_.ensureTotal)
         }
       val toValueResult = ExprPromise
         .promise[FromV](ExprPromise.NameGenerationStrategy.FromPrefix("value"))
         .traverse { value =>
           useOverrideIfPresentOr("everyMapValue", ctx.config.filterCurrentOverridesForEveryMapValue) {
-            deriveRecursiveTransformationExpr[FromV, ToV](value, Path.Root.everyMapValue, Path.Root.everyMapValue)
+            deriveRecursiveTransformationExpr[FromV, ToV](value, Path(_.everyMapValue), Path(_.everyMapValue))
           }.map(_.ensureTotal)
         }
 
@@ -123,14 +123,14 @@ private[compiletime] trait TransformMapToMapRuleModule {
         .promise[FromK](ExprPromise.NameGenerationStrategy.FromPrefix("key"))
         .traverse { key =>
           useOverrideIfPresentOr("everyMapKey", ctx.config.filterCurrentOverridesForEveryMapKey) {
-            deriveRecursiveTransformationExpr[FromK, ToK](key, Path.Root.everyMapKey, Path.Root.everyMapKey)
+            deriveRecursiveTransformationExpr[FromK, ToK](key, Path(_.everyMapKey), Path(_.everyMapKey))
           }.map(_.ensurePartial -> key)
         }
       val toValueResult = ExprPromise
         .promise[FromV](ExprPromise.NameGenerationStrategy.FromPrefix("value"))
         .traverse { value =>
           useOverrideIfPresentOr("everyMapValue", ctx.config.filterCurrentOverridesForEveryMapValue) {
-            deriveRecursiveTransformationExpr[FromV, ToV](value, Path.Root.everyMapValue, Path.Root.everyMapValue)
+            deriveRecursiveTransformationExpr[FromV, ToV](value, Path(_.everyMapValue), Path(_.everyMapValue))
           }.map(_.ensurePartial -> value)
         }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -40,8 +40,8 @@ private[compiletime] trait TransformOptionToOptionRuleModule {
           useOverrideIfPresentOr("matchingSome", ctx.config.filterCurrentOverridesForSome) {
             deriveRecursiveTransformationExpr[InnerFrom, InnerTo](
               newFromExpr,
-              Path.Root.matching[Some[InnerFrom]],
-              Path.Root.matching[Some[InnerTo]]
+              Path(_.matching[Some[InnerFrom]]),
+              Path(_.matching[Some[InnerTo]])
             )
           }
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
@@ -49,8 +49,7 @@ private[compiletime] trait TransformPartialOptionToNonOptionRuleModule { this: D
               await(
                 deriveRecursiveTransformationExpr[InnerFrom, To](
                   from2Expr,
-                  Path.Root.matching[Some[InnerFrom]],
-                  Path.Root
+                  followFrom = Path(_.matching[Some[InnerFrom]])
                 )
               ).ensurePartial
             }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -408,7 +408,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
             deriveRecursiveTransformationExpr[ExtractedSrc, CtorParam](
               extractedSrcExpr,
               sourcePath,
-              Path.Root.select(toName)
+              Path(_.select(toName))
             )
               .transformWith { expr =>
                 // If we derived partial.Result[$ctorParam] we are appending:
@@ -460,8 +460,8 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
           // '{ ${ derivedToElement } } // using ${ src.$name }
           deriveRecursiveTransformationExpr[Getter, CtorParam](
             get(ctx.src),
-            Path.Root.select(fromName),
-            Path.Root.select(toName)
+            Path(_.select(fromName)),
+            Path(_.select(toName))
           ).transformWith { expr =>
             // If we derived partial.Result[$ctorParam] we are appending:
             //  ${ derivedToElement }.prependErrorPath(PathElement.Accessor("fromName"))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformTypeToValueClassRuleModule.scala
@@ -33,8 +33,7 @@ private[compiletime] trait TransformTypeToValueClassRuleModule {
   )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
     deriveRecursiveTransformationExpr[From, InnerTo](
       ctx.src,
-      Path.Root,
-      Path.Root.select(innerToFieldName)
+      followTo = Path(_.select(innerToFieldName))
     )
       .flatMap { derivedInnerTo =>
         // We're constructing:

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToTypeRuleModule.scala
@@ -34,8 +34,7 @@ private[compiletime] trait TransformValueClassToTypeRuleModule {
       // '{ ${ derivedTo } /* using ${ src }.from internally */ }
       deriveRecursiveTransformationExpr[InnerFrom, To](
         unwrapFromIntoInnerFrom(ctx.src),
-        Path.Root.select(innerFromFieldName),
-        Path.Root
+        followFrom = Path(_.select(innerFromFieldName))
       )
         .flatMap(DerivationResult.expanded)
         // fall back to case classes expansion; see https://github.com/scalalandio/chimney/issues/297 for more info

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformValueClassToValueClassRuleModule.scala
@@ -44,8 +44,8 @@ private[compiletime] trait TransformValueClassToValueClassRuleModule { this: Der
   )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
     deriveRecursiveTransformationExpr[InnerFrom, InnerTo](
       unwrapFromIntoInnerFrom(ctx.src),
-      Path.Root.select(innerFromFieldName),
-      Path.Root.select(innerToFieldName)
+      Path(_.select(innerFromFieldName)),
+      Path(_.select(innerToFieldName))
     ).flatMap { (derivedInnerTo: TransformationExpr[InnerTo]) =>
       // We're constructing:
       // '{ ${ new $To(${ derivedInnerTo }) } /* using ${ src }.$from internally */ }


### PR DESCRIPTION
- allow replacing `Path.Root.matching[Foo].select(bar)` with `Path(_.matching[Foo].select[Bar])` which is closer to how users would define them in DSL
- merge `deriveRecursiveTransformationExpr` with `deriveRecursiveTransformationExprUpdatingRules` by using defaults
- start keeping book for all the intermediate `src` we defined so far (they might be just `src.field1.field1`, but they might also be `map( inner => ... ) // <-- inner` which would allow us to access `.everyItem` and friend in field renaming