### PR TITLE
Failed attempt to resolve the warnings via implicit priorities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ciRelease := {
 val versions = new {
   val scala212 = "2.12.20"
   val scala213 = "2.13.15"
-  val scala3 = "3.3.4"
+  val scala3 = "3.5.1"
 
   // Which versions should be cross-compiled for publishing
   val scalas = List(scala212, scala213, scala3)
@@ -84,7 +84,9 @@ val settings = Seq(
           // format: off
           "-encoding", "UTF-8",
           "-rewrite",
-          "-source", "3.3-migration",
+          //"-source", "3.4-migration",
+          "-source", "3.6",
+          //"-source", "3.3-migration",
           // format: on
           "-unchecked",
           "-deprecation",
@@ -102,7 +104,7 @@ val settings = Seq(
           "-Wunused:implicits",
           "-Wunused:params",
           "-Wvalue-discard",
-          "-Xfatal-warnings",
+          //"-Xfatal-warnings",
           "-Xcheck-macros",
           "-Ykind-projector:underscores"
         )

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -63,7 +63,7 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
         '{ scala.IArray.apply[A](${ quoted.Varargs[A](args.toSeq) }*)(using ${ summonImplicitUnsafe[ClassTag[A]] }) }
 
       def map[A: Type, B: Type](iarray: Expr[IArray[A]])(fExpr: Expr[A => B]): Expr[scala.IArray[B]] =
-        '{ ${ resetOwner(iarray) }.map(${ resetOwner(fExpr) })(${ summonImplicitUnsafe[ClassTag[B]] }) }
+        '{ ${ resetOwner(iarray) }.map(${ resetOwner(fExpr) })(using ${ summonImplicitUnsafe[ClassTag[B]] }) }
 
       def to[A: Type, C: Type](iarray: Expr[IArray[A]])(
           factoryExpr: Expr[scala.collection.compat.Factory[A, C]]

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -64,7 +64,7 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
           // $COVERAGE-OFF$should never happen unless we messed up
           case out =>
             assertionFailed(
-              s"Constructor of ${Type.prettyPrint(fromUntyped[Any](tpe))} has unrecognized/unsupported format of type: $out"
+              s"Constructor of ${Type.prettyPrint(using fromUntyped[Any](tpe))} has unrecognized/unsupported format of type: $out"
             )
           // $COVERAGE-ON$
         }

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/IterableOrArraysPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/IterableOrArraysPlatform.scala
@@ -16,9 +16,11 @@ trait IterableOrArraysPlatform extends IterableOrArrays { this: DefinitionsPlatf
           new IterableOrArray[M, Inner] {
             def factory: Expr[Factory[Inner, M]] =
               '{
-                io.scalaland.chimney.integrations.FactoryCompat.iarrayFactory[Inner](${
-                  Expr.summonImplicitUnsafe[ClassTag[Inner]]
-                })
+                io.scalaland.chimney.integrations.FactoryCompat.iarrayFactory[Inner](using
+                  ${
+                    Expr.summonImplicitUnsafe[ClassTag[Inner]]
+                  }
+                )
               }.asExprOf[Factory[Inner, M]]
 
             def iterator(m: Expr[M]): Expr[Iterator[Inner]] =

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -32,8 +32,8 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
           assert(
             Argument <:< Inner,
             s"Wrapper/AnyVal ${Type.prettyPrint[A]} only property's type (${Type
-                .prettyPrint(Argument)}) was expected to be the same as only constructor argument's type (${Type
-                .prettyPrint(Inner)})"
+                .prettyPrint(using Argument)}) was expected to be the same as only constructor argument's type (${Type
+                .prettyPrint(using Inner)})"
           )
           Some(
             Existential[WrapperClass[A, *], Inner](

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Existentials.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Existentials.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney.internal.compiletime
 
-private[compiletime] trait Existentials { this: Types with Exprs =>
+private[compiletime] trait Existentials { this: Types & Exprs =>
 
   /** Represents value with some existential type `t` both for `Type[t]` as well as `F[t]`.
     *
@@ -20,7 +20,7 @@ private[compiletime] trait Existentials { this: Types with Exprs =>
       val value: F[Underlying]
 
       def mapK[G[_]](f: Type[Underlying] => F[Underlying] => G[Underlying]): Bounded[L, U, G] =
-        Bounded[L, U, G, Underlying](f(Underlying)(value))(Underlying)
+        Bounded[L, U, G, Underlying](f(Underlying)(value))(using Underlying)
     }
     object Bounded {
       def apply[L, U >: L, F[_ >: L <: U], A >: L <: U: Type](value: F[A]): Bounded[L, U, F] =
@@ -63,9 +63,9 @@ private[compiletime] trait Existentials { this: Types with Exprs =>
       def apply[U, A <: U](implicit A: Type[A]): Bounded[Nothing, U] = Existential.Bounded[Nothing, U, Type, A](A)
     }
 
-    def apply[A](implicit A: Type[A]): ExistentialType = Existential[Type, A](A)(A)
+    def apply[A](implicit A: Type[A]): ExistentialType = Existential[Type, A](A)(using A)
 
-    def prettyPrint(existentialType: ExistentialType): String = Type.prettyPrint(existentialType.Underlying)
+    def prettyPrint(existentialType: ExistentialType): String = Type.prettyPrint(using existentialType.Underlying)
   }
 
   /** Convenient utility to represent `Expr[?]` with erased inner type with accompanying `Type[?]` of the same `?`. */
@@ -74,7 +74,7 @@ private[compiletime] trait Existentials { this: Types with Exprs =>
 
     def apply[A: Type](expr: Expr[A]): ExistentialExpr = Existential[Expr, A](expr)
 
-    def withoutType[A](expr: Expr[A]): ExistentialExpr = apply(expr)(Expr.typeOf(expr))
+    def withoutType[A](expr: Expr[A]): ExistentialExpr = apply(expr)(using Expr.typeOf(expr))
 
     def prettyPrint(existentialExpr: ExistentialExpr): String = Expr.prettyPrint(existentialExpr.value)
   }

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
@@ -178,7 +178,7 @@ private[compiletime] trait Types { this: (Existentials & Results) =>
       .unapply(S)
       .getOrElse {
         // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
-        assertionFailed(s"Invalid string literal type: ${prettyPrint(S)}")
+        assertionFailed(s"Invalid string literal type: ${prettyPrint(using S)}")
         // $COVERAGE-ON$
       }
       .value
@@ -199,12 +199,12 @@ private[compiletime] trait Types { this: (Existentials & Results) =>
 
     def isTuple: Boolean = Type.isTuple(tpe)
     def isAnyVal: Boolean = tpe <:< Type.AnyVal
-    def isOption: Boolean = tpe <:< Type.Option(Type.Any)
-    def isEither: Boolean = tpe <:< Type.Either(Type.Any, Type.Any)
-    def isLeft: Boolean = tpe <:< Type.Either.Left(Type.Any, Type.Any)
-    def isRight: Boolean = tpe <:< Type.Either.Right(Type.Any, Type.Any)
-    def isIterable: Boolean = tpe <:< Type.Iterable(Type.Any)
-    def isMap: Boolean = tpe <:< Type.Map(Type.Any, Type.Any)
+    def isOption: Boolean = tpe <:< Type.Option(using Type.Any)
+    def isEither: Boolean = tpe <:< Type.Either(using Type.Any, Type.Any)
+    def isLeft: Boolean = tpe <:< Type.Either.Left(using Type.Any, Type.Any)
+    def isRight: Boolean = tpe <:< Type.Either.Right(using Type.Any, Type.Any)
+    def isIterable: Boolean = tpe <:< Type.Iterable(using Type.Any)
+    def isMap: Boolean = tpe <:< Type.Map(using Type.Any, Type.Any)
 
     def as_?? : ?? = ExistentialType[A](tpe)
     def as_>?<[L <: A, U >: A]: L >?< U = ExistentialType.Bounded[L, U, A](tpe)

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -48,7 +48,7 @@ trait ProductTypes { this: Definitions =>
     final case class Extraction[From](extraction: Getters[From])
     object Extraction {
       def unapply[From](From: Type[From]): Option[Getters[From]] =
-        ProductType.parseExtraction(From).map(getters => getters.extraction)
+        ProductType.parseExtraction(using From).map(getters => getters.extraction)
     }
 
     final case class Parameter[A](targetType: Parameter.TargetType, defaultValue: Option[Expr[A]])
@@ -62,7 +62,7 @@ trait ProductTypes { this: Definitions =>
         /** When constructing, value will be passed as setter argument */
         final case class SetterParameter(returnedType: ??) extends TargetType {
           override def toString: String =
-            s"SetterParameter(returnedType = ${Type.prettyPrint(returnedType.Underlying)})"
+            s"SetterParameter(returnedType = ${Type.prettyPrint(using returnedType.Underlying)})"
         }
       }
     }
@@ -76,7 +76,7 @@ trait ProductTypes { this: Definitions =>
     final case class Constructor[To](parameters: Parameters, constructor: Arguments => Expr[To])
     object Constructor {
       def unapply[To](To: Type[To]): Option[(Parameters, Arguments => Expr[To])] =
-        ProductType.parseConstructor(To).map(constructor => constructor.parameters -> constructor.constructor)
+        ProductType.parseConstructor(using To).map(constructor => constructor.parameters -> constructor.constructor)
 
       def exprAsInstanceOfMethod[To: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Constructor[To] =
         ProductType.exprAsInstanceOfMethod[To](args)(expr)
@@ -109,7 +109,7 @@ trait ProductTypes { this: Definitions =>
     final def parse[A: Type]: Option[Product[A]] = parseExtraction[A].zip(parseConstructor[A]).headOption.map {
       case (getters, constructor) => Product(getters, constructor)
     }
-    final def unapply[A](tpe: Type[A]): Option[Product[A]] = parse(tpe)
+    final def unapply[A](tpe: Type[A]): Option[Product[A]] = parse(using tpe)
 
     def exprAsInstanceOfMethod[A: Type](args: List[ListMap[String, ??]])(expr: Expr[Any]): Product.Constructor[A]
 
@@ -145,7 +145,7 @@ trait ProductTypes { this: Definitions =>
             // $COVERAGE-OFF$should never happen unless we messed up
             assertionFailed(
               s"Constructor of ${Type.prettyPrint[A]} expected expr for parameter $param of type ${Type
-                  .prettyPrint[param.Underlying]}, instead got ${Expr.prettyPrint(argument.value)} ${Type.prettyPrint(argument.Underlying)}"
+                  .prettyPrint[param.Underlying]}, instead got ${Expr.prettyPrint(argument.value)} ${Type.prettyPrint(using argument.Underlying)}"
             )
             // $COVERAGE-ON$
           }

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
@@ -19,7 +19,7 @@ trait SealedHierarchies { this: Definitions =>
   protected trait SealedHierarchyModule { this: SealedHierarchy.type =>
 
     def parse[A: Type]: Option[Enum[A]]
-    final def unapply[A](tpe: Type[A]): Option[Enum[A]] = parse(tpe)
+    final def unapply[A](tpe: Type[A]): Option[Enum[A]] = parse(using tpe)
 
     def isJavaEnum[A: Type]: Boolean
 
@@ -28,6 +28,6 @@ trait SealedHierarchies { this: Definitions =>
 
   implicit class SealedHierarchyOps[A](private val tpe: Type[A]) {
 
-    def isSealed: Boolean = SealedHierarchy.isSealed(tpe)
+    def isSealed: Boolean = SealedHierarchy.isSealed(using tpe)
   }
 }

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SingletonTypes.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SingletonTypes.scala
@@ -47,6 +47,6 @@ trait SingletonTypes { this: (Definitions & ProductTypes) =>
         case _ => None
       }
     }
-    final def unapply[A](tpe: Type[A]): Option[Singleton[A]] = parse(tpe)
+    final def unapply[A](tpe: Type[A]): Option[Singleton[A]] = parse(using tpe)
   }
 }

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ValueClasses.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ValueClasses.scala
@@ -31,7 +31,7 @@ trait ValueClasses { this: Definitions =>
   protected trait WrapperClassTypeModule { this: WrapperClassType.type =>
 
     def parse[A: Type]: Option[Existential[WrapperClass[A, *]]]
-    final def unapply[A](tpe: Type[A]): Option[Existential[WrapperClass[A, *]]] = parse(tpe)
+    final def unapply[A](tpe: Type[A]): Option[Existential[WrapperClass[A, *]]] = parse(using tpe)
   }
 
   protected object ValueClassType {
@@ -45,6 +45,6 @@ trait ValueClasses { this: Definitions =>
           }
         }
       else None
-    def unapply[A](tpe: Type[A]): Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]] = parse(tpe)
+    def unapply[A](tpe: Type[A]): Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]] = parse(using tpe)
   }
 }

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/fp/ApplicativeTraverse.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/fp/ApplicativeTraverse.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.internal.compiletime.fp
 trait ApplicativeTraverse[F[_]] extends Traverse[F] with Applicative[F] {
 
   override def map[A, B](fa: F[A])(f: A => B): F[B] =
-    traverse[Applicative.Id, A, B](fa)(f)(Applicative.IdentityApplicative)
+    traverse[Applicative.Id, A, B](fa)(f)(using Applicative.IdentityApplicative)
 }
 object ApplicativeTraverse {
 

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/fp/Traverse.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/fp/Traverse.scala
@@ -7,7 +7,7 @@ trait Traverse[F[_]] extends Functor[F] {
   def parTraverse[G[_]: Parallel, A, B](fa: F[A])(f: A => G[B]): G[F[B]]
 
   override def map[A, B](fa: F[A])(f: A => B): F[B] =
-    traverse[Applicative.Id, A, B](fa)(f)(Applicative.IdentityApplicative)
+    traverse[Applicative.Id, A, B](fa)(f)(using Applicative.IdentityApplicative)
 }
 object Traverse {
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -258,7 +258,7 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
           Type.of[runtime.ArgumentLists.List[Head, Tail]]
       }
 
-      ApplyParams(head, tail)
+      ApplyParams(using head, tail)
     }
 
     private def constructArgumentListType(
@@ -273,7 +273,7 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
           Type.of[runtime.ArgumentList.Argument[ParamName, ParamType, Args]]
       }
 
-      ApplyParam(
+      ApplyParam(using
         ConstantType(StringConstant(name)).asType.asInstanceOf[Type[String]],
         tpe.tpe.asType.asInstanceOf[Type[Any]],
         args

--- a/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
@@ -168,7 +168,9 @@ object PartialTransformer extends PartialTransformerCompanionPlatform {
   }
 
   /** @since 0.8.0 */
-  object AutoDerived extends PartialTransformerAutoDerivedCompanionPlatform {
+  object AutoDerived extends AutoDerivedLowPriorityImplicits1
+  private[chimney] trait AutoDerivedLowPriorityImplicits1 extends PartialTransformerAutoDerivedCompanionPlatform {
+    this: AutoDerived.type =>
 
     implicit def liftTotal[From, To](implicit total: Transformer[From, To]): AutoDerived[From, To] =
       (src: From, failFast: Boolean) => partial.Result.fromCatching(total.transform(src))

--- a/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Patcher.scala
@@ -80,5 +80,8 @@ object Patcher extends PatcherCompanionPlatform {
   }
 
   /** @since 0.8.0 */
-  object AutoDerived extends PatcherAutoDerivedCompanionPlatform
+  object AutoDerived extends AutoDerivedLowPriorityImplicits1
+  private[chimney] trait AutoDerivedLowPriorityImplicits1 extends PatcherAutoDerivedCompanionPlatform {
+    this: AutoDerived.type =>
+  }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -101,7 +101,13 @@ object Transformer extends TransformerCompanionPlatform {
   }
 
   /** @since 0.8.0 */
-  object AutoDerived extends TransformerAutoDerivedCompanionPlatform
+  object AutoDerived extends AutoDerivedLowPriorityImplicits1
+  private[chimney] trait AutoDerivedLowPriorityImplicits1 extends AutoDerivedLowPriorityImplicits2 {
+    this: AutoDerived.type =>
+  }
+  private[chimney] trait AutoDerivedLowPriorityImplicits2 extends TransformerAutoDerivedCompanionPlatform {
+    this: AutoDerived.type =>
+  }
 }
 // extended by TransformerCompanionPlatform
 private[chimney] trait TransformerLowPriorityImplicits1 extends TransformerLowPriorityImplicits2 {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Contexts.scala
@@ -23,8 +23,8 @@ private[compiletime] trait Contexts { this: Derivation =>
         .asInstanceOf[this.type]
 
     override def toString: String =
-      s"PatcherContext[A = ${Type.prettyPrint(A)}, Patch = ${Type
-          .prettyPrint(Patch)}](obj = ${Expr.prettyPrint(obj)}, patch = ${Expr.prettyPrint(patch)})($config)"
+      s"PatcherContext[A = ${Type.prettyPrint(using A)}, Patch = ${Type
+          .prettyPrint(using Patch)}](obj = ${Expr.prettyPrint(obj)}, patch = ${Expr.prettyPrint(patch)})($config)"
   }
   object PatcherContext {
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
@@ -150,7 +150,7 @@ private[compiletime] trait Derivation
         if (ctx.config.flags.ignoreRedundantPatcherFields)
           DerivationResult.pure(None)
         else
-          DerivationResult.patcherError(PatchFieldNotFoundInTargetObj(patchFieldName, Type.prettyPrint(ctx.A)))
+          DerivationResult.patcherError(PatchFieldNotFoundInTargetObj(patchFieldName, Type.prettyPrint(using ctx.A)))
     }
   }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -203,7 +203,7 @@ private[compiletime] trait Configurations { this: Derivation =>
           case _              => false
         }
 
-        override def toString: String = s".matching[${Type.prettyPrint(tpe.Underlying)}]"
+        override def toString: String = s".matching[${Type.prettyPrint(using tpe.Underlying)}]"
       }
       final case class SourceMatching(tpe: ??) extends Segment {
         override def equals(obj: Any): Boolean = obj match {
@@ -211,7 +211,7 @@ private[compiletime] trait Configurations { this: Derivation =>
           case _              => false
         }
 
-        override def toString: String = s" if src.isInstanceOf[${Type.prettyPrint(tpe.Underlying)}]"
+        override def toString: String = s" if src.isInstanceOf[${Type.prettyPrint(using tpe.Underlying)}]"
       }
       case object EveryItem extends Segment {
         override def toString: String = ".everyItem"

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
@@ -99,7 +99,7 @@ private[compiletime] trait Contexts { this: Derivation =>
       ): B = forTotal(this)
 
       override def toString: String =
-        s"ForTotal[From = ${Type.prettyPrint(From)}, To = ${Type.prettyPrint(To)}](src = ${Expr.prettyPrint(src)})($config)"
+        s"ForTotal[From = ${Type.prettyPrint(using From)}, To = ${Type.prettyPrint(using To)}](src = ${Expr.prettyPrint(src)})($config)"
     }
 
     object ForTotal {
@@ -126,7 +126,7 @@ private[compiletime] trait Contexts { this: Derivation =>
     ) extends TransformationContext[From, To] {
 
       final type Target = partial.Result[To]
-      val Target = ChimneyType.PartialResult(To)
+      val Target = ChimneyType.PartialResult(using To)
 
       override def fold[B](
           forTotal: TransformationContext.ForTotal[From, To] => B
@@ -135,8 +135,8 @@ private[compiletime] trait Contexts { this: Derivation =>
       ): B = forPartial(this)
 
       override def toString: String =
-        s"ForPartial[From = ${Type.prettyPrint(From)}, To = ${Type
-            .prettyPrint(To)}](src = ${Expr.prettyPrint(src)}, failFast = ${Expr.prettyPrint(failFast)})($config)"
+        s"ForPartial[From = ${Type.prettyPrint(using From)}, To = ${Type
+            .prettyPrint(using To)}](src = ${Expr.prettyPrint(src)}, failFast = ${Expr.prettyPrint(failFast)})($config)"
     }
 
     object ForPartial {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -104,13 +104,13 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
       DerivationResult.log {
         val gettersStr = fromExtractors
           .map { case (k, v) =>
-            s"`$k`: ${Type.prettyPrint(v.Underlying)} (${v.value.sourceType}, ${if (!v.value.isInherited) "declared"
+            s"`$k`: ${Type.prettyPrint(using v.Underlying)} (${v.value.sourceType}, ${if (!v.value.isInherited) "declared"
               else "inherited"})"
           }
           .mkString(", ")
         val constructorStr = parameters
           .map { case (k, v) =>
-            s"`$k`: ${Type.prettyPrint(v.Underlying)} (${v.value.targetType}, default = ${v.value.defaultValue
+            s"`$k`: ${Type.prettyPrint(using v.Underlying)} (${v.value.targetType}, default = ${v.value.defaultValue
                 .map(a => Expr.prettyPrint(a))})"
           }
           .mkString(", ")
