### PR TITLE
Define TotalOuterTransformer and PartialOuterTransformer

### DIFF
--- a/chimney-cats/src/test/scala-2.13+/io/scalaland/chimney/cats/CatsData213Spec.scala
+++ b/chimney-cats/src/test/scala-2.13+/io/scalaland/chimney/cats/CatsData213Spec.scala
@@ -2,9 +2,16 @@ package io.scalaland.chimney.cats
 
 import cats.data.NonEmptyLazyList
 import io.scalaland.chimney.ChimneySpec
+import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl.*
 
 class CatsData213Spec extends ChimneySpec {
+
+  test("DSL should always allow transformation between NonEmptyLazyLists") {
+    implicit val intToStr: Transformer[Int, String] = _.toString
+
+    NonEmptyLazyList(1).transformInto[NonEmptyLazyList[String]] ==> NonEmptyLazyList("1")
+  }
 
   test("DSL should handle transformation to and from cats.data.NonEmptyLazyList") {
     List("test").transformIntoPartial[NonEmptyLazyList[String]].asOption ==> Some(NonEmptyLazyList("test"))

--- a/chimney-cats/src/test/scala/io/scalaland/chimney/cats/CatsDataSpec.scala
+++ b/chimney-cats/src/test/scala/io/scalaland/chimney/cats/CatsDataSpec.scala
@@ -2,9 +2,32 @@ package io.scalaland.chimney.cats
 
 import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptyMap, NonEmptySeq, NonEmptySet, NonEmptyVector}
 import io.scalaland.chimney.ChimneySpec
+import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl.*
 
 class CatsDataSpec extends ChimneySpec {
+
+  test("DSL should always allow transformation when outer type has Traverse") {
+    implicit val intToStr: Transformer[Int, String] = _.toString
+
+    NonEmptyChain.one(1).transformInto[NonEmptyChain[String]] ==> NonEmptyChain.one("1")
+    NonEmptyList.one(1).transformInto[NonEmptyList[String]] ==> NonEmptyList.one("1")
+    NonEmptyMap.one(1, 1).transformInto[NonEmptyMap[String, String]] ==> NonEmptyMap.one("1", "1")
+    NonEmptySeq.one(1).transformInto[NonEmptySeq[String]] ==> NonEmptySeq.one("1")
+    NonEmptyVector.one(1).transformInto[NonEmptyVector[String]] ==> NonEmptyVector.one("1")
+  }
+
+  test("DSL should always allow transformation between NonEmptyMaps") {
+    implicit val intToStr: Transformer[Int, String] = _.toString
+
+    NonEmptyMap.one(1, 1).transformInto[NonEmptyMap[String, String]] ==> NonEmptyMap.one("1", "1")
+  }
+
+  test("DSL should always allow transformation between NonEmptySets") {
+    implicit val intToStr: Transformer[Int, String] = _.toString
+
+    NonEmptySet.one(1).transformInto[NonEmptySet[String]] ==> NonEmptySet.one("1")
+  }
 
   test("DSL should handle transformation to and from cats.data.Chain") {
     List("test").transformInto[Chain[String]] ==> Chain("test")

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/Types.scala
@@ -40,6 +40,20 @@ private[compiletime] trait Types { this: (Existentials & Results) =>
         extends Ctor3Bounded[Nothing, U1, Nothing, U2, Nothing, U3, F]
     trait Ctor3[F[_, _, _]] extends Ctor3Bounded[Nothing, Any, Nothing, Any, Nothing, Any, F]
 
+    /** Allow applying and extracting some types `L1 <:< ? <:< U1, L2 <:< ? <:< U2, L3 <:< ? <:< U3, L4 <:< ? <:< U4` */
+    trait Ctor4Bounded[L1, U1 >: L1, L2, U2 >: L2, L3, U3 >: L3, L4, U4 >: L4, F[
+        _ >: L1 <: U1,
+        _ >: L2 <: U2,
+        _ >: L3 <: U3,
+        _ >: L4 <: U4
+    ]] {
+      def apply[A >: L1 <: U1: Type, B >: L2 <: U2: Type, C >: L3 <: U3: Type, D >: L4 <: U4: Type]: Type[F[A, B, C, D]]
+      def unapply[A](A: Type[A]): Option[(L1 >?< U1, L2 >?< U2, L3 >?< U3, L4 >?< U4)]
+    }
+    trait Ctor4UpperBounded[U1, U2, U3, U4, F[_ <: U1, _ <: U2, _ <: U3, _ <: U4]]
+        extends Ctor4Bounded[Nothing, U1, Nothing, U2, Nothing, U3, Nothing, U4, F]
+    trait Ctor4[F[_, _, _, _]] extends Ctor4Bounded[Nothing, Any, Nothing, Any, Nothing, Any, Nothing, Any, F]
+
     // Build-in types' definitions
 
     val Nothing: Type[Nothing]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -240,9 +240,10 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
       def transformWithPartialInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
           totalOuterTransformer: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]],
           src: Expr[From],
+          failFast: Expr[Boolean],
           inner: Expr[InnerFrom => partial.Result[InnerTo]]
       ): Expr[partial.Result[To]] =
-        c.Expr[partial.Result[To]](q"$totalOuterTransformer.transformWithPartialInner($src, $inner)")
+        c.Expr[partial.Result[To]](q"$totalOuterTransformer.transformWithPartialInner($src, $failFast, $inner)")
     }
 
     object DefaultValue extends DefaultValueModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -209,6 +209,42 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
       }
     }
 
