### PR TITLE
Ensure that Scala 2.13 can transform Scala 3 code and vice versa

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -287,7 +287,7 @@ val noPublishSettings =
 
 val ciCommand = (platform: String, scalaSuffix: String) => {
   val isJVM = platform == "JVM"
-  val isSandwichable = scalaSuffix != "2_12"
+  val isSandwichable = isJVM && scalaSuffix != "2_12"
 
   val clean = Vector("clean")
   def withCoverage(tasks: String*): Vector[String] =
@@ -560,7 +560,7 @@ lazy val chimneyEngine = projectMatrix
 
 lazy val chimneySandwichTestCases213 = projectMatrix
   .in(file("chimney-sandwich-test-cases-213"))
-  .someVariations(List(versions.scala213), versions.platforms)()
+  .someVariations(List(versions.scala213), List(VirtualAxis.jvm))()
   .settings(settings *)
   .settings(publishSettings *)
   .settings(noPublishSettings *)
@@ -573,7 +573,7 @@ lazy val chimneySandwichTestCases213 = projectMatrix
 
 lazy val chimneySandwichTestCases3 = projectMatrix
   .in(file("chimney-sandwich-test-cases-3"))
-  .someVariations(List(versions.scala3), versions.platforms)()
+  .someVariations(List(versions.scala3), List(VirtualAxis.jvm))()
   .settings(settings *)
   .settings(publishSettings *)
   .settings(noPublishSettings *)
@@ -586,7 +586,7 @@ lazy val chimneySandwichTestCases3 = projectMatrix
 
 lazy val chimneySandwichTests = projectMatrix
   .in(file("chimney-sandwich-tests"))
-  .someVariations(List(versions.scala213, versions.scala3), versions.platforms)(only1VersionInIDE *)
+  .someVariations(List(versions.scala213, versions.scala3), List(VirtualAxis.jvm))(only1VersionInIDE *)
   .settings(settings *)
   .settings(publishSettings *)
   .settings(noPublishSettings *)

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/TypesPlatform.scala
@@ -11,6 +11,27 @@ private[compiletime] trait TypesPlatform extends Types { this: DefinitionsPlatfo
 
     object platformSpecific {
 
+      /** Symbol for public primary constructor if it exists */
+      def publicPrimaryConstructor(tpe: c.Type): Option[Symbol] =
+        scala
+          .Option(tpe.typeSymbol)
+          .filter(_.isClass)
+          .map(_.asClass.primaryConstructor)
+          .filter(m => m.isPublic && m.isConstructor)
+
+      /** Finds all public constructors */
+      def publicConstructors(tpe: c.Type): List[Symbol] =
+        tpe.decls
+          .filter(m => m.isPublic && m.isConstructor)
+          .toList
+
+      /** Unambiguous constructor */
+      def publicPrimaryOrOnlyPublicConstructor(tpe: c.Type): Option[Symbol] =
+        publicPrimaryConstructor(tpe).orElse {
+          val candidates = publicConstructors(tpe)
+          if (candidates.size == 1) candidates.headOption else None
+        }
+
       /** Nice alias for turning type representation with no type in its signature into Type[A] */
       def fromUntyped[A](untyped: c.Type): Type[A] = c.WeakTypeTag(untyped)
 

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -16,13 +16,11 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
       forceTypeSymbolInitialization[A]
 
       val getterOpt: Option[Symbol] = A.decls.to(List).find(m => m.isPublic && m.isMethod && m.asMethod.isGetter)
-      val primaryConstructorOpt: Option[Symbol] = Option(A.typeSymbol)
-        .filter(_.isClass)
-        .map(_.asClass.primaryConstructor)
-        .find(m => m.isPublic && m.isConstructor && m.asMethod.paramLists.flatten.size == 1)
-      val argumentOpt: Option[Symbol] = primaryConstructorOpt.flatMap(_.asMethod.paramLists.flatten.headOption)
+      val unambiguousConstructorOpt: Option[Symbol] = publicPrimaryOrOnlyPublicConstructor(A)
+        .find(_.asMethod.paramLists.flatten.size == 1)
+      val argumentOpt: Option[Symbol] = unambiguousConstructorOpt.flatMap(_.asMethod.paramLists.flatten.headOption)
 
-      (getterOpt, primaryConstructorOpt, argumentOpt) match {
+      (getterOpt, unambiguousConstructorOpt, argumentOpt) match {
         case (Some(getter), Some(pCtor), Some(argument))
             if !Type[A].isPrimitive && getDecodedName(getter) == getDecodedName(argument) =>
           val PCtor = pCtor.typeSignatureIn(A).asInstanceOf[MethodType]

--- a/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/BeanProperties.scala
+++ b/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/BeanProperties.scala
@@ -1,0 +1,23 @@
+package io.scalaland.chimney.scala213
+
+import scala.beans.BeanProperty
+
+object BeanProperties {
+  final case class Foo private (
+      @BeanProperty var a: Int,
+      @BeanProperty var b: String,
+      @BeanProperty var c: Double,
+      @BeanProperty var d: Boolean
+  ) { def this() = this(0, "", 0.0, false) }
+  final case class Bar private (
+      @BeanProperty var a: Int,
+      @BeanProperty var b: String,
+      @BeanProperty var c: Double
+  ) { def this() = this(0, "", 0.0) }
+  final case class Baz private (
+      @BeanProperty var a: Int,
+      @BeanProperty var b: String,
+      @BeanProperty var c0: Double,
+      @BeanProperty var d: Int
+  ) { def this() = this(0, "", 0.0, 0) }
+}

--- a/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Defaults.scala
+++ b/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Defaults.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.scala213
+
+object Defaults {
+  final case class Foo(a: Int = 0, b: String = "", c: Double = 0.0, d: Boolean = false)
+  final case class Bar(a: Int = 0, b: String = "", c: Double = 0.0)
+  final case class Baz(a: Int = 0, b: String = "", c0: Double = 0.0, d: Int = 0)
+}

--- a/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Monomorphic.scala
+++ b/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Monomorphic.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.scala213
+
+object Monomorphic {
+  final case class Foo(a: Int, b: String, c: Double, d: Boolean)
+  final case class Bar(a: Int, b: String, c: Double)
+  final case class Baz(a: Int, b: String, c0: Double, d: Int)
+}

--- a/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Polymorphic.scala
+++ b/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Polymorphic.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.scala213
+
+object Polymorphic {
+  final case class Foo[A, B](a: A, b: B, c: Double, d: Boolean)
+  final case class Bar[A, B](a: A, b: B, c: Double)
+  final case class Baz[A, B](a: A, b: B, c0: Double, d: Int)
+}

--- a/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Sealed.scala
+++ b/chimney-sandwich-test-cases-213/src/test/scala-2/io/scalaland/chimney/scala213/Sealed.scala
@@ -1,0 +1,19 @@
+package io.scalaland.chimney.scala213
+
+object Sealed {
+  sealed trait Foo extends Product with Serializable
+  object Foo {
+    case object A extends Foo
+    case object B extends Foo
+  }
+  sealed trait Bar extends Product with Serializable
+  object Bar {
+    final case class A(a: Int) extends Bar
+    final case class B(b: String) extends Bar
+  }
+  sealed trait Baz extends Product with Serializable
+  object Baz {
+    case object A extends Baz
+    final case class B(b: String) extends Baz
+  }
+}

--- a/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/BeanProperties.scala
+++ b/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/BeanProperties.scala
@@ -1,0 +1,23 @@
+package io.scalaland.chimney.scala3
+
+import scala.beans.BeanProperty
+
+object BeanProperties {
+  final case class Foo private (
+      @BeanProperty var a: Int,
+      @BeanProperty var b: String,
+      @BeanProperty var c: Double,
+      @BeanProperty var d: Boolean
+  ) { def this() = this(0, "", 0.0, false) }
+  final case class Bar private (
+      @BeanProperty var a: Int,
+      @BeanProperty var b: String,
+      @BeanProperty var c: Double
+  ) { def this() = this(0, "", 0.0) }
+  final case class Baz private (
+      @BeanProperty var a: Int,
+      @BeanProperty var b: String,
+      @BeanProperty var c0: Double,
+      @BeanProperty var d: Int
+  ) { def this() = this(0, "", 0.0, 0) }
+}

--- a/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Defaults.scala
+++ b/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Defaults.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.scala3
+
+object Defaults {
+  final case class Foo(a: Int = 0, b: String = "", c: Double = 0.0, d: Boolean = false)
+  final case class Bar(a: Int = 0, b: String = "", c: Double = 0.0)
+  final case class Baz(a: Int = 0, b: String = "", c0: Double = 0.0, d: Int = 0)
+}

--- a/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Enums.scala
+++ b/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Enums.scala
@@ -1,0 +1,16 @@
+package io.scalaland.chimney.scala3
+
+object Enums {
+  enum Foo {
+    case A
+    case B
+  }
+  enum Bar {
+    case A(a: Int)
+    case B(b: String)
+  }
+  enum Baz {
+    case A
+    case B(b: String)
+  }
+}

--- a/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Monomorphic.scala
+++ b/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Monomorphic.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.scala3
+
+object Monomorphic {
+  final case class Foo(a: Int, b: String, c: Double, d: Boolean)
+  final case class Bar(a: Int, b: String, c: Double)
+  final case class Baz(a: Int, b: String, c0: Double, d: Int)
+}

--- a/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Polymorphic.scala
+++ b/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Polymorphic.scala
@@ -1,0 +1,7 @@
+package io.scalaland.chimney.scala3
+
+object Polymorphic {
+  final case class Foo[A, B](a: A, b: B, c: Double, d: Boolean)
+  final case class Bar[A, B](a: A, b: B, c: Double)
+  final case class Baz[A, B](a: A, b: B, c0: Double, d: Int)
+}

--- a/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Sealed.scala
+++ b/chimney-sandwich-test-cases-3/src/test/scala-3/io/scalaland/chimney/scala3/Sealed.scala
@@ -1,0 +1,19 @@
+package io.scalaland.chimney.scala3
+
+object Sealed {
+  sealed trait Foo extends Product with Serializable
+  object Foo {
+    case object A extends Foo
+    case object B extends Foo
+  }
+  sealed trait Bar extends Product with Serializable
+  object Bar {
+    final case class A(a: Int) extends Bar
+    final case class B(b: String) extends Bar
+  }
+  sealed trait Baz extends Product with Serializable
+  object Baz {
+    case object A extends Baz
+    final case class B(b: String) extends Baz
+  }
+}

--- a/chimney-sandwich-tests/src/test/scala-3/io/scalaland/chimney/MacroCrossCompilationScala3Spec.scala
+++ b/chimney-sandwich-tests/src/test/scala-3/io/scalaland/chimney/MacroCrossCompilationScala3Spec.scala
@@ -1,0 +1,18 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.scala213 as s213
+import io.scalaland.chimney.scala3 as s3
+import scala.util.chaining.*
+
+class MacroCrossCompilationScala3Spec extends ChimneySpec {
+
+  group("Scala 2.13 compiler analyzing Scala 3 code and Scala 3 compiler analyzing Scala 2.13 code") {
+
+    test("should handle reading from and writing to sealed trait/enum") {
+      // only Scala 3 makes distinction between vals in mattern matching :/
+      (s3.Enums.Foo.A: s3.Enums.Foo).transformInto[s213.Sealed.Foo] ==> s213.Sealed.Foo.A
+      (s3.Enums.Foo.B: s3.Enums.Foo).transformInto[s213.Sealed.Foo] ==> s213.Sealed.Foo.B
+    }
+  }
+}

--- a/chimney-sandwich-tests/src/test/scala-3/io/scalaland/chimney/MacroCrossCompilationScala3Spec.scala
+++ b/chimney-sandwich-tests/src/test/scala-3/io/scalaland/chimney/MacroCrossCompilationScala3Spec.scala
@@ -10,7 +10,7 @@ class MacroCrossCompilationScala3Spec extends ChimneySpec {
   group("Scala 2.13 compiler analyzing Scala 3 code and Scala 3 compiler analyzing Scala 2.13 code") {
 
     test("should handle reading from and writing to sealed trait/enum") {
-      // only Scala 3 makes distinction between vals in mattern matching :/
+      // TODO: Only Scala 3 makes distinction between vals in pattern matching :/ Maybe we can fix this one day?
       (s3.Enums.Foo.A: s3.Enums.Foo).transformInto[s213.Sealed.Foo] ==> s213.Sealed.Foo.A
       (s3.Enums.Foo.B: s3.Enums.Foo).transformInto[s213.Sealed.Foo] ==> s213.Sealed.Foo.B
     }

--- a/chimney-sandwich-tests/src/test/scala/io/scalaland/chimney /MacroCrossCompilationSpec.scala
+++ b/chimney-sandwich-tests/src/test/scala/io/scalaland/chimney /MacroCrossCompilationSpec.scala
@@ -3,17 +3,94 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.scala213 as s213
 import io.scalaland.chimney.scala3 as s3
+import scala.util.chaining.*
 
 class MacroCrossCompilationSpec extends ChimneySpec {
 
   group("Scala 2.13 compiler analyzing Scala 3 code and Scala 3 compiler analyzing Scala 2.13 code") {
 
     test("should handle reading from and writing to monomorphic classes") {
-      s213.Monomorphic.Foo(1, "2", 3.0, true).transformInto[s3.Monomorphic.Bar]
-      s3.Monomorphic.Foo(1, "2", 3.0, true).transformInto[s213.Monomorphic.Bar]
+      s213.Monomorphic
+        .Foo(1, "2", 3.0, true)
+        .transformInto[s3.Monomorphic.Bar] ==> s3.Monomorphic.Bar(1, "2", 3.0)
+      s3.Monomorphic
+        .Foo(1, "2", 3.0, true)
+        .transformInto[s213.Monomorphic.Bar] ==> s213.Monomorphic.Bar(1, "2", 3.0)
       implicit val bool2int: Transformer[Boolean, Int] = b => if (b) 1 else 0
-      s213.Monomorphic.Foo(1, "2", 3.0, true).into[s3.Monomorphic.Baz].transform
-      s3.Monomorphic.Foo(1, "2", 3.0, true).into[s213.Monomorphic.Baz].transform
+      s213.Monomorphic
+        .Foo(1, "2", 3.0, true)
+        .into[s3.Monomorphic.Baz]
+        .withFieldRenamed(_.c, _.c0)
+        .transform ==> s3.Monomorphic.Baz(1, "2", 3.0, 1)
+      s3.Monomorphic
+        .Foo(1, "2", 3.0, true)
+        .into[s213.Monomorphic.Baz]
+        .withFieldRenamed(_.c, _.c0)
+        .transform ==> s213.Monomorphic.Baz(1, "2", 3.0, 1)
+    }
+
+    test("should handle reading from and writing to polymorphic classes") {
+      s213.Polymorphic
+        .Foo(1, "2", 3.0, true)
+        .transformInto[s3.Polymorphic.Bar[Int, String]] ==> s3.Polymorphic.Bar(1, "2", 3.0)
+      s3.Polymorphic
+        .Foo(1, "2", 3.0, true)
+        .transformInto[s213.Polymorphic.Bar[Int, String]] ==> s213.Polymorphic.Bar(1, "2", 3.0)
+      implicit val bool2int: Transformer[Boolean, Int] = b => if (b) 1 else 0
+      s213.Polymorphic
+        .Foo(1, "2", 3.0, true)
+        .into[s3.Polymorphic.Baz[Int, String]]
+        .withFieldRenamed(_.c, _.c0)
+        .transform ==> s3.Polymorphic.Baz(1, "2", 3.0, 1)
+      s3.Polymorphic
+        .Foo(1, "2", 3.0, true)
+        .into[s213.Polymorphic.Baz[Int, String]]
+        .withFieldRenamed(_.c, _.c0)
+        .transform ==> s213.Polymorphic.Baz(1, "2", 3.0, 1)
+    }
+
+    test("should handle reading and using default values") {
+      ().into[s3.Defaults.Foo].enableDefaultValues.transform ==> s3.Defaults.Foo()
+      ().into[s213.Defaults.Foo].enableDefaultValues.transform ==> s213.Defaults.Foo()
+    }
+
+    test("should handle reading from and writing to case classes with @BeanProperty") {
+      // TODO: there are some differences in behavior between Scala 2 and Scala 3 that we should eliminate.
+
+      // @BeanProperties can generate both getA and A, so we can ignore getters when reading from them.
+      (new s213.BeanProperties.Foo())
+        .tap(_.a = 1)
+        .tap(_.b = "2")
+        .tap(_.c = 3.0)
+        .tap(_.d = true)
+        .into[s3.BeanProperties.Bar]
+        .enableBeanSetters
+        .transform ==> (new s3.BeanProperties.Bar())
+        .tap(_.a = 1)
+        .tap(_.b = "2")
+        .tap(_.c = 3.0)
+      (new s3.BeanProperties.Foo())
+        .tap(_.a = 1)
+        .tap(_.b = "2")
+        .tap(_.c = 3.0)
+        .tap(_.d = true)
+        .into[s213.BeanProperties.Bar]
+        .enableBeanSetters
+        .transform ==> (new s213.BeanProperties.Bar())
+        .tap(_.a = 1)
+        .tap(_.b = "2")
+        .tap(_.c = 3.0)
+    }
+
+    test("should handle reading from and writing to sealed trait/enum") {
+      (s213.Sealed.Foo.A: s213.Sealed.Foo).transformInto[s3.Sealed.Foo] ==> s3.Sealed.Foo.A
+      (s213.Sealed.Foo.B: s213.Sealed.Foo).transformInto[s3.Sealed.Foo] ==> s3.Sealed.Foo.B
+
+      (s3.Sealed.Foo.A: s3.Sealed.Foo).transformInto[s213.Sealed.Foo] ==> s213.Sealed.Foo.A
+      (s3.Sealed.Foo.B: s3.Sealed.Foo).transformInto[s213.Sealed.Foo] ==> s213.Sealed.Foo.B
+
+      (s213.Sealed.Foo.A: s213.Sealed.Foo).transformInto[s3.Enums.Foo] ==> s3.Enums.Foo.A
+      (s213.Sealed.Foo.B: s213.Sealed.Foo).transformInto[s3.Enums.Foo] ==> s3.Enums.Foo.B
     }
   }
 }

--- a/chimney-sandwich-tests/src/test/scala/io/scalaland/chimney /MacroCrossCompilationSpec.scala
+++ b/chimney-sandwich-tests/src/test/scala/io/scalaland/chimney /MacroCrossCompilationSpec.scala
@@ -1,0 +1,19 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.scala213 as s213
+import io.scalaland.chimney.scala3 as s3
+
+class MacroCrossCompilationSpec extends ChimneySpec {
+
+  group("Scala 2.13 compiler analyzing Scala 3 code and Scala 3 compiler analyzing Scala 2.13 code") {
+
+    test("should handle reading from and writing to monomorphic classes") {
+      s213.Monomorphic.Foo(1, "2", 3.0, true).transformInto[s3.Monomorphic.Bar]
+      s3.Monomorphic.Foo(1, "2", 3.0, true).transformInto[s213.Monomorphic.Bar]
+      implicit val bool2int: Transformer[Boolean, Int] = b => if (b) 1 else 0
+      s213.Monomorphic.Foo(1, "2", 3.0, true).into[s3.Monomorphic.Baz].transform
+      s3.Monomorphic.Foo(1, "2", 3.0, true).into[s213.Monomorphic.Baz].transform
+    }
+  }
+}

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -1623,7 +1623,7 @@ Chimney took it seriously to make sure that in such case:
 
  * Scala 2.13 macros would be able to handle `case class`es and `sealed trait`s compiled with Scala 3  
  * Scala 3 macros would be able to handle `case class`es and `sealed trait`s compiled with Scala 2.13
- * `@BeanProperties` would continue working despite
+ * `@BeanProperty` would continue working despite
    [changes in their semantics](https://docs.scala-lang.org/scala3/guides/migration/incompat-other-changes.html#invisible-bean-property)
  * default values will also work despite [changes to constructors](https://docs.scala-lang.org/scala3/reference/other-new-features/creator-applications.html)
    which changed how default values are stored in the byte code 


### PR DESCRIPTION
TODO:

 - [x] update build
   - [x] test locally that artifacts are not broken
 - [x] define 2.13 and 3 test cases
   - [x] case classes
   - [x] case classes with `@BeanProperty`
   - [x] classes with default values in constructor
   - [x] enums with parameters in any value
   - [x] enums without parameters in any value
   - [x] sealed traits
 - [x] tests 2.13 converting 3 classes and vice versa
   - [x] case classes
   - [x] @BeanProperties as source/target
   - [x] sealed traits to/from enums
   - [x] default values in target type
 - [x] documentation - describe what is possible and what isn't

Updated and fixed version of #475