@@ -688,7 +688,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                         },
                         // Here, we're building:
                         // '{ if (allerrors == null) $ifBlock else $elseBock }
-                        Expr.ifElse[partial.Result[ToOrPartialTo]](allerrors eqExpr Expr.Null) {
+                        Expr.ifElse[partial.Result[ToOrPartialTo]](allerrors `eqExpr` Expr.Null) {
                           // Here, we're building:
                           // '{ partial.Result.Value(${ constructor }) } // using res1.asInstanceOf[partial.Result.Value[Tpe]].value, ...
                           ChimneyExpr.PartialResult

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -32,8 +32,8 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
         toElements: Enum.Elements[To]
     )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       DerivationResult.log {
-        val fromSubs = fromElements.map(tpe => Type.prettyPrint(tpe.Underlying)).mkString(", ")
-        val toSubs = toElements.map(tpe => Type.prettyPrint(tpe.Underlying)).mkString(", ")
+        val fromSubs = fromElements.map(tpe => Type.prettyPrint(using tpe.Underlying)).mkString(", ")
+        val toSubs = toElements.map(tpe => Type.prettyPrint(using tpe.Underlying)).mkString(", ")
         s"Resolved ${Type.prettyPrint[From]} subtypes: ($fromSubs) and ${Type.prettyPrint[To]} subtypes ($toSubs)"
       } >> mapOverriddenElements[From, To].flatMap { overrideMappings =>
         Traverse[List]

--- a/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala
@@ -1,0 +1,23 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+
+class IssuesScala3Spec extends ChimneySpec {
+
+  test("fix issue #592 (givens in companion)") {
+    case class Foo(a: Int, b: String)
+    case class Bar(a: Int, b: String)
+    case class Baz(a: Int)
+    object Foo {
+      given totalTransformer: Transformer[Foo, Bar] =
+        Transformer.define[Foo, Bar].withFieldConst(_.a, 10).buildTransformer
+      given partialTransformer: PartialTransformer[Foo, Bar] =
+        PartialTransformer.define[Foo, Bar].withFieldConst(_.a, 20).buildTransformer
+      given patcher: Patcher[Foo, Baz] = (_, baz) => Foo(baz.a, "patched")
+    }
+
+    Foo(1, "value").transformInto[Bar] ==> Bar(10, "value")
+    Foo(1, "value").transformIntoPartial[Bar].asOption.get ==> Bar(20, "value")
+    Foo(1, "value").patchUsing(Baz(30)) ==> Foo(30, "patched")
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
@@ -31,7 +31,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[Bar]
-      .withConstructor(nullaryConstructor _)
+      .withConstructor((() => nullaryConstructor()))
       .transform
     result.asOption ==> Some(nullaryExpected)
     result.asEither ==> Right(nullaryExpected)
@@ -51,7 +51,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result3 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[Bar]
-      .withConstructorPartial(nullaryConstructorPartial _)
+      .withConstructorPartial((() => nullaryConstructorPartial()))
       .transform
     result3.asOption ==> Some(nullaryExpected)
     result3.asEither ==> Right(nullaryExpected)
@@ -73,7 +73,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result5 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[Bar]
-      .withConstructor(uncurriedConstructor _)
+      .withConstructor(uncurriedConstructor)
       .transform
     result5.asOption ==> Some(uncurriedExpected)
     result5.asEither ==> Right(uncurriedExpected)
@@ -94,7 +94,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result7 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[Bar]
-      .withConstructorPartial(uncurriedConstructorPartial _)
+      .withConstructorPartial(uncurriedConstructorPartial)
       .transform
     result7.asOption ==> Some(uncurriedExpected)
     result7.asEither ==> Right(uncurriedExpected)
@@ -116,7 +116,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result9 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[Bar]
-      .withConstructor(curriedConstructor _)
+      .withConstructor(curriedConstructor)
       .transform
     result9.asOption ==> Some(curriedExpected)
     result9.asEither ==> Right(curriedExpected)
@@ -137,7 +137,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result11 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[Bar]
-      .withConstructorPartial(curriedConstructorPartial _)
+      .withConstructorPartial(curriedConstructorPartial)
       .transform
     result11.asOption ==> Some(curriedExpected)
     result11.asEither ==> Right(curriedExpected)
@@ -159,7 +159,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result13 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[BarParams[Int, Double]]
-      .withConstructor(typeParametricConstructor[Int, Double] _)
+      .withConstructor(typeParametricConstructor[Int, Double])
       .transform
     result13.asOption ==> Some(typeParametricExpected)
     result13.asEither ==> Right(typeParametricExpected)
@@ -170,7 +170,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result14 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[BarParams[Int, Double]]
-      .withConstructorPartial(typeParametricConstructorPartial[Int, Double] _)
+      .withConstructorPartial(typeParametricConstructorPartial[Int, Double])
       .transform
     result14.asOption ==> Some(typeParametricExpected)
     result14.asEither ==> Right(typeParametricExpected)
@@ -181,7 +181,7 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
     val result15 = Foo(3, "pi", (3.14, 3.14))
       .intoPartial[BarParams[Int, Double]]
-      .withConstructorEither(typeParametricConstructorEither[Int, Double] _)
+      .withConstructorEither(typeParametricConstructorEither[Int, Double])
       .transform
     result15.asOption ==> Some(typeParametricExpected)
     result15.asEither ==> Right(typeParametricExpected)

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -21,7 +21,7 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
-      .withConstructor(nullaryConstructor _)
+      .withConstructor((() => nullaryConstructor()))
       .transform ==> Bar(0, (0.0, 0.0))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
@@ -34,7 +34,7 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
-      .withConstructor(uncurriedConstructor _)
+      .withConstructor(uncurriedConstructor)
       .transform ==> Bar(6, (6.28, 6.28))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
@@ -47,7 +47,7 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
-      .withConstructor(curriedConstructor _)
+      .withConstructor(curriedConstructor)
       .transform ==> Bar(9, (9.42, 9.42))
     Foo(3, "pi", (3.14, 3.14))
       .into[Bar]
@@ -60,7 +60,7 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
     Foo(3, "pi", (3.14, 3.14))
       .into[BarParams[Int, Double]]
-      .withConstructor(typeParametricConstructor[Int, Double] _)
+      .withConstructor(typeParametricConstructor[Int, Double])
       .transform ==> BarParams(3, (3.14, 12.56))
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -24,7 +24,7 @@ object tag {
   def apply[Tag] = new Tagger[Tag]
 
   trait Tagged[Tag]
-  type @@[+A, Tag] = A with Tagged[Tag]
+  type @@[+A, Tag] = A & Tagged[Tag]
 
   class Tagger[Tag] {
     def apply[A](a: A): A @@ Tag = a.asInstanceOf[A @@ Tag]

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/javabeans/javabeans.scala
@@ -41,9 +41,9 @@ class JavaBeanSourceWithAmbiguity(var id: String, var name: String, var flag: Bo
 }
 
 class JavaBeanTarget {
-  private var id: String = _
-  private var name: String = _
-  private var flag: Boolean = _
+  private var id: String = scala.compiletime.uninitialized
+  private var name: String = scala.compiletime.uninitialized
+  private var flag: Boolean = scala.compiletime.uninitialized
 
   def setId(id: String): Unit =
     this.id = id
@@ -72,7 +72,7 @@ class JavaBeanTarget {
 }
 
 class JavaBeanTargetNoIdSetter {
-  private var id: String = _
+  private var id: String = scala.compiletime.uninitialized
 
   def withId(id: String): Unit =
     this.id = id
@@ -91,9 +91,9 @@ class JavaBeanTargetNoIdSetter {
 }
 
 class JavaBeanTargetNonUnitSetter {
-  private var id: String = _
-  private var name: String = _
-  private var flag: Boolean = _
+  private var id: String = scala.compiletime.uninitialized
+  private var name: String = scala.compiletime.uninitialized
+  private var flag: Boolean = scala.compiletime.uninitialized
 
   def getId(): String = id
   def setId(id: String): Unit = this.id = id
@@ -120,7 +120,7 @@ class JavaBeanTargetNonUnitSetter {
 case class EnclosingCaseClass(ccNoFlag: CaseClassNoFlag)
 
 class EnclosingBean {
-  private var ccNoFlag: CaseClassNoFlag = _
+  private var ccNoFlag: CaseClassNoFlag = scala.compiletime.uninitialized
 
   def getCcNoFlag: CaseClassNoFlag = ccNoFlag
 


### PR DESCRIPTION
This PR was created only to document that using [implicit priorities to solve the new 3.7-givens](https://www.scala-lang.org/2024/08/19/given-priority-change-3.7.html#explicit-prioritization-by-owner) behavior have failed: Scala 3.5.1 still generates the warnings that would become failures in 3.7. I gave up.

```
[warn] -- Warning: /home/runner/work/chimney/chimney/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala:19:38 
[warn] 19 |    Foo(1, "value").transformInto[Bar] ==> Bar(10, "value")
[warn]    |                                      ^
[warn]    |Given search preference for io.scalaland.chimney.Transformer.AutoDerived[Foo, Bar] between alternatives
[warn]    |  (Foo.totalTransformer : io.scalaland.chimney.Transformer[Foo, Bar])
[warn]    |and
[warn]    |  (io.scalaland.chimney.Transformer.AutoDerived.deriveAutomatic :
[warn]    |  [From, To]: io.scalaland.chimney.Transformer.AutoDerived[From, To])
[warn]    |will change.
[warn]    |Current choice           : the first alternative
[warn]    |New choice from Scala 3.7: none - it's ambiguous
[warn] -- Warning: /home/runner/work/chimney/chimney/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala:20:45 
[warn] 20 |    Foo(1, "value").transformIntoPartial[Bar].asOption.get ==> Bar(20, "value")
[warn]    |                                             ^
[warn]    |Given search preference for io.scalaland.chimney.PartialTransformer.AutoDerived[Foo, Bar] between alternatives
[warn]    |  (Foo.partialTransformer : io.scalaland.chimney.PartialTransformer[Foo, Bar])
[warn]    |and
[warn]    |  (io.scalaland.chimney.PartialTransformer.AutoDerived.deriveAutomatic :
[warn]    |  [From, To]: io.scalaland.chimney.PartialTransformer.AutoDerived[From, To])
[warn]    |will change.
[warn]    |Current choice           : the first alternative
[warn]    |New choice from Scala 3.7: none - it's ambiguous
[warn] -- Warning: /home/runner/work/chimney/chimney/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala:21:39 
[warn] 21 |    Foo(1, "value").patchUsing(Baz(30)) ==> Foo(30, "patched")
[warn]    |                                       ^
[warn]    |Given search preference for io.scalaland.chimney.Patcher.AutoDerived[Foo, Baz] between alternatives
[warn]    |  (Foo.patcher : io.scalaland.chimney.Patcher[Foo, Baz])
[warn]    |and
[warn]    |  (io.scalaland.chimney.Patcher.AutoDerived.deriveAutomatic :
[warn]    |  [A, Patch]: io.scalaland.chimney.Patcher.AutoDerived[A, Patch])
[warn]    |will change.
[warn]    |Current choice           : the first alternative
[warn]    |New choice from Scala 3.7: none - it's ambiguous
```