+    object PartialOuterTransformer extends PartialOuterTransformerModule {
+
+      def transformWithTotalInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          partialOuterTransformer: Expr[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          failFast: Expr[Boolean],
+          inner: Expr[InnerFrom => InnerTo]
+      ): Expr[partial.Result[To]] =
+        c.Expr[partial.Result[To]](q"$partialOuterTransformer.transformWithTotalInner($src, $failFast, $inner)")
+
+      def transformWithPartialInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          partialOuterTransformer: Expr[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          failFast: Expr[Boolean],
+          inner: Expr[InnerFrom => partial.Result[InnerTo]]
+      ): Expr[partial.Result[To]] =
+        c.Expr[partial.Result[To]](q"$partialOuterTransformer.transformWithPartialInner($src, $failFast, $inner)")
+    }
+
+    object TotalOuterTransformer extends TotalOuterTransformerModule {
+
+      def transformWithTotalInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          totalOuterTransformer: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          inner: Expr[InnerFrom => InnerTo]
+      ): Expr[To] =
+        c.Expr[To](q"$totalOuterTransformer.transformWithTotalInner($src, $inner)")
+
+      def transformWithPartialInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          totalOuterTransformer: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          inner: Expr[InnerFrom => partial.Result[InnerTo]]
+      ): Expr[partial.Result[To]] =
+        c.Expr[partial.Result[To]](q"$totalOuterTransformer.transformWithPartialInner($src, $inner)")
+    }
+
     object DefaultValue extends DefaultValueModule {
 
       def provide[Value: Type](

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -406,6 +406,26 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       }
     }
 
+    object PartialOuterTransformer extends PartialOuterTransformerModule {
+      def apply[From: Type, To: Type, InnerFrom: Type, InnerTo: Type]
+          : Type[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]] =
+        weakTypeTag[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]]
+      def unapply[A](A: Type[A]): Option[(??, ??, ??, ??)] =
+        A.asCtor[integrations.PartialOuterTransformer[?, ?, ?, ?]]
+          .map(A0 => (A0.param(0), A0.param(1), A0.param(2), A0.param(3)))
+      def inferred[From: Type, To: Type]: ExistentialType =
+        weakTypeTag[integrations.PartialOuterTransformer[From, To, ?, ?]].as_??
+    }
+    object TotalOuterTransformer extends TotalOuterTransformerModule {
+      def apply[From: Type, To: Type, InnerFrom: Type, InnerTo: Type]
+          : Type[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]] =
+        weakTypeTag[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]]
+      def unapply[A](A: Type[A]): Option[(??, ??, ??, ??)] =
+        A.asCtor[integrations.TotalOuterTransformer[?, ?, ?, ?]]
+          .map(A0 => (A0.param(0), A0.param(1), A0.param(2), A0.param(3)))
+      def inferred[From: Type, To: Type]: ExistentialType =
+        weakTypeTag[integrations.TotalOuterTransformer[From, To, ?, ?]].as_??
+    }
     object DefaultValue extends DefaultValueModule {
       def apply[Value: Type]: Type[integrations.DefaultValue[Value]] =
         weakTypeTag[integrations.DefaultValue[Value]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -10,6 +10,7 @@ trait DerivationPlatform
     with datatypes.SealedHierarchiesPlatform
     with datatypes.ValueClassesPlatform
     with rules.TransformImplicitRuleModule
+    with rules.TransformImplicitOuterTransformerRuleModule
     with rules.TransformSubtypesRuleModule
     with rules.TransformToSingletonRuleModule
     with rules.TransformOptionToOptionRuleModule
@@ -26,6 +27,7 @@ trait DerivationPlatform
 
   final override protected val rulesAvailableForPlatform: List[Rule] = List(
     TransformImplicitRule,
+    TransformImplicitOuterTransformerRule,
     TransformSubtypesRule,
     TransformToSingletonRule,
     TransformOptionToOptionRule,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -227,8 +227,10 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
       def transformWithPartialInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
           totalOuterTransformer: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]],
           src: Expr[From],
+          failFast: Expr[Boolean],
           inner: Expr[InnerFrom => partial.Result[InnerTo]]
-      ): Expr[partial.Result[To]] = '{ ${ totalOuterTransformer }.transformWithPartialInner(${ src }, ${ inner }) }
+      ): Expr[partial.Result[To]] =
+        '{ ${ totalOuterTransformer }.transformWithPartialInner(${ src }, ${ failFast }, ${ inner }) }
     }
 
     object DefaultValue extends DefaultValueModule {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -197,6 +197,40 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
         }
     }
 
+    object PartialOuterTransformer extends PartialOuterTransformerModule {
+
+      def transformWithTotalInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          partialOuterTransformer: Expr[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          failFast: Expr[Boolean],
+          inner: Expr[InnerFrom => InnerTo]
+      ): Expr[partial.Result[To]] =
+        '{ ${ partialOuterTransformer }.transformWithTotalInner(${ src }, ${ failFast }, ${ inner }) }
+
+      def transformWithPartialInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          partialOuterTransformer: Expr[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          failFast: Expr[Boolean],
+          inner: Expr[InnerFrom => partial.Result[InnerTo]]
+      ): Expr[partial.Result[To]] =
+        '{ ${ partialOuterTransformer }.transformWithPartialInner(${ src }, ${ failFast }, ${ inner }) }
+    }
+
+    object TotalOuterTransformer extends TotalOuterTransformerModule {
+
+      def transformWithTotalInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          totalOuterTransformer: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          inner: Expr[InnerFrom => InnerTo]
+      ): Expr[To] = '{ ${ totalOuterTransformer }.transformWithTotalInner(${ src }, ${ inner }) }
+
+      def transformWithPartialInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
+          totalOuterTransformer: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]],
+          src: Expr[From],
+          inner: Expr[InnerFrom => partial.Result[InnerTo]]
+      ): Expr[partial.Result[To]] = '{ ${ totalOuterTransformer }.transformWithPartialInner(${ src }, ${ inner }) }
+    }
+
     object DefaultValue extends DefaultValueModule {
 
       def provide[Value: Type](

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -405,6 +405,30 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       }
     }
 
+    object PartialOuterTransformer extends PartialOuterTransformerModule {
+      def apply[From: Type, To: Type, InnerFrom: Type, InnerTo: Type]
+          : Type[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]] =
+        quoted.Type.of[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]]
+      def unapply[A](tpe: Type[A]): Option[(??, ??, ??, ??)] = tpe match {
+        case '[integrations.PartialOuterTransformer[from, to, innerFrom, innerTo]] =>
+          Some((Type[from].as_??, Type[to].as_??, Type[innerFrom].as_??, Type[innerTo].as_??))
+        case _ => None
+      }
+      def inferred[From: Type, To: Type]: ExistentialType =
+        quoted.Type.of[integrations.PartialOuterTransformer[From, To, ?, ?]].as_??
+    }
+    object TotalOuterTransformer extends TotalOuterTransformerModule {
+      def apply[From: Type, To: Type, InnerFrom: Type, InnerTo: Type]
+          : Type[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]] =
+        quoted.Type.of[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]]
+      def unapply[A](tpe: Type[A]): Option[(??, ??, ??, ??)] = tpe match {
+        case '[integrations.TotalOuterTransformer[from, to, innerFrom, innerTo]] =>
+          Some((Type[from].as_??, Type[to].as_??, Type[innerFrom].as_??, Type[innerTo].as_??))
+        case _ => None
+      }
+      def inferred[From: Type, To: Type]: ExistentialType =
+        quoted.Type.of[integrations.TotalOuterTransformer[From, To, ?, ?]].as_??
+    }
     object DefaultValue extends DefaultValueModule {
       def apply[Value: Type]: Type[integrations.DefaultValue[Value]] =
         quoted.Type.of[integrations.DefaultValue[Value]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/DerivationPlatform.scala
@@ -11,6 +11,7 @@ abstract private[compiletime] class DerivationPlatform(q: scala.quoted.Quotes)
     with datatypes.SealedHierarchiesPlatform
     with datatypes.ValueClassesPlatform
     with rules.TransformImplicitRuleModule
+    with rules.TransformImplicitOuterTransformerRuleModule
     with rules.TransformSubtypesRuleModule
     with rules.TransformToSingletonRuleModule
     with rules.TransformOptionToOptionRuleModule
@@ -27,6 +28,7 @@ abstract private[compiletime] class DerivationPlatform(q: scala.quoted.Quotes)
 
   final override protected val rulesAvailableForPlatform: List[Rule] = List(
     TransformImplicitRule,
+    TransformImplicitOuterTransformerRule,
     TransformSubtypesRule,
     TransformToSingletonRule,
     TransformOptionToOptionRule,

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/PartialOuterTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/PartialOuterTransformer.scala
@@ -1,0 +1,18 @@
+package io.scalaland.chimney.integrations
+
+import io.scalaland.chimney.partial
+
+trait PartialOuterTransformer[From, To, InnerFrom, InnerTo] {
+
+  def transformWithTotalInner(
+      src: From,
+      failFast: Boolean,
+      inner: InnerFrom => InnerTo
+  ): partial.Result[To]
+
+  def transformWithPartialInner(
+      src: From,
+      failFast: Boolean,
+      inner: InnerFrom => partial.Result[InnerTo]
+  ): partial.Result[To]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/PartialOuterTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/PartialOuterTransformer.scala
@@ -2,14 +2,30 @@ package io.scalaland.chimney.integrations
 
 import io.scalaland.chimney.partial
 
+/** Tells Chimney how to convert some outer types/wrappers/collections where conversions for their inner values/items
+  * could be derived, when the type sometimes cannot be constructed.
+  *
+  * @tparam From
+  *   whole outer source type (with all possible type parameters applied)
+  * @tparam To
+  *   whole outer target type (with all possible type parameters applied)
+  * @tparam InnerFrom
+  *   type of the value(s) inside From that Chimney can derive conversion from
+  * @tparam InnerTo
+  *   type of the value(s) inside To that Chimney can derive conversion to
+  *
+  * @since 1.5.0
+  */
 trait PartialOuterTransformer[From, To, InnerFrom, InnerTo] {
 
+  /** Converts the outer type when the conversion of inner type turns out to be total. */
   def transformWithTotalInner(
       src: From,
       failFast: Boolean,
       inner: InnerFrom => InnerTo
   ): partial.Result[To]
 
+  /** Converts the outer type when the conversion of inner type turns out to be partial. */
   def transformWithPartialInner(
       src: From,
       failFast: Boolean,

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalOuterTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalOuterTransformer.scala
@@ -1,0 +1,16 @@
+package io.scalaland.chimney.integrations
+
+import io.scalaland.chimney.partial
+
+trait TotalOuterTransformer[From, To, InnerFrom, InnerTo] {
+
+  def transformWithTotalInner(
+      src: From,
+      inner: InnerFrom => InnerTo
+  ): To
+
+  def transformWithPartialInner(
+      src: From,
+      inner: InnerFrom => partial.Result[InnerTo]
+  ): partial.Result[To]
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalOuterTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalOuterTransformer.scala
@@ -2,13 +2,29 @@ package io.scalaland.chimney.integrations
 
 import io.scalaland.chimney.partial
 
+/** Tells Chimney how to convert some outer types/wrappers/collections where conversions for their inner values/items
+  * could be derived, when the type can be always constructed.
+  *
+  * @tparam From
+  *   whole outer source type (with all possible type parameters applied)
+  * @tparam To
+  *   whole outer target type (with all possible type parameters applied)
+  * @tparam InnerFrom
+  *   type of the value(s) inside From that Chimney can derive conversion from
+  * @tparam InnerTo
+  *   type of the value(s) inside To that Chimney can derive conversion to
+  *
+  * @since 1.5.0
+  */
 trait TotalOuterTransformer[From, To, InnerFrom, InnerTo] {
 
+  /** Converts the outer type when the conversion of inner types turns out to be total. */
   def transformWithTotalInner(
       src: From,
       inner: InnerFrom => InnerTo
   ): To
 
+  /** Converts the outer type when the conversion of inner types turns out to be partial. */
   def transformWithPartialInner(
       src: From,
       failFast: Boolean,

--- a/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalOuterTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/integrations/TotalOuterTransformer.scala
@@ -11,6 +11,7 @@ trait TotalOuterTransformer[From, To, InnerFrom, InnerTo] {
 
   def transformWithPartialInner(
       src: From,
+      failFast: Boolean,
       inner: InnerFrom => partial.Result[InnerTo]
   ): partial.Result[To]
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
@@ -167,6 +167,7 @@ private[compiletime] trait ChimneyExprs { this: ChimneyDefinitions =>
       def transformWithPartialInner[From: Type, To: Type, InnerFrom: Type, InnerTo: Type](
           totalOuterTransformer: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]],
           src: Expr[From],
+          failFast: Expr[Boolean],
           inner: Expr[InnerFrom => partial.Result[InnerTo]]
       ): Expr[partial.Result[To]]
     }
@@ -334,9 +335,10 @@ private[compiletime] trait ChimneyExprs { this: ChimneyDefinitions =>
 
     def transformWithPartialInner(
         src: Expr[From],
+        failFast: Expr[Boolean],
         inner: Expr[InnerFrom => partial.Result[InnerTo]]
     ): Expr[partial.Result[To]] =
-      ChimneyExpr.TotalOuterTransformer.transformWithPartialInner(totalOuterTransformer, src, inner)
+      ChimneyExpr.TotalOuterTransformer.transformWithPartialInner(totalOuterTransformer, src, failFast, inner)
   }
 
   implicit final protected class DefaultValueOps[Value: Type](

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -289,6 +289,18 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
           ] { this: EveryMapValue.type => }
     }
 
+    val PartialOuterTransformer: PartialOuterTransformerModule
+    trait PartialOuterTransformerModule extends Type.Ctor4[integrations.PartialOuterTransformer] {
+      this: PartialOuterTransformer.type =>
+      def inferred[From: Type, To: Type]: ExistentialType
+    }
+
+    val TotalOuterTransformer: TotalOuterTransformerModule
+    trait TotalOuterTransformerModule extends Type.Ctor4[integrations.TotalOuterTransformer] {
+      this: TotalOuterTransformer.type =>
+      def inferred[From: Type, To: Type]: ExistentialType
+    }
+
     val DefaultValue: DefaultValueModule
     trait DefaultValueModule extends Type.Ctor1[integrations.DefaultValue] { this: DefaultValue.type => }
 
@@ -300,7 +312,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
     val PartiallyBuildIterable: PartiallyBuildIterableModule
     trait PartiallyBuildIterableModule extends Type.Ctor2[integrations.PartiallyBuildIterable] {
       this: PartiallyBuildIterable.type =>
-      def inferred[Optional: Type]: ExistentialType
+      def inferred[Collection: Type]: ExistentialType
     }
 
     val PartiallyBuildMap: PartiallyBuildMapModule
@@ -309,7 +321,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
     val TotallyBuildIterable: TotallyBuildIterableModule
     trait TotallyBuildIterableModule extends Type.Ctor2[integrations.TotallyBuildIterable] {
       this: TotallyBuildIterable.type =>
-      def inferred[Optional: Type]: ExistentialType
+      def inferred[Collection: Type]: ExistentialType
     }
 
     val TotallyBuildMap: TotallyBuildMapModule
@@ -340,6 +352,12 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
 
       implicit val RuntimeDataStoreType: Type[dsls.TransformerDefinitionCommons.RuntimeDataStore] = RuntimeDataStore
 
+      implicit def PartialOuterTransformerType[From: Type, To: Type, InnerFrom: Type, InnerTo: Type]
+          : Type[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]] =
+        PartialOuterTransformer[From, To, InnerFrom, InnerTo]
+      implicit def TotalOuterTransformerType[From: Type, To: Type, InnerFrom: Type, InnerTo: Type]
+          : Type[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]] =
+        TotalOuterTransformer[From, To, InnerFrom, InnerTo]
       implicit def DefaultValueType[Value: Type]: Type[integrations.DefaultValue[Value]] = DefaultValue[Value]
       implicit def OptionalValueType[Optional: Type, Value: Type]: Type[integrations.OptionalValue[Optional, Value]] =
         OptionalValue[Optional, Value]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -13,6 +13,8 @@ private[compiletime] trait Derivation
     with datatypes.SealedHierarchies
     with datatypes.SingletonTypes
     with datatypes.ValueClasses
+    with integrations.TotalOuterTransformers
+    with integrations.PartialOuterTransformers
     with integrations.OptionalValues
     with integrations.PartiallyBuildIterables
     with integrations.TotallyBuildIterables

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ImplicitSummoning.scala
@@ -26,6 +26,44 @@ private[compiletime] trait ImplicitSummoning { this: Derivation =>
       : Option[Expr[io.scalaland.chimney.PartialTransformer[From, To]]] =
     Expr.summonImplicit[io.scalaland.chimney.PartialTransformer[From, To]]
 
+  final protected def summonTotalOuterTransformer[From: Type, To: Type]: Option[TotalOuterTransformer[From, To]] = {
+    val inferred = ChimneyType.TotalOuterTransformer.inferred[From, To]
+    import inferred.Underlying as Inferred
+    Expr.summonImplicit[Inferred].map { outerTransformerExpr =>
+      val ChimneyType.TotalOuterTransformer(_, _, innerFrom, innerTo) = outerTransformerExpr.tpe: @unchecked
+      new TotalOuterTransformer[From, To] {
+        type InnerFrom = innerFrom.Underlying
+        implicit val InnerFrom: Type[InnerFrom] = innerFrom.Underlying
+
+        type InnerTo = innerTo.Underlying
+        implicit val InnerTo: Type[InnerTo] = innerTo.Underlying
+
+        val instance: Expr[io.scalaland.chimney.integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]] =
+          outerTransformerExpr
+            .asInstanceOf[Expr[io.scalaland.chimney.integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]]]
+      }
+    }
+  }
+
+  final protected def summonPartialOuterTransformer[From: Type, To: Type]: Option[PartialOuterTransformer[From, To]] = {
+    val inferred = ChimneyType.PartialOuterTransformer.inferred[From, To]
+    import inferred.Underlying as Inferred
+    Expr.summonImplicit[Inferred].map { outerTransformerExpr =>
+      val ChimneyType.PartialOuterTransformer(_, _, innerFrom, innerTo) = outerTransformerExpr.tpe: @unchecked
+      new PartialOuterTransformer[From, To] {
+        type InnerFrom = innerFrom.Underlying
+        implicit val InnerFrom: Type[InnerFrom] = innerFrom.Underlying
+
+        type InnerTo = innerTo.Underlying
+        implicit val InnerTo: Type[InnerTo] = innerTo.Underlying
+
+        val instance: Expr[io.scalaland.chimney.integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]] =
+          outerTransformerExpr
+            .asInstanceOf[Expr[io.scalaland.chimney.integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]]]
+      }
+    }
+  }
+
   final protected def summonDefaultValue[Value: Type]
       : Option[Expr[io.scalaland.chimney.integrations.DefaultValue[Value]]] =
     Expr.summonImplicit[io.scalaland.chimney.integrations.DefaultValue[Value]]

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ResultOps.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/ResultOps.scala
@@ -14,6 +14,7 @@ import io.scalaland.chimney.internal.compiletime.{
   NotSupportedTransformerDerivation,
   TupleArityMismatch
 }
+import io.scalaland.chimney.integrations as in
 import io.scalaland.chimney.{partial, PartialTransformer, Transformer}
 
 private[compiletime] trait ResultOps { this: Derivation =>
@@ -156,6 +157,18 @@ private[compiletime] trait ResultOps { this: Derivation =>
     def ambiguousImplicitPriority[From, To, A](
         total: Expr[Transformer[From, To]],
         partial: Expr[PartialTransformer[From, To]]
+    )(implicit
+        ctx: TransformationContext[From, To]
+    ): DerivationResult[A] = DerivationResult.transformerError(
+      AmbiguousImplicitPriority(
+        totalExprPrettyPrint = total.prettyPrint,
+        partialExprPrettyPrint = partial.prettyPrint
+      )(fromType = Type.prettyPrint[From], toType = Type.prettyPrint[To])
+    )
+
+    def ambiguousImplicitOuterPriority[From, To, InnerFromT: Type, InnerToT: Type, InnerFromP: Type, InnerToP: Type, A](
+        total: Expr[in.TotalOuterTransformer[From, To, InnerFromT, InnerToT]],
+        partial: Expr[in.PartialOuterTransformer[From, To, InnerFromP, InnerToP]]
     )(implicit
         ctx: TransformationContext[From, To]
     ): DerivationResult[A] = DerivationResult.transformerError(

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartialOuterTransformers.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartialOuterTransformers.scala
@@ -1,0 +1,36 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer.integrations
+
+import io.scalaland.chimney.integrations
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+import io.scalaland.chimney.partial
+
+trait PartialOuterTransformers { this: Derivation =>
+
+  abstract protected class PartialOuterTransformer[From: Type, To: Type] {
+    type InnerFrom
+    implicit val InnerFrom: Type[InnerFrom]
+
+    type InnerTo
+    implicit val InnerTo: Type[InnerTo]
+
+    val instance: Expr[integrations.PartialOuterTransformer[From, To, InnerFrom, InnerTo]]
+
+    def transformWithTotalInner(
+        src: Expr[From],
+        failFast: Expr[Boolean],
+        inner: Expr[InnerFrom => InnerTo]
+    ): Expr[partial.Result[To]] =
+      instance.transformWithTotalInner(src, failFast, inner)
+
+    def transformWithPartialInner(
+        src: Expr[From],
+        failFast: Expr[Boolean],
+        inner: Expr[InnerFrom => partial.Result[InnerTo]]
+    ): Expr[partial.Result[To]] = instance.transformWithPartialInner(src, failFast, inner)
+  }
+  protected object PartialOuterTransformer {
+
+    def unapply[From, To](implicit from: Type[From], to: Type[To]): Option[PartialOuterTransformer[From, To]] =
+      summonPartialOuterTransformer[From, To]
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
@@ -22,8 +22,9 @@ trait TotalOuterTransformers { this: Derivation =>
 
     def transformWithPartialInner(
         src: Expr[From],
+        failFast: Expr[Boolean],
         inner: Expr[InnerFrom => partial.Result[InnerTo]]
-    ): Expr[partial.Result[To]] = instance.transformWithPartialInner(src, inner)
+    ): Expr[partial.Result[To]] = instance.transformWithPartialInner(src, failFast, inner)
   }
   protected object TotalOuterTransformer {
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
@@ -1,0 +1,33 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer.integrations
+
+import io.scalaland.chimney.integrations
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+import io.scalaland.chimney.partial
+
+trait TotalOuterTransformers { this: Derivation =>
+
+  abstract protected class TotalOuterTransformer[From: Type, To: Type] {
+    type InnerFrom
+    implicit val InnerFrom: Type[InnerFrom]
+
+    type InnerTo
+    implicit val InnerTo: Type[InnerTo]
+
+    val instance: Expr[integrations.TotalOuterTransformer[From, To, InnerFrom, InnerTo]]
+
+    def transformWithTotalInner(
+        src: Expr[From],
+        inner: Expr[InnerFrom => InnerTo]
+    ): Expr[To] = instance.transformWithTotalInner(src, inner)
+
+    def transformWithPartialInner(
+        src: Expr[From],
+        inner: Expr[InnerFrom => partial.Result[InnerTo]]
+    ): Expr[partial.Result[To]] = instance.transformWithPartialInner(src, inner)
+  }
+  protected object TotalOuterTransformer {
+
+    def unapply[From, To](implicit from: Type[From], to: Type[To]): Option[TotalOuterTransformer[From, To]] =
+      summonTotalOuterTransformer[From, To]
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitOuterTransformerRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitOuterTransformerRuleModule.scala
@@ -1,0 +1,95 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
+
+import io.scalaland.chimney.dsl.{PreferPartialTransformer, PreferTotalTransformer}
+import io.scalaland.chimney.internal.compiletime.DerivationResult
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+import io.scalaland.chimney.partial
+import io.scalaland.chimney.partial.Result
+
+private[compiletime] trait TransformImplicitOuterTransformerRuleModule { this: Derivation =>
+
+  import ChimneyType.Implicits.*
+
+  protected object TransformImplicitOuterTransformerRule extends Rule("ImplicitOuterTransformer") {
+
+    def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
+      transformWithImplicitOuterTransformerIfAvailable[From, To]
+
+    private def transformWithImplicitOuterTransformerIfAvailable[From, To](implicit
+        ctx: TransformationContext[From, To]
+    ): DerivationResult[Rule.ExpansionResult[To]] = ctx match {
+      case TransformationContext.ForTotal(src) =>
+        summonTotalOuterTransformer[From, To].fold(DerivationResult.attemptNextRule[To]) { totalOuterTransformer =>
+          useTotalOuterTransformer(totalOuterTransformer, src)
+        }
+      case TransformationContext.ForPartial(src, failFast) =>
+        import ctx.config.flags.implicitConflictResolution
+        (summonTotalOuterTransformer[From, To], summonPartialOuterTransformer[From, To]) match {
+          case (Some(total), Some(partial)) if implicitConflictResolution.isEmpty =>
+            import total.{InnerFrom as InnerFromT, InnerTo as InnerToT}
+            import partial.{InnerFrom as InnerFromP, InnerTo as InnerToP}
+            DerivationResult.ambiguousImplicitOuterPriority(total.instance, partial.instance)
+          case (Some(totalOuterTransformer), partialOuterTransformerOpt)
+              if partialOuterTransformerOpt.isEmpty || implicitConflictResolution.contains(PreferTotalTransformer) =>
+            useTotalOuterTransformer(totalOuterTransformer, src)
+          case (totalOuterTransformerOpt, Some(partialOuterTransformer))
+              if totalOuterTransformerOpt.isEmpty || implicitConflictResolution.contains(PreferPartialTransformer) =>
+            usePartialOuterTransformer(partialOuterTransformer, src, failFast)
+          case _ => DerivationResult.attemptNextRule
+        }
+    }
+
+    private def useTotalOuterTransformer[From, To](
+        totalOuterTransformer: TotalOuterTransformer[From, To],
+        src: Expr[From]
+    )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] = {
+      import totalOuterTransformer.{InnerFrom, InnerTo}
+      ExprPromise
+        .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromType, ExprPromise.UsageHint.None)
+        .traverse { (innerFromExpr: Expr[InnerFrom]) =>
+          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](innerFromExpr, Path(_.everyItem), Path(_.everyItem))
+        }
+        .flatMap { promise =>
+          promise.foldTransformationExpr { (onTotal: ExprPromise[InnerFrom, Expr[InnerTo]]) =>
+            DerivationResult.expandedTotal(
+              totalOuterTransformer.transformWithTotalInner(src, onTotal.fulfilAsLambda[InnerTo])
+            )
+          } { (onPartial: ExprPromise[InnerFrom, Expr[Result[InnerTo]]]) =>
+            DerivationResult.expandedPartial(
+              totalOuterTransformer.transformWithPartialInner(src, onPartial.fulfilAsLambda[partial.Result[InnerTo]])
+            )
+          }
+        }
+    }
+
+    private def usePartialOuterTransformer[From, To](
+        partialOuterTransformer: PartialOuterTransformer[From, To],
+        src: Expr[From],
+        failFast: Expr[Boolean]
+    )(implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] = {
+      import partialOuterTransformer.{InnerFrom, InnerTo}
+      ExprPromise
+        .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromType, ExprPromise.UsageHint.None)
+        .traverse { (innerFromExpr: Expr[InnerFrom]) =>
+          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](
+            innerFromExpr,
+            Path(_.everyItem),
+            Path(_.everyItem)
+          )
+        }
+        .flatMap { promise =>
+          promise.foldTransformationExpr { (onTotal: ExprPromise[InnerFrom, Expr[InnerTo]]) =>
+            DerivationResult.expandedPartial(
+              partialOuterTransformer
+                .transformWithTotalInner(src, failFast, onTotal.fulfilAsLambda[InnerTo])
+            )
+          } { (onPartial: ExprPromise[InnerFrom, Expr[partial.Result[InnerTo]]]) =>
+            DerivationResult.expandedPartial(
+              partialOuterTransformer
+                .transformWithPartialInner(src, failFast, onPartial.fulfilAsLambda[partial.Result[InnerTo]])
+            )
+          }
+        }
+    }
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitOuterTransformerRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformImplicitOuterTransformerRuleModule.scala
@@ -6,9 +6,10 @@ import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivati
 import io.scalaland.chimney.partial
 import io.scalaland.chimney.partial.Result
 
-private[compiletime] trait TransformImplicitOuterTransformerRuleModule { this: Derivation =>
+private[compiletime] trait TransformImplicitOuterTransformerRuleModule {
+  this: Derivation & TransformProductToProductRuleModule =>
 
-  import ChimneyType.Implicits.*
+  import ChimneyType.Implicits.*, TransformProductToProductRule.useOverrideIfPresentOr
 
   protected object TransformImplicitOuterTransformerRule extends Rule("ImplicitOuterTransformer") {
 
@@ -48,7 +49,9 @@ private[compiletime] trait TransformImplicitOuterTransformerRuleModule { this: D
       ExprPromise
         .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromType, ExprPromise.UsageHint.None)
         .traverse { (innerFromExpr: Expr[InnerFrom]) =>
-          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](innerFromExpr, Path(_.everyItem), Path(_.everyItem))
+          useOverrideIfPresentOr("everyItem", ctx.config.filterCurrentOverridesForEveryItem) {
+            deriveRecursiveTransformationExpr[InnerFrom, InnerTo](innerFromExpr, Path(_.everyItem), Path(_.everyItem))
+          }
         }
         .flatMap { promise =>
           promise.foldTransformationExpr { (onTotal: ExprPromise[InnerFrom, Expr[InnerTo]]) =>
@@ -77,7 +80,9 @@ private[compiletime] trait TransformImplicitOuterTransformerRuleModule { this: D
       ExprPromise
         .promise[InnerFrom](ExprPromise.NameGenerationStrategy.FromType, ExprPromise.UsageHint.None)
         .traverse { (innerFromExpr: Expr[InnerFrom]) =>
-          deriveRecursiveTransformationExpr[InnerFrom, InnerTo](innerFromExpr, Path(_.everyItem), Path(_.everyItem))
+          useOverrideIfPresentOr("everyItem", ctx.config.filterCurrentOverridesForEveryItem) {
+            deriveRecursiveTransformationExpr[InnerFrom, InnerTo](innerFromExpr, Path(_.everyItem), Path(_.everyItem))
+          }
         }
         .flatMap { promise =>
           promise.foldTransformationExpr { (onTotal: ExprPromise[InnerFrom, Expr[InnerTo]]) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
@@ -27,24 +27,38 @@ object IsCollection extends IsCollectionImplicits0 with IsCollectionImplicitComp
 }
 private[runtime] trait IsCollectionImplicits0 extends IsCollectionImplicits1 { this: IsCollection.type =>
 
+  // outer transformers should have a priority over collections
+  implicit def totalOuterTransformerIsCollection[To, InnerTo](implicit
+      @unused ev: TotalOuterTransformer[?, To, ?, InnerTo]
+  ): IsCollection.Of[To, InnerTo] = Impl.asInstanceOf[IsCollection.Of[To, InnerTo]]
+}
+private[runtime] trait IsCollectionImplicits1 extends IsCollectionImplicits2 { this: IsCollection.type =>
+
+  // outer transformers should have a priority over collections
+  implicit def partialOuterTransformerIsCollection[To, InnerTo](implicit
+      @unused ev: PartialOuterTransformer[?, To, ?, InnerTo]
+  ): IsCollection.Of[To, InnerTo] = Impl.asInstanceOf[IsCollection.Of[To, InnerTo]]
+}
+private[runtime] trait IsCollectionImplicits2 extends IsCollectionImplicits3 { this: IsCollection.type =>
+
   // build-in Chimney support for Arrays is always provided
   implicit def arrayIsCollection[A]: IsCollection.Of[Array[A], A] = Impl.asInstanceOf[IsCollection.Of[Array[A], A]]
 }
-private[runtime] trait IsCollectionImplicits1 extends IsCollectionImplicits2 { this: IsCollection.type =>
+private[runtime] trait IsCollectionImplicits3 extends IsCollectionImplicits4 { this: IsCollection.type =>
 
   // build-in Chimney support for collections assumes that they are BOTH Iterable and have a Factory
   implicit def scalaCollectionIsCollection[A, C <: Iterable[A]](implicit
       @unused ev: Factory[A, C]
   ): IsCollection.Of[C, A] = Impl.asInstanceOf[IsCollection.Of[C, A]]
 }
-private[runtime] trait IsCollectionImplicits2 extends IsCollectionImplicits3 { this: IsCollection.type =>
+private[runtime] trait IsCollectionImplicits4 extends IsCollectionImplicits5 { this: IsCollection.type =>
 
   // TotallyBuildIterable is supported by design
   implicit def totallyBuildIterableIsCollection[A, C](implicit
       @unused ev: TotallyBuildIterable[C, A]
   ): IsCollection.Of[C, A] = Impl.asInstanceOf[IsCollection.Of[C, A]]
 }
-private[runtime] trait IsCollectionImplicits3 { this: IsCollection.type =>
+private[runtime] trait IsCollectionImplicits5 { this: IsCollection.type =>
 
   // PartiallyBuildIterable is supported by design
   implicit def partiallyBuildIterableIsCollection[A, C](implicit

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerIntegrationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerIntegrationsSpec.scala
@@ -13,51 +13,77 @@ class PartialTransformerIntegrationsSpec extends ChimneySpec {
   test("transform using TotalOuterTransformer") {
     import OuterTransformers.totalNonEmptyToSorted
 
+    val result = NonEmptyWrapper("b", "a").transformIntoPartial[SortedWrapper[String]]
+    result.asOption ==> Some(SortedWrapper("a", "b"))
+    result.asEither ==> Right(SortedWrapper("a", "b"))
+    result.asErrorPathMessageStrings ==> Iterable.empty
+
     implicit val barOrdering: Ordering[Bar] = Ordering[String].on[Bar](_.value)
 
-    val result = NonEmptyWrapper(Foo("b"), Foo("a")).transformIntoPartial[SortedWrapper[Bar]]
-    result.asOption ==> Some(SortedWrapper(Bar("a"), Bar("b")))
-    result.asEither ==> Right(SortedWrapper(Bar("a"), Bar("b")))
-    result.asErrorPathMessageStrings ==> Iterable.empty
+    val result2 = NonEmptyWrapper(Foo("b"), Foo("a")).transformIntoPartial[SortedWrapper[Bar]]
+    result2.asOption ==> Some(SortedWrapper(Bar("a"), Bar("b")))
+    result2.asEither ==> Right(SortedWrapper(Bar("a"), Bar("b")))
+    result2.asErrorPathMessageStrings ==> Iterable.empty
   }
 
   test("transform using TotalOuterTransformer with an override") {
     import OuterTransformers.totalNonEmptyToSorted
 
+    val result = NonEmptyWrapper("b", "a")
+      .intoPartial[SortedWrapper[String]]
+      .withFieldConst(_.everyItem, "c")
+      .transform
+    result.asOption ==> Some(SortedWrapper("c"))
+    result.asEither ==> Right(SortedWrapper("c"))
+    result.asErrorPathMessageStrings ==> Iterable.empty
+
     implicit val barOrdering: Ordering[Bar] = Ordering[String].on[Bar](_.value)
 
-    val result = NonEmptyWrapper(Foo("b"), Foo("a"))
+    val result2 = NonEmptyWrapper(Foo("b"), Foo("a"))
       .intoPartial[SortedWrapper[Bar]]
       .withFieldConst(_.everyItem.value, "c")
       .transform
-    result.asOption ==> Some(SortedWrapper(Bar("c")))
-    result.asEither ==> Right(SortedWrapper(Bar("c")))
-    result.asErrorPathMessageStrings ==> Iterable.empty
+    result2.asOption ==> Some(SortedWrapper(Bar("c")))
+    result2.asEither ==> Right(SortedWrapper(Bar("c")))
+    result2.asErrorPathMessageStrings ==> Iterable.empty
   }
 
   test("transform using PartialOuterTransformer") {
     import OuterTransformers.partialNonEmptyToSorted
 
+    val result = NonEmptyWrapper("b", "a").transformIntoPartial[SortedWrapper[String]]
+    result.asOption ==> Some(SortedWrapper("a", "b"))
+    result.asEither ==> Right(SortedWrapper("a", "b"))
+    result.asErrorPathMessageStrings ==> Iterable.empty
+
     implicit val barOrdering: Ordering[Bar] = Ordering[String].on[Bar](_.value)
 
-    val result = NonEmptyWrapper(Foo("b"), Foo("a")).transformIntoPartial[SortedWrapper[Bar]]
-    result.asOption ==> Some(SortedWrapper(Bar("a"), Bar("b")))
-    result.asEither ==> Right(SortedWrapper(Bar("a"), Bar("b")))
-    result.asErrorPathMessageStrings ==> Iterable.empty
+    val result2 = NonEmptyWrapper(Foo("b"), Foo("a")).transformIntoPartial[SortedWrapper[Bar]]
+    result2.asOption ==> Some(SortedWrapper(Bar("a"), Bar("b")))
+    result2.asEither ==> Right(SortedWrapper(Bar("a"), Bar("b")))
+    result2.asErrorPathMessageStrings ==> Iterable.empty
   }
 
   test("transform using PartialOuterTransformer with an override") {
     import OuterTransformers.partialNonEmptyToSorted
 
+    val result = NonEmptyWrapper("b", "a")
+      .intoPartial[SortedWrapper[String]]
+      .withFieldConst(_.everyItem, "c")
+      .transform
+    result.asOption ==> Some(SortedWrapper("c"))
+    result.asEither ==> Right(SortedWrapper("c"))
+    result.asErrorPathMessageStrings ==> Iterable.empty
+
     implicit val barOrdering: Ordering[Bar] = Ordering[String].on[Bar](_.value)
 
-    val result = NonEmptyWrapper(Foo("b"), Foo("a"))
+    val result2 = NonEmptyWrapper(Foo("b"), Foo("a"))
       .intoPartial[SortedWrapper[Bar]]
       .withFieldConst(_.everyItem.value, "c")
       .transform
-    result.asOption ==> Some(SortedWrapper(Bar("c")))
-    result.asEither ==> Right(SortedWrapper(Bar("c")))
-    result.asErrorPathMessageStrings ==> Iterable.empty
+    result2.asOption ==> Some(SortedWrapper(Bar("c")))
+    result2.asEither ==> Right(SortedWrapper(Bar("c")))
+    result2.asErrorPathMessageStrings ==> Iterable.empty
   }
 
   test("transform using PartialOuterTransformer resolving total-partial-conflict") {

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerIntegrationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerIntegrationsSpec.scala
@@ -17,6 +17,7 @@ class TotalTransformerIntegrationsSpec extends ChimneySpec {
 
     implicit val barOrdering: Ordering[Bar] = Ordering[String].on[Bar](_.value)
 
+    NonEmptyWrapper("b", "a").transformInto[SortedWrapper[String]] ==> SortedWrapper("a", "b")
     NonEmptyWrapper(Foo("b"), Foo("a")).transformInto[SortedWrapper[Bar]] ==> SortedWrapper(Bar("a"), Bar("b"))
   }
 
@@ -25,6 +26,10 @@ class TotalTransformerIntegrationsSpec extends ChimneySpec {
 
     implicit val barOrdering: Ordering[Bar] = Ordering[String].on[Bar](_.value)
 
+    NonEmptyWrapper("b", "a")
+      .into[SortedWrapper[String]]
+      .withFieldConst(_.everyItem, "c")
+      .transform ==> SortedWrapper("c")
     NonEmptyWrapper(Foo("b"), Foo("a"))
       .into[SortedWrapper[Bar]]
       .withFieldConst(_.everyItem.value, "c")

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -524,14 +524,20 @@ Cats integration module contains the following utilities:
         - `InvariantSemigroupal[Iso[First, *]]` (implementing also `Invariant`, `Semigroupal`)
   - instances for `cats.data` types allowing Chimney to recognize them as collections:
     - `cats.data.Chain` (transformation _from_ and _to_ always available)
-    - `cats.data.NonEmptyChain` (transformations: _from_ always available, _to_ only with `PartialTransformer`)
-    - `cats.data.NonEmptyLazyList` (transformation: _from_ always available, _to_ only with `PartialTransformer`,
-      the type is only defined on 2.13+)
-    - `cats.data.NonEmptyList` (transformation: _from_ always available, _to_ only with `PartialTransformer`)
-    - `cats.data.NonEmptyMap` (transformation: _from_ always available, _to_ only with `PartialTransformer`)
-    - `cats.data.NonEmptySeq` (transformation: _from_ always available, _to_ only with `PartialTransformer`)
-    - `cats.data.NonEmptySet` (transformation: _from_ always available, _to_ only with `PartialTransformer`)
-    - `cats.data.NonEmptyVector` (transformation: _from_ always available, _to_ only with `PartialTransformer`)
+    - `cats.data.NonEmptyChain` (transformations: _from_ always available, _to_ only with `PartialTransformer`
+      or to another `NonEmptyChain`)
+    - `cats.data.NonEmptyLazyList` (transformation: _from_ always available, _to_ only with `PartialTransformer`
+      or to another `NonEmptyLazyList`, the type is only defined on 2.13+)
+    - `cats.data.NonEmptyList` (transformation: _from_ always available, _to_ only with `PartialTransformer`
+      or to another `NonEmptyList`)
+    - `cats.data.NonEmptyMap` (transformation: _from_ always available, _to_ only with `PartialTransformer`
+      or to another `NonEmptyMap`)
+    - `cats.data.NonEmptySeq` (transformation: _from_ always available, _to_ only with `PartialTransformer`
+      or to another `NonEmptySeq`)
+    - `cats.data.NonEmptySet` (transformation: _from_ always available, _to_ only with `PartialTransformer`
+      or to another `NonEmptySet`)
+    - `cats.data.NonEmptyVector` (transformation: _from_ always available, _to_ only with `PartialTransformer`
+      or to another `NonEmptyVector`)
 
 !!! important
 


### PR DESCRIPTION
TODO

 - [x] define `TotalOuterTransformer`/`PartialOuterTransformer`
 - [x] define evidence for `IsCollection` for `TotalOuterTransformer`/`PartialOuterTransformer` (allowing `.everyItem` in path DSL)
 - [x] tests in core
 - [x] Cats' integrations like https://github.com/scalalandio/chimney/issues/569
   - [x] consider something like `NonEmptyTraverse` or similar to handle all `NonEmptyX[A] => NonEmptyY[B]` mappings in `TotalOuterTransformer`
 - [x] Cats' tests
 - [x] Scaladocs (documentation for new type classes)
 - [x] mkdocs (usage of new type classes, how they differ from Totally/PartiallyBuildIterable, new Cats' instances)