### PR TITLE
Overrides computation for nested fields

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -37,7 +37,7 @@ final class CodecDefinition[
 
   /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`.
     *
-    * By default if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
+    * By default, if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -37,7 +37,7 @@ final class IsoDefinition[
 
   /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`.
     *
-    * By default if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
+    * By default, if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -32,7 +32,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use provided `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -58,7 +58,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use provided partial result `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -82,9 +82,9 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldConstPartialImpl[From, To, Overrides, Flags]
 
-  /** Use function `f` to compute value of field picked using `selector`.
+  /** Use the function `f` to compute a value of the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -108,14 +108,40 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
+  /** Use the function `f` to compute a value of the field picked using the `selectorTo` from a value extracted with
+    * `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(selectorTo: To => T, f: S => U)(implicit
       ev: U <:< T
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
 
-  /** Use function `f` to compute partial result for field picked using `selector`.
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -140,15 +166,41 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
 
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   def withFieldComputedPartialFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
       f: S => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
+  /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
-    * By default if `From` is missing field picked by `selectorTo` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
@@ -175,14 +227,14 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use `f` to calculate the unmatched subtype when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandled]] alias can be used (e.g. for Scala 3 enums or Java enums).
     *
     * It differs from `withFieldComputed(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled` matches on
-    * `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -223,15 +275,15 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandledPartial]] alias can be used (e.g. for Scala 3 enums or Java
     * enums).
     *
     * It differs from `withFieldComputedPartial(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled`
-    * matches on `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * matches on a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -270,7 +322,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialImpl[From, To, Overrides, Flags, Subtype]
 
-  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+  /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
@@ -323,6 +375,29 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorImpl[From, To, Overrides, Flags]
 
+  /** Use `f` instead of the primary constructor to construct the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `T`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `To`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorTo[T, Ctor](selector: To => T)(f: Ctor)(implicit
       ev: IsFunction.Of[Ctor, T]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
@@ -354,6 +429,29 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorPartialImpl[From, To, Overrides, Flags]
 
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorPartialTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit
@@ -387,6 +485,30 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorEitherImpl[From, To, Overrides, Flags]
 
+  /** Use `f` instead of the primary constructor to parse into the `Either` value extracted from `To` using the
+    * `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Either[String, T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Either[String, T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorEitherTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -108,6 +108,11 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
+  def withFieldComputedFrom[S, T, U](selectorFrom: From => S, selectorTo: To => T, f: From => U)(implicit
+      ev: U <:< T
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
+
   /** Use function `f` to compute partial result for field picked using `selector`.
     *
     * By default if `From` is missing field picked by `selector` compilation fails.
@@ -134,6 +139,13 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       f: From => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
+
+  def withFieldComputedPartialFrom[S, T, U](
+      selectorFrom: From => S,
+      selectorTo: To => T,
+      f: From => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
@@ -312,6 +324,12 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorImpl[From, To, Overrides, Flags]
 
+  def withConstructorTo[Ctor](
+      selector: To => Ctor,
+      f: Ctor
+  )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withConstructorToImpl[From, To, Overrides, Flags]
+
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -338,6 +356,14 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorPartialImpl[From, To, Overrides, Flags]
 
+  def withConstructorPartialTo[Ctor](
+      selector: To => Ctor,
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, partial.Result[To]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withConstructorPartialToImpl[From, To, Overrides, Flags]
+
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -363,6 +389,14 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       ev: IsFunction.Of[Ctor, Either[String, To]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorEitherImpl[From, To, Overrides, Flags]
+
+  def withConstructorEitherTo[Ctor](
+      selector: To => Ctor,
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, Either[String, To]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withConstructorEitherToImpl[From, To, Overrides, Flags]
 
   /** Build Partial Transformer using current configuration.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -108,7 +108,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
-  def withFieldComputedFrom[S, T, U](selectorFrom: From => S, selectorTo: To => T, f: From => U)(implicit
+  def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(selectorTo: To => T, f: S => U)(implicit
       ev: U <:< T
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
@@ -140,10 +140,9 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
 
-  def withFieldComputedPartialFrom[S, T, U](
-      selectorFrom: From => S,
+  def withFieldComputedPartialFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
-      f: From => partial.Result[U]
+      f: S => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
 
@@ -324,10 +323,9 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorImpl[From, To, Overrides, Flags]
 
-  def withConstructorTo[Ctor](
-      selector: To => Ctor,
-      f: Ctor
-  )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+  def withConstructorTo[T, Ctor](selector: To => T)(f: Ctor)(implicit
+      ev: IsFunction.Of[Ctor, T]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorToImpl[From, To, Overrides, Flags]
 
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
@@ -356,11 +354,10 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorPartialImpl[From, To, Overrides, Flags]
 
-  def withConstructorPartialTo[Ctor](
-      selector: To => Ctor,
+  def withConstructorPartialTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit
-      ev: IsFunction.Of[Ctor, partial.Result[To]]
+      ev: IsFunction.Of[Ctor, partial.Result[T]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorPartialToImpl[From, To, Overrides, Flags]
 
@@ -390,11 +387,10 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorEitherImpl[From, To, Overrides, Flags]
 
-  def withConstructorEitherTo[Ctor](
-      selector: To => Ctor,
+  def withConstructorEitherTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit
-      ev: IsFunction.Of[Ctor, Either[String, To]]
+      ev: IsFunction.Of[Ctor, Either[String, T]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorEitherToImpl[From, To, Overrides, Flags]
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -113,10 +113,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
-  def withFieldComputedFrom[S, T, U](
-      selectorFrom: From => S,
+  def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
-      f: From => U
+      f: S => U
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
 
@@ -147,10 +146,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
 
-  def withFieldComputedPartialFrom[S, T, U](
-      selectorFrom: From => S,
+  def withFieldComputedPartialFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
-      f: From => partial.Result[U]
+      f: S => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
 
@@ -328,10 +326,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorImpl[From, To, Overrides, Flags]
 
-  def withConstructorTo[Ctor](
-      selector: To => Ctor,
+  def withConstructorTo[T, Ctor](selector: To => T)(
       f: Ctor
-  )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+  )(implicit ev: IsFunction.Of[Ctor, T]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorToImpl[From, To, Overrides, Flags]
 
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
@@ -360,11 +357,10 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorPartialImpl[From, To, Overrides, Flags]
 
-  def withConstructorPartialTo[Ctor](
-      selector: To => Ctor,
+  def withConstructorPartialTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit
-      ev: IsFunction.Of[Ctor, partial.Result[To]]
+      ev: IsFunction.Of[Ctor, partial.Result[T]]
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorPartialToImpl[From, To, Overrides, Flags]
 
@@ -394,11 +390,10 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorEitherImpl[From, To, Overrides, Flags]
 
-  def withConstructorEitherTo[Ctor](
-      selector: To => Ctor,
+  def withConstructorEitherTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit
-      ev: IsFunction.Of[Ctor, Either[String, To]]
+      ev: IsFunction.Of[Ctor, Either[String, T]]
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorEitherToImpl[From, To, Overrides, Flags]
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -35,7 +35,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use provided `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -61,7 +61,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use provided partial result `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -86,9 +86,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldConstPartialImpl[From, To, Overrides, Flags]
 
-  /** Use function `f` to compute value of field picked using `selector`.
+  /** Use the function `f` to compute a value of the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -113,20 +113,45 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
+  /** Use the function `f` to compute a value of the field picked using the `selectorTo` from a value extracted with
+    * `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
       f: S => U
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
 
-  /** Use function `f` to compute partial result for field picked using `selector`.
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
     *   for more details
-    *
     * @tparam T
     *   type of target field
     * @tparam U
@@ -146,15 +171,41 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
 
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withFieldComputedPartialFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
       f: S => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
-    * By default if `From` is missing field picked by `selectorTo` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
@@ -181,14 +232,14 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use `f` to calculate the unmatched subtype when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandled]] alias can be used (e.g. for Scala 3 enums or Java enums).
     *
     * It differs from `withFieldComputed(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled` matches on
-    * `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -229,15 +280,15 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandledPartial]] alias can be used (e.g. for Scala 3 enums or Java
     * enums).
     *
     * It differs from `withFieldComputedPartial(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled`
-    * matches on `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * matches on a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -276,7 +327,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withSealedSubtypeHandledPartialImpl[From, To, Overrides, Flags, Subtype]
 
-  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+  /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
@@ -326,6 +377,29 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorImpl[From, To, Overrides, Flags]
 
+  /** Use `f` instead of the primary constructor to construct the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `T`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `To`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit ev: IsFunction.Of[Ctor, T]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
@@ -341,6 +415,8 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
     *   details
     *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
     * @tparam Ctor
     *   type of the Eta-expanded method/lambda which should return `partial.Result[To]`
     * @param f
@@ -357,6 +433,29 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorPartialImpl[From, To, Overrides, Flags]
 
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorPartialTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit
@@ -390,6 +489,30 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorEitherImpl[From, To, Overrides, Flags]
 
+  /** Use `f` instead of the primary constructor to parse into the `Either` value extracted from `To` using the
+    * `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Either[String, T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Either[String, T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorEitherTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -113,6 +113,13 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
+  def withFieldComputedFrom[S, T, U](
+      selectorFrom: From => S,
+      selectorTo: To => T,
+      f: From => U
+  )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
+
   /** Use function `f` to compute partial result for field picked using `selector`.
     *
     * By default if `From` is missing field picked by `selector` compilation fails.
@@ -139,6 +146,13 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       f: From => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
+
+  def withFieldComputedPartialFrom[S, T, U](
+      selectorFrom: From => S,
+      selectorTo: To => T,
+      f: From => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
     *
@@ -314,6 +328,12 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorImpl[From, To, Overrides, Flags]
 
+  def withConstructorTo[Ctor](
+      selector: To => Ctor,
+      f: Ctor
+  )(implicit ev: IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withConstructorToImpl[From, To, Overrides, Flags]
+
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -340,6 +360,14 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorPartialImpl[From, To, Overrides, Flags]
 
+  def withConstructorPartialTo[Ctor](
+      selector: To => Ctor,
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, partial.Result[To]]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withConstructorPartialToImpl[From, To, Overrides, Flags]
+
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -365,6 +393,14 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       ev: IsFunction.Of[Ctor, Either[String, To]]
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorEitherImpl[From, To, Overrides, Flags]
+
+  def withConstructorEitherTo[Ctor](
+      selector: To => Ctor,
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, Either[String, To]]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withConstructorEitherToImpl[From, To, Overrides, Flags]
 
   /** Apply configured partial transformation in-place.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -93,6 +93,14 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
+  // TODO
+  def withFieldComputedFrom[S, T, U](
+      selectorFrom: From => S,
+      selectorTo: To => T,
+      f: From => U
+  )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
+
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
@@ -217,6 +225,13 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
       f: Ctor
   )(implicit ev: IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withConstructorImpl[From, To, Overrides, Flags]
+
+  // TODO
+  def withConstructorTo[Ctor](
+      selector: To => Ctor,
+      f: Ctor
+  )(implicit ev: IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionMacros.withConstructorToImpl[From, To, Overrides, Flags]
 
   /** Build Transformer using current configuration.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -94,10 +94,9 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     macro TransformerDefinitionMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
   // TODO
-  def withFieldComputedFrom[S, T, U](
-      selectorFrom: From => S,
+  def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
-      f: From => U
+      f: S => U
   )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
 
@@ -227,10 +226,9 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     macro TransformerDefinitionMacros.withConstructorImpl[From, To, Overrides, Flags]
 
   // TODO
-  def withConstructorTo[Ctor](
-      selector: To => Ctor,
+  def withConstructorTo[T, Ctor](selector: To => T)(
       f: Ctor
-  )(implicit ev: IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+  )(implicit ev: IsFunction.Of[Ctor, T]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withConstructorToImpl[From, To, Overrides, Flags]
 
   /** Build Transformer using current configuration.

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -42,7 +42,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
 
   /** Use provided value `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -66,9 +66,9 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withFieldConstImpl[From, To, Overrides, Flags]
 
-  /** Use function `f` to compute value of field picked using `selector`.
+  /** Use the function `f` to compute a value of the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -93,16 +93,41 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
-  // TODO
+  /** Use the function `f` to compute a value of the field picked using the `selectorTo` from a value extracted with
+    * `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
       f: S => U
   )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
+  /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
-    * By default if `From` is missing field picked by `selectorTo` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
@@ -129,14 +154,14 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
 
   /** Use `f` to calculate the unmatched subtype when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandled]] alias can be used (e.g. for Scala 3 enums or Java enums).
     *
     * It differs from `withFieldComputed(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled` matches on
-    * `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -175,7 +200,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withSealedSubtypeHandledImpl[From, To, Overrides, Flags, Subtype]
 
-  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+  /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
@@ -225,7 +250,29 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(implicit ev: IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerDefinitionMacros.withConstructorImpl[From, To, Overrides, Flags]
 
-  // TODO
+  /** Use `f` instead of the primary constructor to construct the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `T`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `To`
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorTo[T, Ctor](selector: To => T)(
       f: Ctor
   )(implicit ev: IsFunction.Of[Ctor, T]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -87,6 +87,14 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(implicit ev: U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
+  // TODO
+  def withFieldComputedFrom[S, T, U](
+      selectorFrom: From => S,
+      selectorTo: To => T,
+      f: From => U
+  )(implicit ev: U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerIntoMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
+
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
@@ -204,6 +212,12 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
       ev: IsFunction.Of[Ctor, To]
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withConstructorImpl[From, To, Overrides, Flags]
+
+  // TODO
+  def withConstructorTo[Ctor](selector: From => Ctor, f: Ctor)(implicit
+      ev: IsFunction.Of[Ctor, To]
+  ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerIntoMacros.withConstructorToImpl[From, To, Overrides, Flags]
 
   /** Apply configured transformation in-place.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -32,7 +32,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     ], Flags]
     with WithRuntimeDataStore {
 
-  /** Lifts current transformation as partial transformation.
+  /** Lifts the current transformation to the partial transformation.
     *
     * It keeps all the configuration, provided missing values, renames, coproduct instances etc.
     *
@@ -42,9 +42,9 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   def partial: PartialTransformerInto[From, To, Overrides, Flags] =
     new PartialTransformerInto[From, To, Overrides, Flags](source, td.partial)
 
-  /** Use `value` provided here for field picked using `selector`.
+  /** Use the `value` provided here for the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -60,9 +60,9 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withFieldConstImpl[From, To, Overrides, Flags]
 
-  /** Use function `f` to compute value of field picked using `selector`.
+  /** Use the function `f` to compute a value of the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -87,16 +87,41 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(implicit ev: U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
-  // TODO
+  /** Use the function `f` to compute a value of the field picked using the `selectorTo` from a value extracted with
+    * `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
       f: S => U
   )(implicit ev: U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
-    * By default if `From` is missing field picked by `selectorTo` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
@@ -121,16 +146,16 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withFieldRenamedImpl[From, To, Overrides, Flags]
 
-  /** Use `f` to calculate the (missing) coproduct instance when mapping one coproduct into another
+  /** Use `f` to calculate the unmatched subtype when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
     * will have matching names of its components, and for every component in `To` field's type there is matching
     * component in `From` type. If some component is missing it will fail.
     *
     * For convenience/readability [[withEnumCaseHandled]] alias can be used (e.g. for Scala 3 enums or Java enums).
     *
     * It differs from `withFieldComputed(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled` matches on
-    * `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -163,7 +188,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   def withCoproductInstance[Subtype](f: Subtype => To): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withSealedSubtypeHandledImpl[From, To, Overrides, Flags, Subtype]
 
-  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+  /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
@@ -212,7 +237,29 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withConstructorImpl[From, To, Overrides, Flags]
 
-  // TODO
+  /** Use `f` instead of the primary constructor to construct the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `T`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `To`
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 1.6.0
+    */
   def withConstructorTo[T, Ctor](selector: To => T)(f: Ctor)(implicit
       ev: IsFunction.Of[Ctor, T]
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -88,10 +88,9 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     macro TransformerIntoMacros.withFieldComputedImpl[From, To, Overrides, Flags]
 
   // TODO
-  def withFieldComputedFrom[S, T, U](
-      selectorFrom: From => S,
+  def withFieldComputedFrom[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
-      f: From => U
+      f: S => U
   )(implicit ev: U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withFieldComputedFromImpl[From, To, Overrides, Flags]
 
@@ -214,8 +213,8 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     macro TransformerIntoMacros.withConstructorImpl[From, To, Overrides, Flags]
 
   // TODO
-  def withConstructorTo[Ctor](selector: From => Ctor, f: Ctor)(implicit
-      ev: IsFunction.Of[Ctor, To]
+  def withConstructorTo[T, Ctor](selector: To => T)(f: Ctor)(implicit
+      ev: IsFunction.Of[Ctor, T]
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro TransformerIntoMacros.withConstructorToImpl[From, To, Overrides, Flags]
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -163,6 +163,38 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             fixJavaEnums(A0.param_<[runtime.Path](0)) -> A0.param_<[runtime.TransformerOverrides](1)
           }
       }
+      object ComputedFrom extends ComputedFromModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ComputedFrom[FromPath, ToPath, Tail]] =
+          weakTypeTag[runtime.TransformerOverrides.ComputedFrom[FromPath, ToPath, Tail]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.ComputedFrom[?, ?, ?]].map { A0 =>
+            (
+              fixJavaEnums(A0.param_<[runtime.Path](0)),
+              fixJavaEnums(A0.param_<[runtime.Path](1)),
+              A0.param_<[runtime.TransformerOverrides](2)
+            )
+          }
+      }
+      object ComputedPartialFrom extends ComputedPartialFromModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ComputedPartialFrom[FromPath, ToPath, Tail]] =
+          weakTypeTag[runtime.TransformerOverrides.ComputedPartialFrom[FromPath, ToPath, Tail]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.ComputedPartialFrom[?, ?, ?]].map { A0 =>
+            (
+              fixJavaEnums(A0.param_<[runtime.Path](0)),
+              fixJavaEnums(A0.param_<[runtime.Path](1)),
+              A0.param_<[runtime.TransformerOverrides](2)
+            )
+          }
+      }
       object CaseComputed extends CaseComputedModule {
         def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
             : Type[runtime.TransformerOverrides.CaseComputed[ToPath, Tail]] =

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -58,7 +58,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
     .addOverride(f)
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
@@ -86,7 +86,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
     .addOverride(f)
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
@@ -175,7 +175,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
       .asInstanceOfExpr(
@@ -202,7 +202,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
       .asInstanceOfExpr(
@@ -229,7 +229,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(q"_root_.io.scalaland.chimney.internal.runtime.FunctionEitherToResult.lift($f)")
       .asInstanceOfExpr(

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -38,6 +38,7 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
           weakTypeTag[PartialTransformerDefinition[From, To, ConstPartial[ToPath, Overrides], Flags]]
       }.applyFromSelector(selector)
     )
+
   def withFieldComputedImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -52,6 +53,20 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       }.applyFromSelector(selector)
     )
 
+  def withFieldComputedFromImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+    .addOverride(f)
+    .asInstanceOfExpr(
+      new ApplyFieldNameTypes {
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[PartialTransformerDefinition[From, To, ComputedFrom[FromPath, ToPath, Overrides], Flags]]
+      }.applyFromSelectors(selectorFrom, selectorTo)
+    )
+
   def withFieldComputedPartialImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -64,6 +79,20 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
         def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
           weakTypeTag[PartialTransformerDefinition[From, To, ComputedPartial[ToPath, Overrides], Flags]]
       }.applyFromSelector(selector)
+    )
+
+  def withFieldComputedPartialFromImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+    .addOverride(f)
+    .asInstanceOfExpr(
+      new ApplyFieldNameTypes {
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[PartialTransformerDefinition[From, To, ComputedPartialFrom[FromPath, ToPath, Overrides], Flags]]
+      }.applyFromSelectors(selectorFrom, selectorTo)
     )
 
   def withFieldRenamedImpl[
@@ -141,6 +170,22 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       .asInstanceOfExpr[PartialTransformerDefinition[From, To, Constructor[Args, Path.Root, Overrides], Flags]]
   }.applyFromBody(f)
 
+  def withConstructorToImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerDefinition[From, To, Constructor[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }.applyFromBody(f)
+
   def withConstructorPartialImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -152,6 +197,22 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       .asInstanceOfExpr[PartialTransformerDefinition[From, To, ConstructorPartial[Args, Path.Root, Overrides], Flags]]
   }.applyFromBody(f)
 
+  def withConstructorPartialToImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerDefinition[From, To, ConstructorPartial[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }.applyFromBody(f)
+
   def withConstructorEitherImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -161,5 +222,21 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(q"_root_.io.scalaland.chimney.internal.runtime.FunctionEitherToResult.lift($f)")
       .asInstanceOfExpr[PartialTransformerDefinition[From, To, ConstructorPartial[Args, Path.Root, Overrides], Flags]]
+  }.applyFromBody(f)
+
+  def withConstructorEitherToImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(q"_root_.io.scalaland.chimney.internal.runtime.FunctionEitherToResult.lift($f)")
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerDefinition[From, To, ConstructorPartial[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
   }.applyFromBody(f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -58,7 +58,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
     .addOverride(f)
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
@@ -86,7 +86,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
     .addOverride(f)
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
@@ -175,7 +175,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
       .asInstanceOfExpr(
@@ -202,7 +202,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
       .asInstanceOfExpr(
@@ -229,7 +229,7 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(q"_root_.io.scalaland.chimney.internal.runtime.FunctionEitherToResult.lift($f)")
       .asInstanceOfExpr(

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -53,6 +53,20 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       }.applyFromSelector(selector)
     )
 
+  def withFieldComputedFromImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+    .addOverride(f)
+    .asInstanceOfExpr(
+      new ApplyFieldNameTypes {
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[PartialTransformerInto[From, To, ComputedFrom[FromPath, ToPath, Overrides], Flags]]
+      }.applyFromSelectors(selectorFrom, selectorTo)
+    )
+
   def withFieldComputedPartialImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -65,6 +79,20 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
         def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
           weakTypeTag[PartialTransformerInto[From, To, ComputedPartial[ToPath, Overrides], Flags]]
       }.applyFromSelector(selector)
+    )
+
+  def withFieldComputedPartialFromImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+    .addOverride(f)
+    .asInstanceOfExpr(
+      new ApplyFieldNameTypes {
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[PartialTransformerInto[From, To, ComputedPartialFrom[FromPath, ToPath, Overrides], Flags]]
+      }.applyFromSelectors(selectorFrom, selectorTo)
     )
 
   def withFieldRenamedImpl[
@@ -142,6 +170,22 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       .asInstanceOfExpr[PartialTransformerInto[From, To, Constructor[Args, Path.Root, Overrides], Flags]]
   }.applyFromBody(f)
 
+  def withConstructorToImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerInto[From, To, Constructor[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }.applyFromBody(f)
+
   def withConstructorPartialImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -153,6 +197,22 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       .asInstanceOfExpr[PartialTransformerInto[From, To, ConstructorPartial[Args, Path.Root, Overrides], Flags]]
   }.applyFromBody(f)
 
+  def withConstructorPartialToImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerInto[From, To, ConstructorPartial[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }.applyFromBody(f)
+
   def withConstructorEitherImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -162,5 +222,21 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(q"_root_.io.scalaland.chimney.internal.runtime.FunctionEitherToResult.lift($f)")
       .asInstanceOfExpr[PartialTransformerInto[From, To, ConstructorPartial[Args, Path.Root, Overrides], Flags]]
+  }.applyFromBody(f)
+
+  def withConstructorEitherToImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(q"_root_.io.scalaland.chimney.internal.runtime.FunctionEitherToResult.lift($f)")
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerInto[From, To, ConstructorPartial[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
   }.applyFromBody(f)
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -44,7 +44,7 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
     .addOverride(f)
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
@@ -116,7 +116,7 @@ class TransformerDefinitionMacros(val c: whitebox.Context) extends utils.DslMacr
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
       .asInstanceOfExpr(

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -44,7 +44,7 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
     .addOverride(f)
     .asInstanceOfExpr(
       new ApplyFieldNameTypes {
@@ -116,7 +116,7 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       To: WeakTypeTag,
       Overrides <: TransformerOverrides: WeakTypeTag,
       Flags <: TransformerFlags: WeakTypeTag
-  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
       .asInstanceOfExpr(

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -39,6 +39,20 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
       }.applyFromSelector(selector)
     )
 
+  def withFieldComputedFromImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = c.prefix.tree
+    .addOverride(f)
+    .asInstanceOfExpr(
+      new ApplyFieldNameTypes {
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[TransformerInto[From, To, ComputedFrom[FromPath, ToPath, Overrides], Flags]]
+      }.applyFromSelectors(selectorFrom, selectorTo)
+    )
+
   def withFieldRenamedImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -95,5 +109,21 @@ class TransformerIntoMacros(val c: whitebox.Context) extends utils.DslMacroUtils
     def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
       .addOverride(f)
       .asInstanceOfExpr[TransformerInto[From, To, Constructor[Args, Path.Root, Overrides], Flags]]
+  }.applyFromBody(f)
+
+  def withConstructorToImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[TransformerInto[From, To, Constructor[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
   }.applyFromBody(f)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -36,7 +36,7 @@ final class CodecDefinition[
 
   /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`.
     *
-    * By default if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
+    * By default, if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -36,7 +36,7 @@ final class IsoDefinition[
 
   /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`.
     *
-    * By default if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
+    * By default, if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -31,7 +31,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use provided `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -58,7 +58,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use provided partial result `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -83,9 +83,9 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldConstPartialImpl('this, 'selector, 'value) }
 
-  /** Use function `f` to compute value of field picked using `selector`.
+  /** Use the function `f` to compute a value of the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -110,15 +110,41 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
+  /** Use the function `f` to compute a value of the field picked using the `selectorTo` from a value extracted with
+    * `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
       inline f: S => U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
-  /** Use function `f` to compute partial result for field picked using `selector`.
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -143,15 +169,41 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
 
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
       inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
+  /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
-    * By default if `From` is missing field picked by `selectorTo` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
@@ -178,14 +230,14 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use `f` to calculate the unmatched subtype when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandled]] alias can be used (e.g. for Scala 3 enums or Java enums).
     *
     * It differs from `withFieldComputed(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled` matches on
-    * `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -226,15 +278,15 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandledPartial]] alias can be used (e.g. for Scala 3 enums or Java
     * enums).
     *
     * It differs from `withFieldComputedPartial(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled`
-    * matches on `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * matches on a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -273,7 +325,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialImpl('this, 'f) }
 
-  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+  /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
@@ -330,6 +382,29 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorImpl('this, 'f) }
 
+  /** Use `f` instead of the primary constructor to construct the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `T`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `To`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, T]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
@@ -361,6 +436,29 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorPartialImpl('this, 'f) }
 
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withConstructorPartialTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using
@@ -394,6 +492,30 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorEitherImpl('this, 'f) }
 
+  /** Use `f` instead of the primary constructor to parse into the `Either` value extracted from `To` using the
+    * `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Either[String, T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Either[String, T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withConstructorEitherTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -110,10 +110,9 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
-  transparent inline def withFieldComputedFrom[S, T, U](
-      inline selectorFrom: From => S,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
-      inline f: From => U
+      inline f: S => U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
@@ -144,10 +143,9 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
 
-  transparent inline def withFieldComputedPartialFrom[S, T, U](
-      inline selectorFrom: From => S,
+  transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
-      inline f: From => partial.Result[U]
+      inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
@@ -332,10 +330,9 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorImpl('this, 'f) }
 
-  transparent inline def withConstructorTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
-  )(using IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+  )(using IsFunction.Of[Ctor, T]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorToImpl('this, 'selector, 'f) }
 
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
@@ -364,11 +361,10 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorPartialImpl('this, 'f) }
 
-  transparent inline def withConstructorPartialTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorPartialTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using
-      IsFunction.Of[Ctor, partial.Result[To]]
+      IsFunction.Of[Ctor, partial.Result[T]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorPartialToImpl('this, 'selector, 'f) }
 
@@ -398,11 +394,10 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorEitherImpl('this, 'f) }
 
-  transparent inline def withConstructorEitherTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorEitherTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using
-      IsFunction.Of[Ctor, Either[String, To]]
+      IsFunction.Of[Ctor, Either[String, T]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorEitherToImpl('this, 'selector, 'f) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -110,6 +110,13 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
+  transparent inline def withFieldComputedFrom[S, T, U](
+      inline selectorFrom: From => S,
+      inline selectorTo: To => T,
+      inline f: From => U
+  )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
+
   /** Use function `f` to compute partial result for field picked using `selector`.
     *
     * By default if `From` is missing field picked by `selector` compilation fails.
@@ -136,6 +143,13 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       inline f: From => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
+
+  transparent inline def withFieldComputedPartialFrom[S, T, U](
+      inline selectorFrom: From => S,
+      inline selectorTo: To => T,
+      inline f: From => partial.Result[U]
+  )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
@@ -318,6 +332,12 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorImpl('this, 'f) }
 
+  transparent inline def withConstructorTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withConstructorToImpl('this, 'selector, 'f) }
+
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -344,6 +364,14 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorPartialImpl('this, 'f) }
 
+  transparent inline def withConstructorPartialTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using
+      IsFunction.Of[Ctor, partial.Result[To]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withConstructorPartialToImpl('this, 'selector, 'f) }
+
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -369,6 +397,14 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       IsFunction.Of[Ctor, Either[String, To]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorEitherImpl('this, 'f) }
+
+  transparent inline def withConstructorEitherTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using
+      IsFunction.Of[Ctor, Either[String, To]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withConstructorEitherToImpl('this, 'selector, 'f) }
 
   /** Build Partial Transformer using current configuration.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -114,10 +114,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
-  transparent inline def withFieldComputedFrom[S, T, U](
-      inline selectorFrom: From => S,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
-      inline f: From => U
+      inline f: S => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
@@ -148,10 +147,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
 
-  transparent inline def withFieldComputedPartialFrom[S, T, U](
-      inline selectorFrom: From => S,
+  transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
-      inline f: From => partial.Result[U]
+      inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
@@ -338,10 +336,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorImpl('this, 'f) }
 
-  transparent inline def withConstructorTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
-  )(using IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+  )(using IsFunction.Of[Ctor, T]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorToImpl('this, 'selector, 'f) }
 
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
@@ -368,10 +365,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorPartialImpl('this, 'f) }
 
-  transparent inline def withConstructorPartialTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorPartialTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
-  )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+  )(using IsFunction.Of[Ctor, partial.Result[T]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorPartialToImpl('this, 'selector, 'f) }
 
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
@@ -398,10 +394,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, Either[String, To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorEitherImpl('this, 'f) }
 
-  transparent inline def withConstructorEitherTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorEitherTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
-  )(using IsFunction.Of[Ctor, Either[String, To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+  )(using IsFunction.Of[Ctor, Either[String, T]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorEitherToImpl('this, 'selector, 'f) }
 
   /** Apply configured partial transformation in-place.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -35,7 +35,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use provided `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -62,7 +62,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use provided partial result `value` for field picked using `selector`.
     *
-    * By default if `From` is missing field picked by `selector`, compilation fails.
+    * By default, if `From` is missing field picked by `selector`, compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -87,9 +87,9 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldConstPartialImpl('this, 'selector, 'value) }
 
-  /** Use function `f` to compute value of field picked using `selector`.
+  /** Use the function `f` to compute a value of the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -114,15 +114,41 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
+  /** Use the function `f` to compute a value of the field picked using the `selectorTo` from a value extracted with
+    * `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
       inline f: S => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
-  /** Use function `f` to compute partial result for field picked using `selector`.
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -147,15 +173,41 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
 
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
       inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
-    * By default if `From` is missing field picked by `selectorTo` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
@@ -182,14 +234,14 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use `f` to calculate the unmatched subtype when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandled]] alias can be used (e.g. for Scala 3 enums or Java enums).
     *
     * It differs from `withFieldComputed(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled` matches on
-    * `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -230,15 +282,15 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts to
-    * have matching names of its components, and for every component in `To` field's type there is matching component in
-    * `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
     *
     * For convenience/readability [[withEnumCaseHandledPartial]] alias can be used (e.g. for Scala 3 enums or Java
     * enums).
     *
     * It differs from `withFieldComputedPartial(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled`
-    * matches on `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * matches on a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -277,7 +329,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withSealedSubtypeHandledPartialImpl('this, 'f) }
 
-  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+  /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
@@ -336,6 +388,29 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorImpl('this, 'f) }
 
+  /** Use `f` instead of the primary constructor to construct the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `T`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `To`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, T]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
@@ -365,6 +440,29 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorPartialImpl('this, 'f) }
 
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withConstructorPartialTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, partial.Result[T]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
@@ -394,6 +492,30 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, Either[String, To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorEitherImpl('this, 'f) }
 
+  /** Use `f` instead of the primary constructor to parse into the `Either` value extracted from `To` using the
+    * `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Either[String, T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Either[String, T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withConstructorEitherTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, Either[String, T]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -114,6 +114,13 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
+  transparent inline def withFieldComputedFrom[S, T, U](
+      inline selectorFrom: From => S,
+      inline selectorTo: To => T,
+      inline f: From => U
+  )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
+
   /** Use function `f` to compute partial result for field picked using `selector`.
     *
     * By default if `From` is missing field picked by `selector` compilation fails.
@@ -140,6 +147,13 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       inline f: From => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
+
+  transparent inline def withFieldComputedPartialFrom[S, T, U](
+      inline selectorFrom: From => S,
+      inline selectorTo: To => T,
+      inline f: From => partial.Result[U]
+  )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
     *
@@ -324,6 +338,12 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorImpl('this, 'f) }
 
+  transparent inline def withConstructorTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withConstructorToImpl('this, 'selector, 'f) }
+
   /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -348,6 +368,12 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorPartialImpl('this, 'f) }
 
+  transparent inline def withConstructorPartialTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, partial.Result[To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withConstructorPartialToImpl('this, 'selector, 'f) }
+
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *
     * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
@@ -371,6 +397,12 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       inline f: Ctor
   )(using IsFunction.Of[Ctor, Either[String, To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorEitherImpl('this, 'f) }
+
+  transparent inline def withConstructorEitherTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, Either[String, To]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withConstructorEitherToImpl('this, 'selector, 'f) }
 
   /** Apply configured partial transformation in-place.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -96,10 +96,9 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
-  transparent inline def withFieldComputedFrom[S, T, U](
-      inline selectorFrom: From => S,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
-      inline f: From => U
+      inline f: S => U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
@@ -237,10 +236,9 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(using IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withConstructorImpl('this, 'f) }
 
-  transparent inline def withConstructorTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
-  )(using IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+  )(using IsFunction.Of[Ctor, T]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withConstructorToImpl('this, 'selector, 'f) }
 
   /** Build Transformer using current configuration.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -96,6 +96,13 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
+  transparent inline def withFieldComputedFrom[S, T, U](
+      inline selectorFrom: From => S,
+      inline selectorTo: To => T,
+      inline f: From => U
+  )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerDefinitionMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
+
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`.
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
@@ -229,6 +236,12 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
       inline f: Ctor
   )(using IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withConstructorImpl('this, 'f) }
+
+  transparent inline def withConstructorTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerDefinitionMacros.withConstructorToImpl('this, 'selector, 'f) }
 
   /** Build Transformer using current configuration.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -85,6 +85,13 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
+  transparent inline def withFieldComputedFrom[S, T, U](
+      inline selectorFrom: From => S,
+      inline selectorTo: To => T,
+      inline f: From => U
+  )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
+
   /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
     *
     * By default if `From` is missing field picked by `selectorTo` compilation fails.
@@ -210,6 +217,12 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
       inline f: Ctor
   )(using IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withConstructorImpl('this, 'f) }
+
+  transparent inline def withConstructorTo[Ctor](
+      inline selector: To => Ctor,
+      inline f: Ctor
+  )(using IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerIntoMacros.withConstructorToImpl('this, 'selector, 'f) }
 
   /** Apply configured transformation in-place.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -85,10 +85,9 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
-  transparent inline def withFieldComputedFrom[S, T, U](
-      inline selectorFrom: From => S,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
-      inline f: From => U
+      inline f: S => U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
@@ -218,10 +217,9 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(using IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withConstructorImpl('this, 'f) }
 
-  transparent inline def withConstructorTo[Ctor](
-      inline selector: To => Ctor,
+  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
-  )(using IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+  )(using IsFunction.Of[Ctor, T]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withConstructorToImpl('this, 'selector, 'f) }
 
   /** Apply configured transformation in-place.

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -29,7 +29,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
 ) extends TransformerFlagsDsl[[Flags1 <: TransformerFlags] =>> TransformerInto[From, To, Overrides, Flags1], Flags]
     with WithRuntimeDataStore {
 
-  /** Lifts current transformation as partial transformation.
+  /** Lifts the current transformation to the partial transformation.
     *
     * It keeps all the configuration, provided missing values, renames, coproduct instances etc.
     *
@@ -39,9 +39,9 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   def partial: PartialTransformerInto[From, To, Overrides, Flags] =
     new PartialTransformerInto[From, To, Overrides, Flags](source, td.partial)
 
-  /** Use `value` provided here for field picked using `selector`.
+  /** Use the `value` provided here for the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-a-provided-value]]
@@ -58,9 +58,9 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldConstImpl('this, 'selector, 'value) }
 
-  /** Use function `f` to compute value of field picked using `selector`.
+  /** Use the function `f` to compute a value of the field picked using the `selector`.
     *
-    * By default if `From` is missing field picked by `selector` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
@@ -85,15 +85,41 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
 
+  /** Use the function `f` to compute a value of the field picked using the `selectorTo` from a value extracted with
+    * `selectorFrom` as an input.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
       inline f: S => U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
-  /** Use `selectorFrom` field in `From` to obtain the value of `selectorTo` field in `To`
+  /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
-    * By default if `From` is missing field picked by `selectorTo` compilation fails.
+    * By default, if `From` is missing a field and it's not provided with some `selectorTo`, the compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-its-source-field]]
@@ -120,14 +146,14 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
 
   /** Use `f` to calculate the unmatched subtype when mapping one sealed/enum into another.
     *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
     * will have matching names of its components, and for every component in `To` field's type there is matching
     * component in `From` type. If some component is missing it will fail.
     *
     * For convenience/readability [[withEnumCaseHandled]] alias can be used (e.g. for Scala 3 enums or Java enums).
     *
     * It differs from `withFieldComputed(_.matching[Subtype], src => ...)`, since `withSealedSubtypeHandled` matches on
-    * `From` subtype, while `.matching[Subtype]` matches on `To` value's piece.
+    * a `From` subtype, while `.matching[Subtype]` matches on a `To` value's piece.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
@@ -166,7 +192,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withSealedSubtypeHandledImpl('this, 'f) }
 
-  /** Use `FromSubtype` in `From` as a source for `ToSubtype` in `To`.
+  /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-by-a-specific-target-subtype]]
@@ -217,6 +243,29 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   )(using IsFunction.Of[Ctor, To]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withConstructorImpl('this, 'f) }
 
+  /** Use `f` instead of the primary constructor to construct the value extracted from `To` using the `selector`.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `T`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `To`
+    * @return
+    *   [[io.scalaland.chimney.dsl.TransformerInto]]
+    *
+    * @since 1.6.0
+    */
   transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, T]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -92,7 +92,7 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           quoted.Type.of[runtime.TransformerOverrides.ConstPartial[ToPath, Tail]]
         def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] = tpe match {
           case '[runtime.TransformerOverrides.ConstPartial[toPath, cfg]] =>
-            Some((Type[toPath].as_>?<[Nothing, runtime.Path], Type[cfg].as_>?<[Nothing, runtime.TransformerOverrides]))
+            Some((Type[toPath].as_?<[runtime.Path], Type[cfg].as_?<[runtime.TransformerOverrides]))
           case _ => scala.None
         }
       }
@@ -110,10 +110,50 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
         def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
             : Type[runtime.TransformerOverrides.ComputedPartial[ToPath, Tail]] =
           quoted.Type.of[runtime.TransformerOverrides.ComputedPartial[ToPath, Tail]]
-        def unapply[A](tpe: Type[A]): Option[(Nothing >?< runtime.Path, Nothing >?< runtime.TransformerOverrides)] =
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
           tpe match {
             case '[runtime.TransformerOverrides.ComputedPartial[toPath, cfg]] =>
               Some((Type[toPath].as_?<[runtime.Path], Type[cfg].as_?<[runtime.TransformerOverrides]))
+            case _ => scala.None
+          }
+      }
+      object ComputedFrom extends ComputedFromModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ComputedFrom[FromPath, ToPath, Tail]] =
+          quoted.Type.of[runtime.TransformerOverrides.ComputedFrom[FromPath, ToPath, Tail]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          tpe match {
+            case '[runtime.TransformerOverrides.ComputedFrom[fromPath, toPath, cfg]] =>
+              Some(
+                (
+                  Type[fromPath].as_?<[runtime.Path],
+                  Type[toPath].as_?<[runtime.Path],
+                  Type[cfg].as_?<[runtime.TransformerOverrides]
+                )
+              )
+            case _ => scala.None
+          }
+      }
+      object ComputedPartialFrom extends ComputedPartialFromModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ComputedPartialFrom[FromPath, ToPath, Tail]] =
+          quoted.Type.of[runtime.TransformerOverrides.ComputedPartialFrom[FromPath, ToPath, Tail]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          tpe match {
+            case '[runtime.TransformerOverrides.ComputedPartialFrom[fromPath, toPath, cfg]] =>
+              Some(
+                (
+                  Type[fromPath].as_?<[runtime.Path],
+                  Type[toPath].as_?<[runtime.Path],
+                  Type[cfg].as_?<[runtime.TransformerOverrides]
+                )
+              )
             case _ => scala.None
           }
       }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -102,7 +102,7 @@ object PartialTransformerDefinitionMacros {
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
       selectorFrom: Expr[From => S],
       selectorTo: Expr[To => T],
-      f: Expr[From => U]
+      f: Expr[S => U]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] =>
@@ -154,7 +154,7 @@ object PartialTransformerDefinitionMacros {
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
       selectorFrom: Expr[From => S],
       selectorTo: Expr[To => T],
-      f: Expr[From => partial.Result[U]]
+      f: Expr[S => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] =>
@@ -282,10 +282,11 @@ object PartialTransformerDefinitionMacros {
       To: Type,
       Overrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
+      T: Type,
       Ctor: Type
   ](
       ti: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => Ctor],
+      selector: Expr[To => T],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyConstructorType {
@@ -337,10 +338,11 @@ object PartialTransformerDefinitionMacros {
       To: Type,
       Overrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
+      T: Type,
       Ctor: Type
   ](
       ti: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => Ctor],
+      selector: Expr[To => T],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyConstructorType {
@@ -397,10 +399,11 @@ object PartialTransformerDefinitionMacros {
       To: Type,
       Overrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
+      T: Type,
       Ctor: Type
   ](
       ti: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => Ctor],
+      selector: Expr[To => T],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyConstructorType {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -424,7 +424,7 @@ object PartialTransformerDefinitionMacros {
                     .asInstanceOf[PartialTransformerDefinition[
                       From,
                       To,
-                      ConstructorPartial[args, Path.Root, Overrides],
+                      ConstructorPartial[args, toPath, Overrides],
                       Flags
                     ]]
               }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -398,7 +398,7 @@ object PartialTransformerIntoMacros {
                     .asInstanceOf[PartialTransformerInto[
                       From,
                       To,
-                      ConstructorPartial[args, Path.Root, Overrides],
+                      ConstructorPartial[args, toPath, Overrides],
                       Flags
                     ]]
               }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -97,7 +97,7 @@ object PartialTransformerIntoMacros {
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
       selectorFrom: Expr[From => S],
       selectorTo: Expr[To => T],
-      f: Expr[From => U]
+      f: Expr[S => U]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] =>
@@ -144,7 +144,7 @@ object PartialTransformerIntoMacros {
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
       selectorFrom: Expr[From => S],
       selectorTo: Expr[To => T],
-      f: Expr[From => partial.Result[U]]
+      f: Expr[S => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] =>
@@ -267,10 +267,11 @@ object PartialTransformerIntoMacros {
       To: Type,
       Overrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
+      T: Type,
       Ctor: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => Ctor],
+      selector: Expr[To => T],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyConstructorType {
@@ -372,10 +373,11 @@ object PartialTransformerIntoMacros {
       To: Type,
       Overrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
+      T: Type,
       Ctor: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => Ctor],
+      selector: Expr[To => T],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyConstructorType {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -85,6 +85,31 @@ object PartialTransformerIntoMacros {
         }
     }(selector)
 
+  def withFieldComputedFromImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      S: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selectorFrom: Expr[From => S],
+      selectorTo: Expr[To => T],
+      f: Expr[From => U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] =>
+        (_: Type[fromPath]) ?=>
+          (_: Type[toPath]) ?=>
+            '{
+              WithRuntimeDataStore
+                .update($ti, $f)
+                .asInstanceOf[PartialTransformerInto[From, To, ComputedFrom[fromPath, toPath, Overrides], Flags]]
+          }
+    }(selectorFrom, selectorTo)
+
   def withFieldComputedPartialImpl[
       From: Type,
       To: Type,
@@ -106,6 +131,31 @@ object PartialTransformerIntoMacros {
               .asInstanceOf[PartialTransformerInto[From, To, ComputedPartial[toPath, Overrides], Flags]]
         }
     }(selector)
+
+  def withFieldComputedPartialFromImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      S: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selectorFrom: Expr[From => S],
+      selectorTo: Expr[To => T],
+      f: Expr[From => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] =>
+        (_: Type[fromPath]) ?=>
+          (_: Type[toPath]) ?=>
+            '{
+              WithRuntimeDataStore
+                .update($ti, $f)
+                .asInstanceOf[PartialTransformerInto[From, To, ComputedPartialFrom[fromPath, toPath, Overrides], Flags]]
+          }
+    }(selectorFrom, selectorTo)
 
   def withFieldRenamedImpl[
       From: Type,
@@ -212,6 +262,31 @@ object PartialTransformerIntoMacros {
         }
     }(f)
 
+  def withConstructorToImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selector: Expr[To => Ctor],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [args <: ArgumentLists] =>
+        (_: Type[args]) ?=>
+          DslMacroUtils().applyFieldNameType {
+            [toPath <: Path] =>
+              (_: Type[toPath]) ?=>
+                '{
+                  WithRuntimeDataStore
+                    .update($ti, $f)
+                    .asInstanceOf[PartialTransformerInto[From, To, Constructor[args, toPath, Overrides], Flags]]
+              }
+          }(selector)
+    }(f)
+
   def withConstructorPartialImpl[
       From: Type,
       To: Type,
@@ -228,8 +303,43 @@ object PartialTransformerIntoMacros {
           '{
             WithRuntimeDataStore
               .update($ti, $f)
-              .asInstanceOf[PartialTransformerInto[From, To, ConstructorPartial[args, Path.Root, Overrides], Flags]]
+              .asInstanceOf[PartialTransformerInto[
+                From,
+                To,
+                ConstructorPartial[args, Path.Root, Overrides],
+                Flags
+              ]]
         }
+    }(f)
+
+  def withConstructorPartialToImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selector: Expr[To => Ctor],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [args <: ArgumentLists] =>
+        (_: Type[args]) ?=>
+          DslMacroUtils().applyFieldNameType {
+            [toPath <: Path] =>
+              (_: Type[toPath]) ?=>
+                '{
+                  WithRuntimeDataStore
+                    .update($ti, $f)
+                    .asInstanceOf[PartialTransformerInto[
+                      From,
+                      To,
+                      ConstructorPartial[args, toPath, Overrides],
+                      Flags
+                    ]]
+              }
+          }(selector)
     }(f)
 
   def withConstructorEitherImpl[
@@ -255,5 +365,41 @@ object PartialTransformerIntoMacros {
               )
               .asInstanceOf[PartialTransformerInto[From, To, ConstructorPartial[args, Path.Root, Overrides], Flags]]
         }
+    }(f)
+
+  def withConstructorEitherToImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selector: Expr[To => Ctor],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [args <: ArgumentLists] =>
+        (_: Type[args]) ?=>
+          DslMacroUtils().applyFieldNameType {
+            [toPath <: Path] =>
+              (_: Type[toPath]) ?=>
+                '{
+                  WithRuntimeDataStore
+                    .update(
+                      $ti,
+                      FunctionEitherToResult.lift[Ctor, Any]($f)(
+                        ${ Expr.summon[FunctionEitherToResult[Ctor]].get }
+                          .asInstanceOf[FunctionEitherToResult.Aux[Ctor, Any]]
+                      )
+                    )
+                    .asInstanceOf[PartialTransformerInto[
+                      From,
+                      To,
+                      ConstructorPartial[args, Path.Root, Overrides],
+                      Flags
+                    ]]
+              }
+          }(selector)
     }(f)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -59,6 +59,31 @@ object TransformerDefinitionMacros {
         }
     }(selector)
 
+  def withFieldComputedFromImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      S: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
+      selectorFrom: Expr[From => S],
+      selectorTo: Expr[To => T],
+      f: Expr[From => U]
+  )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] =>
+        (_: Type[fromPath]) ?=>
+          (_: Type[toPath]) ?=>
+            '{
+              WithRuntimeDataStore
+                .update($td, $f)
+                .asInstanceOf[TransformerDefinition[From, To, ComputedFrom[fromPath, toPath, Overrides], Flags]]
+          }
+    }(selectorFrom, selectorTo)
+
   def withFieldRenamedImpl[
       From: Type,
       To: Type,
@@ -144,5 +169,30 @@ object TransformerDefinitionMacros {
               .update($ti, $f)
               .asInstanceOf[TransformerDefinition[From, To, Constructor[args, Path.Root, Overrides], Flags]]
         }
+    }(f)
+
+  def withConstructorToImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[TransformerDefinition[From, To, Overrides, Flags]],
+      selector: Expr[To => Ctor],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType {
+      [args <: ArgumentLists] =>
+        (_: Type[args]) ?=>
+          DslMacroUtils().applyFieldNameType {
+            [toPath <: Path] =>
+              (_: Type[toPath]) ?=>
+                '{
+                  WithRuntimeDataStore
+                    .update($ti, $f)
+                    .asInstanceOf[TransformerDefinition[From, To, Constructor[args, toPath, Overrides], Flags]]
+              }
+          }(selector)
     }(f)
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -71,7 +71,7 @@ object TransformerDefinitionMacros {
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
       selectorFrom: Expr[From => S],
       selectorTo: Expr[To => T],
-      f: Expr[From => U]
+      f: Expr[S => U]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] =>
@@ -176,10 +176,11 @@ object TransformerDefinitionMacros {
       To: Type,
       Overrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
+      T: Type,
       Ctor: Type
   ](
       ti: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => Ctor],
+      selector: Expr[To => T],
       f: Expr[Ctor]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyConstructorType {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -74,7 +74,7 @@ object TransformerIntoMacros {
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
       selectorFrom: Expr[From => S],
       selectorTo: Expr[To => T],
-      f: Expr[From => U]
+      f: Expr[S => U]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] =>
@@ -174,10 +174,11 @@ object TransformerIntoMacros {
       To: Type,
       Overrides <: TransformerOverrides: Type,
       Flags <: TransformerFlags: Type,
+      T: Type,
       Ctor: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => Ctor],
+      selector: Expr[To => T],
       f: Expr[Ctor]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
     DslMacroUtils().applyConstructorType {

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerFlagsDsl.scala
@@ -14,7 +14,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable lookup in definitions inherited from supertype.
     *
-    * By default only values defined directly in the type are considered. With this flag supertype methods would not be
+    * By default, only values defined directly in the type are considered. With this flag supertype methods would not be
     * filtered out
     *
     * @see
@@ -39,7 +39,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable values to be supplied from method calls. Source method must be public and have no parameter list.
     *
-    * By default this is disabled because method calls may perform side effects (e.g. mutations)
+    * By default, this is disabled because method calls may perform side effects (e.g. mutations)
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#reading-from-methods]] for more details
@@ -61,7 +61,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable fallback to default case class values in `To` type.
     *
-    * By default in such case derivation will fail. By enabling this flag, derivation will fallback to default value.
+    * By default, in such case derivation will fail. By enabling this flag, derivation will fallback to default value.
     *
     * This flag can be set in parallel to enabling default values for specific field type with
     * [[enableDefaultValueOfType]].
@@ -91,7 +91,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable fallback to default case class values in `To` type for fields of `T` type.
     *
-    * By default in such case derivation will fail. By enabling this flag, derivation will fallback to default value.
+    * By default, in such case derivation will fail. By enabling this flag, derivation will fallback to default value.
     *
     * This flag can be set in parallel to globally enabling default values with [[enableDefaultValues]].
     *
@@ -119,7 +119,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable Java Beans naming convention (`.getName`, `.isName`) on `From`.
     *
-    * By default only Scala conversions (`.name`) are allowed.
+    * By default, only Scala conversions (`.name`) are allowed.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#reading-from-bean-getters]] for more details
@@ -141,7 +141,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable Java Beans naming convention (`.setName(value)`) on `To`.
     *
-    * By default only Scala conversions (`.copy(name = value)`) are allowed.
+    * By default, only Scala conversions (`.copy(name = value)`) are allowed.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#writing-to-bean-setters]] for more details
@@ -163,8 +163,8 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable not failing compilation on unresolved Java Beans naming convention (`.setName(value)`) in `To`.
     *
-    * By default presence of setters (`.setName(value)`) fails compilation unless setters are enabled and matched with a
-    * source field or provided valued.
+    * By default, presence of setters (`.setName(value)`) fails compilation unless setters are enabled and matched with
+    * a source field or provided valued.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#ignoring-unmatched-bean-setters]] for more details
@@ -186,7 +186,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Enable calling unary non-Unit methods with Java Beans naming convention (`.setName(value)`) in `To`.
     *
-    * By default only methods returning `Unit` (`setName(value): Unit`) could be considered setters.
+    * By default, only methods returning `Unit` (`setName(value): Unit`) could be considered setters.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#writing-to-non-unit-bean-setters]] for more details
@@ -208,7 +208,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
 
   /** Sets target value of optional field to None if field is missing from source type `From`.
     *
-    * By default in such case compilation fails.
+    * By default, in such case compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#allowing-fallback-to-none-as-the-constructors-argument]]
@@ -259,7 +259,7 @@ private[dsl] trait TransformerFlagsDsl[UpdateFlag[_ <: TransformerFlags], Flags 
   /** Enable unpacking/wrapping with wrapper types (classes with have only 1 val, set in a constructor) even when they
     * are not AnyVals.
     *
-    * By default in such case compilation fails.
+    * By default, in such case compilation fails.
     *
     * @see
     *   [[https://chimney.readthedocs.io/supported-transformations/#frominto-a-wrapper-type]] for more details

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -100,6 +100,24 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerOverrides.ComputedPartial
           ] { this: ComputedPartial.type => }
 
+      val ComputedFrom: ComputedFromModule
+      trait ComputedFromModule
+          extends Type.Ctor3UpperBounded[
+            runtime.Path,
+            runtime.Path,
+            runtime.TransformerOverrides,
+            runtime.TransformerOverrides.ComputedFrom
+          ] { this: ComputedFrom.type => }
+
+      val ComputedPartialFrom: ComputedPartialFromModule
+      trait ComputedPartialFromModule
+          extends Type.Ctor3UpperBounded[
+            runtime.Path,
+            runtime.Path,
+            runtime.TransformerOverrides,
+            runtime.TransformerOverrides.ComputedPartialFrom
+          ] { this: ComputedPartialFrom.type => }
+
       val CaseComputed: CaseComputedModule
       trait CaseComputedModule
           extends Type.Ctor2UpperBounded[

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
@@ -12,9 +12,14 @@ private[compiletime] trait Contexts { this: Derivation =>
     val To: Type[To]
 
     val srcJournal: Vector[(Path, ExistentialExpr)]
+    val tgtJournal: Vector[Path]
 
     /** When using nested paths (_.foo.bar.baz) and recursive derivation this is the original, "top-level" value */
     val originalSrc: ExistentialExpr = srcJournal.head._2
+
+    /** Path to the current target value */
+    val currentTgt: Path = tgtJournal.last
+
     val config: TransformerConfiguration
     val derivationStartedAt: java.time.Instant
 
@@ -31,6 +36,7 @@ private[compiletime] trait Contexts { this: Derivation =>
           From = Type[NewFrom],
           To = Type[NewTo],
           srcJournal = ctx.srcJournal :+ (ctx.srcJournal.last._1.concat(followFrom) -> newSrc.as_??),
+          tgtJournal = ctx.tgtJournal :+ ctx.tgtJournal.last.concat(followTo),
           config = ctx.config.prepareForRecursiveCall(followFrom, followTo)(ctx),
           ctx.derivationStartedAt
         )
@@ -39,6 +45,7 @@ private[compiletime] trait Contexts { this: Derivation =>
           From = Type[NewFrom],
           To = Type[NewTo],
           srcJournal = ctx.srcJournal :+ (ctx.srcJournal.last._1.concat(followFrom) -> newSrc.as_??),
+          tgtJournal = ctx.tgtJournal :+ ctx.tgtJournal.last.concat(followTo),
           config = ctx.config.prepareForRecursiveCall(followFrom, followTo)(ctx),
           ctx.derivationStartedAt
         )
@@ -50,6 +57,7 @@ private[compiletime] trait Contexts { this: Derivation =>
           From = ctx.From,
           To = ctx.To,
           srcJournal = ctx.srcJournal,
+          tgtJournal = ctx.tgtJournal,
           config = update(ctx.config),
           derivationStartedAt = ctx.derivationStartedAt
         )
@@ -58,6 +66,7 @@ private[compiletime] trait Contexts { this: Derivation =>
           From = ctx.From,
           To = ctx.To,
           srcJournal = ctx.srcJournal,
+          tgtJournal = ctx.tgtJournal,
           config = update(ctx.config),
           derivationStartedAt = ctx.derivationStartedAt
         )
@@ -85,6 +94,7 @@ private[compiletime] trait Contexts { this: Derivation =>
         val From: Type[From],
         val To: Type[To],
         val srcJournal: Vector[(Path, ExistentialExpr)],
+        val tgtJournal: Vector[Path],
         val config: TransformerConfiguration,
         val derivationStartedAt: java.time.Instant
     ) extends TransformationContext[From, To] {
@@ -112,6 +122,7 @@ private[compiletime] trait Contexts { this: Derivation =>
           From = Type[From],
           To = Type[To],
           srcJournal = Vector(Path.Root -> src.as_??),
+          tgtJournal = Vector(Path.Root),
           config = config.preventImplicitSummoningFor[From, To],
           derivationStartedAt = java.time.Instant.now()
         )
@@ -121,6 +132,7 @@ private[compiletime] trait Contexts { this: Derivation =>
         val From: Type[From],
         val To: Type[To],
         val srcJournal: Vector[(Path, ExistentialExpr)],
+        val tgtJournal: Vector[Path],
         val config: TransformerConfiguration,
         val derivationStartedAt: java.time.Instant
     ) extends TransformationContext[From, To] {
@@ -149,6 +161,7 @@ private[compiletime] trait Contexts { this: Derivation =>
         From = Type[From],
         To = Type[To],
         srcJournal = Vector(Path.Root -> src.as_??),
+        tgtJournal = Vector(Path.Root),
         config = config.preventImplicitSummoningFor[From, To],
         derivationStartedAt = java.time.Instant.now()
       )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/FunctionEitherToResult.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/FunctionEitherToResult.scala
@@ -21,7 +21,145 @@ object FunctionEitherToResult extends FunctionEitherToResultImplicits0 {
 
   def lift[FnE, FnR](fn: FnE)(implicit liftFn: Aux[FnE, FnR]): FnR = liftFn.lift(fn)
 }
-private[runtime] trait FunctionEitherToResultImplicits0 { this: FunctionEitherToResult.type =>
+private[runtime] trait FunctionEitherToResultImplicits0 extends FunctionEitherToResultImplicits1 {
+  this: FunctionEitherToResult.type =>
+
+  private def make[FnE, FnR0](l: FnE => FnR0): Aux[FnE, FnR0] = new FunctionEitherToResult[FnE] {
+    type FnR = FnR0
+    def lift(fn: FnE): FnR = l(fn)
+  }
+
+  implicit def curriedFunction0[Mid, Out](implicit ev: Aux[Mid, Out]): Aux[() => Mid, () => Out] =
+    make(fn => () => ev.lift(fn()))
+  implicit def curriedFunction1[A, Mid, Out](implicit ev: Aux[Mid, Out]): Aux[A => Mid, A => Out] =
+    make(fn => a => ev.lift(fn(a)))
+  implicit def curriedFunction2[A, B, Mid, Out](implicit ev: Aux[Mid, Out]): Aux[(A, B) => Mid, (A, B) => Out] =
+    make(fn => (a, b) => ev.lift(fn(a, b)))
+  implicit def curriedFunction3[A, B, C, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C) => Mid, (A, B, C) => Out] =
+    make(fn => (a, b, c) => ev.lift(fn(a, b, c)))
+  implicit def curriedFunction4[A, B, C, D, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D) => Mid, (A, B, C, D) => Out] =
+    make(fn => (a, b, c, d) => ev.lift(fn(a, b, c, d)))
+  implicit def curriedFunction5[A, B, C, D, E, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E) => Mid, (A, B, C, D, E) => Out] =
+    make(fn => (a, b, c, d, e) => ev.lift(fn(a, b, c, d, e)))
+  implicit def curriedFunction6[A, B, C, D, E, F, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F) => Mid, (A, B, C, D, E, F) => Out] =
+    make(fn => (a, b, c, d, e, f) => ev.lift(fn(a, b, c, d, e, f)))
+  implicit def curriedFunction7[A, B, C, D, E, F, G, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G) => Mid, (A, B, C, D, E, F, G) => Out] =
+    make(fn => (a, b, c, d, e, f, g) => ev.lift(fn(a, b, c, d, e, f, g)))
+  implicit def curriedFunction8[A, B, C, D, E, F, G, H, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H) => Mid, (A, B, C, D, E, F, G, H) => Out] =
+    make(fn => (a, b, c, d, e, f, g, h) => ev.lift(fn(a, b, c, d, e, f, g, h)))
+  implicit def curriedFunction9[A, B, C, D, E, F, G, H, I, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H, I) => Mid, (A, B, C, D, E, F, G, H, I) => Out] =
+    make(fn => (a, b, c, d, e, f, g, h, i) => ev.lift(fn(a, b, c, d, e, f, g, h, i)))
+  implicit def curriedFunction10[A, B, C, D, E, F, G, H, I, J, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H, I, J) => Mid, (A, B, C, D, E, F, G, H, I, J) => Out] =
+    make(fn => (a, b, c, d, e, f, g, h, i, j) => ev.lift(fn(a, b, c, d, e, f, g, h, i, j)))
+  implicit def curriedFunction11[A, B, C, D, E, F, G, H, I, J, K, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H, I, J, K) => Mid, (A, B, C, D, E, F, G, H, I, J, K) => Out] =
+    make(fn => (a, b, c, d, e, f, g, h, i, j, k) => ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k)))
+  implicit def curriedFunction12[A, B, C, D, E, F, G, H, I, J, K, L, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H, I, J, K, L) => Mid, (A, B, C, D, E, F, G, H, I, J, K, L) => Out] =
+    make(fn => (a, b, c, d, e, f, g, h, i, j, k, l) => ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l)))
+  implicit def curriedFunction13[A, B, C, D, E, F, G, H, I, J, K, L, M, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Mid, (A, B, C, D, E, F, G, H, I, J, K, L, M) => Out] =
+    make(fn => (a, b, c, d, e, f, g, h, i, j, k, l, m) => ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m)))
+  implicit def curriedFunction14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Mid, (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Out] =
+    make(fn => (a, b, c, d, e, f, g, h, i, j, k, l, m, n) => ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n)))
+  implicit def curriedFunction15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Mid, (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Out] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o))
+    )
+  implicit def curriedFunction16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Mid,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Out
+  ] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))
+    )
+  implicit def curriedFunction17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Mid,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Out
+  ] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) =>
+        ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))
+    )
+  implicit def curriedFunction18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Mid,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Out
+  ] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) =>
+        ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r))
+    )
+  implicit def curriedFunction19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Mid,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Out
+  ] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) =>
+        ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s))
+    )
+  implicit def curriedFunction20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Mid,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Out
+  ] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) =>
+        ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t))
+    )
+  implicit def curriedFunction21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Mid,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Out
+  ] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) =>
+        ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u))
+    )
+  implicit def curriedFunction22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Mid, Out](implicit
+      ev: Aux[Mid, Out]
+  ): Aux[
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Mid,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Out
+  ] =
+    make(fn =>
+      (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) =>
+        ev.lift(fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v))
+    )
+}
+private[runtime] trait FunctionEitherToResultImplicits1 { this: FunctionEitherToResult.type =>
 
   private def make[FnE, FnR0](l: FnE => FnR0): Aux[FnE, FnR0] = new FunctionEitherToResult[FnE] {
     type FnR = FnR0

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
@@ -11,12 +11,18 @@ object TransformerOverrides {
   // Computes a value from a whole (src: From)
   final class Computed[ToPath <: Path, Tail <: Overrides] extends Overrides
   final class ComputedPartial[ToPath <: Path, Tail <: Overrides] extends Overrides
+  // FIXME (2.0.0 cleanup) - merge Computed with ComputedFrom, ComputedPartial with ComputedPartialFrom
+  // Computes a value from an expr
+  final class ComputedFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
+  final class ComputedPartialFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
+  // FIXME (2.0.0 cleanup)...
   // Computes a value from an already extracted (e.g. matched) piece of (src: From)
   final class CaseComputed[ToPath <: Path, Tail <: Overrides] extends Overrides
   final class CaseComputedPartial[ToPath <: Path, Tail <: Overrides] extends Overrides
   // Computes a value after all constructor arguments have been matched
   final class Constructor[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
   final class ConstructorPartial[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
+  // FIXME (2.0.0 cleanup) - try merging RenameFrom with RenameTo
   // Computes a value using manually pointed value from (src: From)
   final class RenamedFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
   // Computes a value from matched subtype, targeting another subtype

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
@@ -15,7 +15,7 @@ object TransformerOverrides {
   // Computes a value from an expr
   final class ComputedFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
   final class ComputedPartialFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
-  // FIXME (2.0.0 cleanup)...
+  // FIXME (2.0.0 cleanup) - merge CaseComputed with ComputedFrom, CaseComputedPartial with ComputedPartialFrom
   // Computes a value from an already extracted (e.g. matched) piece of (src: From)
   final class CaseComputed[ToPath <: Path, Tail <: Overrides] extends Overrides
   final class CaseComputedPartial[ToPath <: Path, Tail <: Overrides] extends Overrides

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
@@ -5,205 +5,709 @@ import io.scalaland.chimney.fixtures.*
 
 class PartialTransformerCustomConstructorSpec extends ChimneySpec {
 
-  test("""not allow transformation when passed value is not a function/method""") {
-    import products.{Foo, Bar}
+  group("setting .withConstructor(fn)") {
 
-    compileErrors("""Foo(3, "pi", (3.14, 3.14)).intoPartial[Bar].withConstructor(Bar(4, (5.0, 5.0))).transform""")
-      .check(
-        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
-        ", got io.scalaland.chimney.fixtures.products.Bar"
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}
+
+      compileErrors("""Foo(3, "pi", (3.14, 3.14)).intoPartial[Bar].withConstructor(Bar(4, (5.0, 5.0))).transform""")
+        .check(
+          "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+          ", got io.scalaland.chimney.fixtures.products.Bar"
+        )
+    }
+
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}
+
+      val nullaryExpected = Bar(0, (0.0, 0.0))
+
+      def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
+
+      val result = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructor(nullaryConstructor _)
+        .transform
+      result.asOption ==> Some(nullaryExpected)
+      result.asEither ==> Right(nullaryExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructor { () =>
+          nullaryConstructor()
+        }
+        .transform
+      result2.asOption ==> Some(nullaryExpected)
+      result2.asEither ==> Right(nullaryExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+
+      val uncurriedExpected = Bar(6, (6.28, 6.28))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+      val result3 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructor(uncurriedConstructor _)
+        .transform
+      result3.asOption ==> Some(uncurriedExpected)
+      result3.asEither ==> Right(uncurriedExpected)
+      result3.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result4 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructor { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform
+      result4.asOption ==> Some(uncurriedExpected)
+      result4.asEither ==> Right(uncurriedExpected)
+      result4.asErrorPathMessageStrings ==> Iterable.empty
+
+      val curriedExpected = Bar(9, (9.42, 9.42))
+
+      def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+
+      val result5 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructor(curriedConstructor _)
+        .transform
+      result5.asOption ==> Some(curriedExpected)
+      result5.asEither ==> Right(curriedExpected)
+      result5.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result6 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructor { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform
+      result6.asOption ==> Some(curriedExpected)
+      result6.asEither ==> Right(curriedExpected)
+      result6.asErrorPathMessageStrings ==> Iterable.empty
+
+      val typeParametricExpected = BarParams(3, (3.14, 12.56))
+
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+
+      val result7 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[BarParams[Int, Double]]
+        .withConstructor(typeParametricConstructor[Int, Double] _)
+        .transform
+      result7.asOption ==> Some(typeParametricExpected)
+      result7.asEither ==> Right(typeParametricExpected)
+      result7.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*
+
+      implicit val transformer: PartialTransformer[ClassSource, TraitSource] = PartialTransformer
+        .define[ClassSource, TraitSource]
+        .withConstructor { (name: String, id: String) =>
+          // swap
+          new TraitSourceImpl(name = id, id = name): TraitSource
+        }
+        // another swap
+        .withFieldRenamed(_.id, _.name)
+        .withFieldRenamed(_.name, _.id)
+        .buildTransformer
+
+      val result = (new ClassSource("id", "name")).transformIntoPartial[TraitSource].asOption.get
+      result.id ==> "id"
+      result.name ==> "name"
+    }
+  }
+
+  group("setting .withConstructorTo(_.field)(fn)") {
+
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}, nestedpath.*
+
+      compileErrors(
+        """NestedProduct(Foo(3, "pi", (3.14, 3.14))).intoPartial[NestedProduct[Bar]].withConstructorTo(_.value)(Bar(4, (5.0, 5.0))).transform"""
       )
+        .check(
+          "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+          ", got io.scalaland.chimney.fixtures.products.Bar"
+        )
+    }
 
-    compileErrors(
-      """Foo(3, "pi", (3.14, 3.14)).intoPartial[Bar].withConstructorPartial(partial.Result.fromValue(Bar(4, (5.0, 5.0)))).transform"""
-    ).check(
-      "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
-      ", got io.scalaland.chimney.partial.Result[io.scalaland.chimney.fixtures.products.Bar]"
-    )
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}, nestedpath.*
+
+      val nullaryExpected = NestedProduct(Bar(0, (0.0, 0.0)))
+
+      def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
+
+      val result = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorTo(_.value)(nullaryConstructor _)
+        .transform
+      result.asOption ==> Some(nullaryExpected)
+      result.asEither ==> Right(nullaryExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorTo(_.value) { () =>
+          nullaryConstructor()
+        }
+        .transform
+      result2.asOption ==> Some(nullaryExpected)
+      result2.asEither ==> Right(nullaryExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+
+      val uncurriedExpected = NestedProduct(Bar(6, (6.28, 6.28)))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+      val result3 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorTo(_.value)(uncurriedConstructor _)
+        .transform
+      result3.asOption ==> Some(uncurriedExpected)
+      result3.asEither ==> Right(uncurriedExpected)
+      result3.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result4 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorTo(_.value) { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform
+      result4.asOption ==> Some(uncurriedExpected)
+      result4.asEither ==> Right(uncurriedExpected)
+      result4.asErrorPathMessageStrings ==> Iterable.empty
+
+      val curriedExpected = NestedProduct(Bar(9, (9.42, 9.42)))
+
+      def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+
+      val result5 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorTo(_.value)(curriedConstructor _)
+        .transform
+      result5.asOption ==> Some(curriedExpected)
+      result5.asEither ==> Right(curriedExpected)
+      result5.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result6 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorTo(_.value) { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform
+      result6.asOption ==> Some(curriedExpected)
+      result6.asEither ==> Right(curriedExpected)
+      result6.asErrorPathMessageStrings ==> Iterable.empty
+
+      val typeParametricExpected = NestedProduct(BarParams(3, (3.14, 12.56)))
+
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+
+      val result7 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[BarParams[Int, Double]]]
+        .withConstructorTo(_.value)(typeParametricConstructor[Int, Double] _)
+        .transform
+      result7.asOption ==> Some(typeParametricExpected)
+      result7.asEither ==> Right(typeParametricExpected)
+      result7.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*, nestedpath.*
+
+      implicit val transformer: PartialTransformer[NestedProduct[ClassSource], NestedProduct[TraitSource]] =
+        PartialTransformer
+          .define[NestedProduct[ClassSource], NestedProduct[TraitSource]]
+          .withConstructorTo(_.value) { (name: String, id: String) =>
+            // swap
+            new TraitSourceImpl(name = id, id = name): TraitSource
+          }
+          // another swap
+          .withFieldRenamed(_.value.id, _.value.name)
+          .withFieldRenamed(_.value.name, _.value.id)
+          .buildTransformer
+
+      val result =
+        NestedProduct(new ClassSource("id", "name")).transformIntoPartial[NestedProduct[TraitSource]].asOption.get
+      result.value.id ==> "id"
+      result.value.name ==> "name"
+    }
   }
 
-  test("""allow transformation from using Eta-expanded method or lambda""") {
-    import products.{Foo, Bar, BarParams}
+  group("setting .withConstructorPartial(fn)") {
 
-    val nullaryExpected = Bar(0, (0.0, 0.0))
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}
 
-    def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
+      compileErrors(
+        """Foo(3, "pi", (3.14, 3.14)).intoPartial[Bar].withConstructorPartial(partial.Result.fromValue(Bar(4, (5.0, 5.0)))).transform"""
+      ).check(
+        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+        ", got io.scalaland.chimney.partial.Result[io.scalaland.chimney.fixtures.products.Bar]"
+      )
+    }
 
-    val result = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructor(nullaryConstructor _)
-      .transform
-    result.asOption ==> Some(nullaryExpected)
-    result.asEither ==> Right(nullaryExpected)
-    result.asErrorPathMessageStrings ==> Iterable.empty
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}
 
-    val result2 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructor { () =>
-        nullaryConstructor()
-      }
-      .transform
-    result2.asOption ==> Some(nullaryExpected)
-    result2.asEither ==> Right(nullaryExpected)
-    result2.asErrorPathMessageStrings ==> Iterable.empty
+      val nullaryExpected = Bar(0, (0.0, 0.0))
 
-    def nullaryConstructorPartial(): partial.Result[Bar] = partial.Result.fromValue(Bar(0, (0.0, 0.0)))
+      def nullaryConstructor(): partial.Result[Bar] = partial.Result.fromValue(Bar(0, (0.0, 0.0)))
 
-    val result3 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructorPartial(nullaryConstructorPartial _)
-      .transform
-    result3.asOption ==> Some(nullaryExpected)
-    result3.asEither ==> Right(nullaryExpected)
-    result3.asErrorPathMessageStrings ==> Iterable.empty
+      val result = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorPartial(nullaryConstructor _)
+        .transform
+      result.asOption ==> Some(nullaryExpected)
+      result.asEither ==> Right(nullaryExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
 
-    val result4 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructorPartial { () =>
-        nullaryConstructorPartial()
-      }
-      .transform
-    result4.asOption ==> Some(nullaryExpected)
-    result4.asEither ==> Right(nullaryExpected)
-    result4.asErrorPathMessageStrings ==> Iterable.empty
+      val result2 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorPartial { () =>
+          nullaryConstructor()
+        }
+        .transform
+      result2.asOption ==> Some(nullaryExpected)
+      result2.asEither ==> Right(nullaryExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
 
-    val uncurriedExpected = Bar(6, (6.28, 6.28))
+      val uncurriedExpected = Bar(6, (6.28, 6.28))
 
-    def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+      def uncurriedConstructor(x: Int, z: (Double, Double)): partial.Result[Bar] =
+        partial.Result.fromValue(Bar(x * 2, (z._1 * 2, z._2 * 2)))
 
-    val result5 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructor(uncurriedConstructor _)
-      .transform
-    result5.asOption ==> Some(uncurriedExpected)
-    result5.asEither ==> Right(uncurriedExpected)
-    result5.asErrorPathMessageStrings ==> Iterable.empty
+      val result3 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorPartial(uncurriedConstructor _)
+        .transform
+      result3.asOption ==> Some(uncurriedExpected)
+      result3.asEither ==> Right(uncurriedExpected)
+      result3.asErrorPathMessageStrings ==> Iterable.empty
 
-    val result6 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructor { (x: Int, z: (Double, Double)) =>
-        uncurriedConstructor(x, z)
-      }
-      .transform
-    result6.asOption ==> Some(uncurriedExpected)
-    result6.asEither ==> Right(uncurriedExpected)
-    result6.asErrorPathMessageStrings ==> Iterable.empty
+      val result4 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorPartial { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform
+      result4.asOption ==> Some(uncurriedExpected)
+      result4.asEither ==> Right(uncurriedExpected)
+      result4.asErrorPathMessageStrings ==> Iterable.empty
 
-    def uncurriedConstructorPartial(x: Int, z: (Double, Double)): partial.Result[Bar] =
-      partial.Result.fromValue(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+      val curriedExpected = Bar(9, (9.42, 9.42))
 
-    val result7 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructorPartial(uncurriedConstructorPartial _)
-      .transform
-    result7.asOption ==> Some(uncurriedExpected)
-    result7.asEither ==> Right(uncurriedExpected)
-    result7.asErrorPathMessageStrings ==> Iterable.empty
+      def curriedConstructor(x: Int)(z: (Double, Double)): partial.Result[Bar] =
+        partial.Result.fromValue(Bar(x * 3, (z._1 * 3, z._2 * 3)))
 
-    val result8 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructorPartial { (x: Int, z: (Double, Double)) =>
-        uncurriedConstructorPartial(x, z)
-      }
-      .transform
-    result8.asOption ==> Some(uncurriedExpected)
-    result8.asEither ==> Right(uncurriedExpected)
-    result8.asErrorPathMessageStrings ==> Iterable.empty
+      val result5 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorPartial(curriedConstructor _)
+        .transform
+      result5.asOption ==> Some(curriedExpected)
+      result5.asEither ==> Right(curriedExpected)
+      result5.asErrorPathMessageStrings ==> Iterable.empty
 
-    val curriedExpected = Bar(9, (9.42, 9.42))
+      val result6 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorPartial { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform
+      result6.asOption ==> Some(curriedExpected)
+      result6.asEither ==> Right(curriedExpected)
+      result6.asErrorPathMessageStrings ==> Iterable.empty
 
-    def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+      val typeParametricExpected = BarParams(3, (3.14, 12.56))
 
-    val result9 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructor(curriedConstructor _)
-      .transform
-    result9.asOption ==> Some(curriedExpected)
-    result9.asEither ==> Right(curriedExpected)
-    result9.asErrorPathMessageStrings ==> Iterable.empty
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): partial.Result[BarParams[A, B]] =
+        partial.Result.fromValue(BarParams(x, (z._1, z._2 * 4)))
 
-    val result10 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructor { (x: Int) => (z: (Double, Double)) =>
-        curriedConstructor(x)(z)
-      }
-      .transform
-    result10.asOption ==> Some(curriedExpected)
-    result10.asEither ==> Right(curriedExpected)
-    result10.asErrorPathMessageStrings ==> Iterable.empty
+      val result7 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[BarParams[Int, Double]]
+        .withConstructorPartial(typeParametricConstructor[Int, Double] _)
+        .transform
+      result7.asOption ==> Some(typeParametricExpected)
+      result7.asEither ==> Right(typeParametricExpected)
+      result7.asErrorPathMessageStrings ==> Iterable.empty
+    }
 
-    def curriedConstructorPartial(x: Int)(z: (Double, Double)): partial.Result[Bar] =
-      partial.Result.fromValue(Bar(x * 3, (z._1 * 3, z._2 * 3)))
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*
 
-    val result11 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructorPartial(curriedConstructorPartial _)
-      .transform
-    result11.asOption ==> Some(curriedExpected)
-    result11.asEither ==> Right(curriedExpected)
-    result11.asErrorPathMessageStrings ==> Iterable.empty
+      implicit val transformer: PartialTransformer[ClassSource, TraitSource] = PartialTransformer
+        .define[ClassSource, TraitSource]
+        .withConstructorPartial { (name: String, id: String) =>
+          // swap
+          partial.Result.fromValue[TraitSource](new TraitSourceImpl(name = id, id = name))
+        }
+        // another swap
+        .withFieldRenamed(_.id, _.name)
+        .withFieldRenamed(_.name, _.id)
+        .buildTransformer
 
-    val result12 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[Bar]
-      .withConstructorPartial { (x: Int) => (z: (Double, Double)) =>
-        curriedConstructorPartial(x)(z)
-      }
-      .transform
-    result12.asOption ==> Some(curriedExpected)
-    result12.asEither ==> Right(curriedExpected)
-    result12.asErrorPathMessageStrings ==> Iterable.empty
-
-    val typeParametricExpected = BarParams(3, (3.14, 12.56))
-
-    def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
-
-    val result13 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[BarParams[Int, Double]]
-      .withConstructor(typeParametricConstructor[Int, Double] _)
-      .transform
-    result13.asOption ==> Some(typeParametricExpected)
-    result13.asEither ==> Right(typeParametricExpected)
-    result13.asErrorPathMessageStrings ==> Iterable.empty
-
-    def typeParametricConstructorPartial[A, B](x: A, z: (B, Double)): partial.Result[BarParams[A, B]] =
-      partial.Result.fromValue(BarParams(x, (z._1, z._2 * 4)))
-
-    val result14 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[BarParams[Int, Double]]
-      .withConstructorPartial(typeParametricConstructorPartial[Int, Double] _)
-      .transform
-    result14.asOption ==> Some(typeParametricExpected)
-    result14.asEither ==> Right(typeParametricExpected)
-    result14.asErrorPathMessageStrings ==> Iterable.empty
-
-    def typeParametricConstructorEither[A, B](x: A, z: (B, Double)): Either[String, BarParams[A, B]] =
-      Right(BarParams(x, (z._1, z._2 * 4)))
-
-    val result15 = Foo(3, "pi", (3.14, 3.14))
-      .intoPartial[BarParams[Int, Double]]
-      .withConstructorEither(typeParametricConstructorEither[Int, Double] _)
-      .transform
-    result15.asOption ==> Some(typeParametricExpected)
-    result15.asEither ==> Right(typeParametricExpected)
-    result15.asErrorPathMessageStrings ==> Iterable.empty
+      val result = (new ClassSource("id", "name")).transformIntoPartial[TraitSource].asOption.get
+      result.id ==> "id"
+      result.name ==> "name"
+    }
   }
 
-  test("""allow defining transformers with overrides""") {
-    import products.NonCaseDomain.*
+  group("setting .withConstructorPartialTo(_.field)(fn)") {
 
-    implicit val transformer: PartialTransformer[ClassSource, TraitSource] = PartialTransformer
-      .define[ClassSource, TraitSource]
-      .withConstructorPartial { (name: String, id: String) =>
-        // swap
-        partial.Result.fromValue[TraitSource](new TraitSourceImpl(name = id, id = name))
-      }
-      // another swap
-      .withFieldRenamed(_.id, _.name)
-      .withFieldRenamed(_.name, _.id)
-      .buildTransformer
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}, nestedpath.*
 
-    val result = (new ClassSource("id", "name")).transformIntoPartial[TraitSource].asOption.get
-    result.id ==> "id"
-    result.name ==> "name"
+      compileErrors(
+        """NestedProduct(Foo(3, "pi", (3.14, 3.14))).intoPartial[NestedProduct[Bar]].withConstructorPartialTo(_.value)(partial.Result.fromValue(Bar(4, (5.0, 5.0)))).transform"""
+      ).check(
+        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+        ", got io.scalaland.chimney.partial.Result[io.scalaland.chimney.fixtures.products.Bar]"
+      )
+    }
+
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}, nestedpath.*
+
+      val nullaryExpected = NestedProduct(Bar(0, (0.0, 0.0)))
+
+      def nullaryConstructor(): partial.Result[Bar] = partial.Result.fromValue(Bar(0, (0.0, 0.0)))
+
+      val result = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value)(nullaryConstructor _)
+        .transform
+      result.asOption ==> Some(nullaryExpected)
+      result.asEither ==> Right(nullaryExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value) { () =>
+          nullaryConstructor()
+        }
+        .transform
+      result2.asOption ==> Some(nullaryExpected)
+      result2.asEither ==> Right(nullaryExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+
+      val uncurriedExpected = NestedProduct(Bar(6, (6.28, 6.28)))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): partial.Result[Bar] =
+        partial.Result.fromValue(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+      val result3 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value)(uncurriedConstructor _)
+        .transform
+      result3.asOption ==> Some(uncurriedExpected)
+      result3.asEither ==> Right(uncurriedExpected)
+      result3.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result4 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value) { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform
+      result4.asOption ==> Some(uncurriedExpected)
+      result4.asEither ==> Right(uncurriedExpected)
+      result4.asErrorPathMessageStrings ==> Iterable.empty
+
+      val curriedExpected = NestedProduct(Bar(9, (9.42, 9.42)))
+
+      def curriedConstructor(x: Int)(z: (Double, Double)): partial.Result[Bar] =
+        partial.Result.fromValue(Bar(x * 3, (z._1 * 3, z._2 * 3)))
+
+      val result5 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value)(curriedConstructor _)
+        .transform
+      result5.asOption ==> Some(curriedExpected)
+      result5.asEither ==> Right(curriedExpected)
+      result5.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result6 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value) { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform
+      result6.asOption ==> Some(curriedExpected)
+      result6.asEither ==> Right(curriedExpected)
+      result6.asErrorPathMessageStrings ==> Iterable.empty
+
+      val typeParametricExpected = NestedProduct(BarParams(3, (3.14, 12.56)))
+
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): partial.Result[BarParams[A, B]] =
+        partial.Result.fromValue(BarParams(x, (z._1, z._2 * 4)))
+
+      val result7 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[BarParams[Int, Double]]]
+        .withConstructorPartialTo(_.value)(typeParametricConstructor[Int, Double] _)
+        .transform
+      result7.asOption ==> Some(typeParametricExpected)
+      result7.asEither ==> Right(typeParametricExpected)
+      result7.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*, nestedpath.*
+
+      implicit val transformer: PartialTransformer[NestedProduct[ClassSource], NestedProduct[TraitSource]] =
+        PartialTransformer
+          .define[NestedProduct[ClassSource], NestedProduct[TraitSource]]
+          .withConstructorPartialTo(_.value) { (name: String, id: String) =>
+            // swap
+            partial.Result.fromValue[TraitSource](new TraitSourceImpl(name = id, id = name))
+          }
+          // another swap
+          .withFieldRenamed(_.value.id, _.value.name)
+          .withFieldRenamed(_.value.name, _.value.id)
+          .buildTransformer
+
+      val result =
+        NestedProduct(new ClassSource("id", "name")).transformIntoPartial[NestedProduct[TraitSource]].asOption.get
+      result.value.id ==> "id"
+      result.value.name ==> "name"
+    }
+  }
+
+  group("setting .withConstructorEither(fn)") {
+
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}
+
+      compileErrors(
+        """Foo(3, "pi", (3.14, 3.14)).intoPartial[Bar].withConstructorEither(Right(Bar(4, (5.0, 5.0)))).transform"""
+      ).check(
+        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of " // difference between Scala 2 and 3
+      )
+    }
+
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}
+
+      val nullaryExpected = Bar(0, (0.0, 0.0))
+
+      def nullaryConstructor(): Either[String, Bar] = Right(Bar(0, (0.0, 0.0)))
+
+      val result = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorEither(nullaryConstructor _)
+        .transform
+      result.asOption ==> Some(nullaryExpected)
+      result.asEither ==> Right(nullaryExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorEither { () =>
+          nullaryConstructor()
+        }
+        .transform
+      result2.asOption ==> Some(nullaryExpected)
+      result2.asEither ==> Right(nullaryExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+
+      val uncurriedExpected = Bar(6, (6.28, 6.28))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Either[String, Bar] =
+        Right(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+      val result3 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorEither(uncurriedConstructor _)
+        .transform
+      result3.asOption ==> Some(uncurriedExpected)
+      result3.asEither ==> Right(uncurriedExpected)
+      result3.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result4 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorEither { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform
+      result4.asOption ==> Some(uncurriedExpected)
+      result4.asEither ==> Right(uncurriedExpected)
+      result4.asErrorPathMessageStrings ==> Iterable.empty
+
+      val curriedExpected = Bar(9, (9.42, 9.42))
+
+      def curriedConstructor(x: Int)(z: (Double, Double)): Either[String, Bar] =
+        Right(Bar(x * 3, (z._1 * 3, z._2 * 3)))
+
+      val result5 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorEither(curriedConstructor _)
+        .transform
+      result5.asOption ==> Some(curriedExpected)
+      result5.asEither ==> Right(curriedExpected)
+      result5.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result6 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[Bar]
+        .withConstructorEither { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform
+      result6.asOption ==> Some(curriedExpected)
+      result6.asEither ==> Right(curriedExpected)
+      result6.asErrorPathMessageStrings ==> Iterable.empty
+
+      val typeParametricExpected = BarParams(3, (3.14, 12.56))
+
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): Either[String, BarParams[A, B]] =
+        Right(BarParams(x, (z._1, z._2 * 4)))
+
+      val result7 = Foo(3, "pi", (3.14, 3.14))
+        .intoPartial[BarParams[Int, Double]]
+        .withConstructorEither(typeParametricConstructor[Int, Double] _)
+        .transform
+      result7.asOption ==> Some(typeParametricExpected)
+      result7.asEither ==> Right(typeParametricExpected)
+      result7.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*
+
+      implicit val transformer: PartialTransformer[ClassSource, TraitSource] = PartialTransformer
+        .define[ClassSource, TraitSource]
+        .withConstructorEither { (name: String, id: String) =>
+          // swap
+          Right[String, TraitSource](new TraitSourceImpl(name = id, id = name)): Either[String, TraitSource]
+        }
+        // another swap
+        .withFieldRenamed(_.id, _.name)
+        .withFieldRenamed(_.name, _.id)
+        .buildTransformer
+
+      val result = (new ClassSource("id", "name")).transformIntoPartial[TraitSource].asOption.get
+      result.id ==> "id"
+      result.name ==> "name"
+    }
+  }
+
+  group("setting .withConstructorEitherTo(_.field)(fn)") {
+
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}, nestedpath.*
+
+      compileErrors(
+        """NestedProduct(Foo(3, "pi", (3.14, 3.14))).intoPartial[NestedProduct[Bar]].withConstructorEitherTo(_.value)(Right(Bar(4, (5.0, 5.0)))).transform"""
+      ).check(
+        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of " // difference between Scala 2 and 3
+      )
+    }
+
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}, nestedpath.*
+
+      val nullaryExpected = NestedProduct(Bar(0, (0.0, 0.0)))
+
+      def nullaryConstructor(): Either[String, Bar] = Right(Bar(0, (0.0, 0.0)))
+
+      val result = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value)(nullaryConstructor _)
+        .transform
+      result.asOption ==> Some(nullaryExpected)
+      result.asEither ==> Right(nullaryExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value) { () =>
+          nullaryConstructor()
+        }
+        .transform
+      result2.asOption ==> Some(nullaryExpected)
+      result2.asEither ==> Right(nullaryExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+
+      val uncurriedExpected = NestedProduct(Bar(6, (6.28, 6.28)))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Either[String, Bar] =
+        Right(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+      val result3 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value)(uncurriedConstructor _)
+        .transform
+      result3.asOption ==> Some(uncurriedExpected)
+      result3.asEither ==> Right(uncurriedExpected)
+      result3.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result4 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value) { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform
+      result4.asOption ==> Some(uncurriedExpected)
+      result4.asEither ==> Right(uncurriedExpected)
+      result4.asErrorPathMessageStrings ==> Iterable.empty
+
+      val curriedExpected = NestedProduct(Bar(9, (9.42, 9.42)))
+
+      def curriedConstructor(x: Int)(z: (Double, Double)): Either[String, Bar] =
+        Right(Bar(x * 3, (z._1 * 3, z._2 * 3)))
+
+      val result5 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value)(curriedConstructor _)
+        .transform
+      result5.asOption ==> Some(curriedExpected)
+      result5.asEither ==> Right(curriedExpected)
+      result5.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result6 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value) { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform
+      result6.asOption ==> Some(curriedExpected)
+      result6.asEither ==> Right(curriedExpected)
+      result6.asErrorPathMessageStrings ==> Iterable.empty
+
+      val typeParametricExpected = NestedProduct(BarParams(3, (3.14, 12.56)))
+
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): Either[String, BarParams[A, B]] =
+        Right(BarParams(x, (z._1, z._2 * 4)))
+
+      val result7 = NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .intoPartial[NestedProduct[BarParams[Int, Double]]]
+        .withConstructorEitherTo(_.value)(typeParametricConstructor[Int, Double] _)
+        .transform
+      result7.asOption ==> Some(typeParametricExpected)
+      result7.asEither ==> Right(typeParametricExpected)
+      result7.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*, nestedpath.*
+
+      implicit val transformer: PartialTransformer[NestedProduct[ClassSource], NestedProduct[TraitSource]] =
+        PartialTransformer
+          .define[NestedProduct[ClassSource], NestedProduct[TraitSource]]
+          .withConstructorEitherTo(_.value) { (name: String, id: String) =>
+            // swap
+            Right[String, TraitSource](new TraitSourceImpl(name = id, id = name)): Either[String, TraitSource]
+          }
+          // another swap
+          .withFieldRenamed(_.value.id, _.value.name)
+          .withFieldRenamed(_.value.name, _.value.id)
+          .buildTransformer
+
+      val result =
+        NestedProduct(new ClassSource("id", "name")).transformIntoPartial[NestedProduct[TraitSource]].asOption.get
+      result.value.id ==> "id"
+      result.value.name ==> "name"
+    }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -5,81 +5,167 @@ import io.scalaland.chimney.fixtures.*
 
 class TotalTransformerCustomConstructorSpec extends ChimneySpec {
 
-  test("""not allow transformation when passed value is not a function/method""") {
-    import products.{Foo, Bar}
+  group("setting .withConstructor(fn)") {
 
-    compileErrors("""Foo(3, "pi", (3.14, 3.14)).into[Bar].withConstructor(Bar(4, (5.0, 5.0))).transform""").check(
-      "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
-      ", got io.scalaland.chimney.fixtures.products.Bar"
-    )
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}
+
+      compileErrors("""Foo(3, "pi", (3.14, 3.14)).into[Bar].withConstructor(Bar(4, (5.0, 5.0))).transform""").check(
+        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+        ", got io.scalaland.chimney.fixtures.products.Bar"
+      )
+    }
+
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}
+
+      def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
+
+      Foo(3, "pi", (3.14, 3.14))
+        .into[Bar]
+        .withConstructor(nullaryConstructor _)
+        .transform ==> Bar(0, (0.0, 0.0))
+      Foo(3, "pi", (3.14, 3.14))
+        .into[Bar]
+        .withConstructor { () =>
+          nullaryConstructor()
+        }
+        .transform ==> Bar(0, (0.0, 0.0))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+      Foo(3, "pi", (3.14, 3.14))
+        .into[Bar]
+        .withConstructor(uncurriedConstructor _)
+        .transform ==> Bar(6, (6.28, 6.28))
+      Foo(3, "pi", (3.14, 3.14))
+        .into[Bar]
+        .withConstructor { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform ==> Bar(6, (6.28, 6.28))
+
+      def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+
+      Foo(3, "pi", (3.14, 3.14))
+        .into[Bar]
+        .withConstructor(curriedConstructor _)
+        .transform ==> Bar(9, (9.42, 9.42))
+      Foo(3, "pi", (3.14, 3.14))
+        .into[Bar]
+        .withConstructor { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform ==> Bar(9, (9.42, 9.42))
+
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+
+      Foo(3, "pi", (3.14, 3.14))
+        .into[BarParams[Int, Double]]
+        .withConstructor(typeParametricConstructor[Int, Double] _)
+        .transform ==> BarParams(3, (3.14, 12.56))
+    }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*
+
+      implicit val transformer: Transformer[ClassSource, TraitSource] = Transformer
+        .define[ClassSource, TraitSource]
+        .withConstructor { (name: String, id: String) =>
+          // swap
+          new TraitSourceImpl(name = id, id = name): TraitSource
+        }
+        // another swap
+        .withFieldRenamed(_.id, _.name)
+        .withFieldRenamed(_.name, _.id)
+        .buildTransformer
+
+      val result = (new ClassSource("id", "name")).transformInto[TraitSource]
+      result.id ==> "id"
+      result.name ==> "name"
+    }
   }
 
-  test("""allow transformation from using Eta-expanded method or lambda""") {
-    import products.{Foo, Bar, BarParams}
+  group("setting .withConstructorTo(_.field)(fn)") {
 
-    def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
+    test("""should not allow transformation when passed value is not a function/method""") {
+      import products.{Foo, Bar}, nestedpath.*
 
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor(nullaryConstructor _)
-      .transform ==> Bar(0, (0.0, 0.0))
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor { () =>
-        nullaryConstructor()
-      }
-      .transform ==> Bar(0, (0.0, 0.0))
+      compileErrors(
+        """NestedProduct(Foo(3, "pi", (3.14, 3.14))).into[NestedProduct[Bar]].withConstructorTo(_.value)(Bar(4, (5.0, 5.0))).transform"""
+      ).check(
+        "Expected function of any arity (scala.Function0, scala.Function1, scala.Function2, ...) that returns a value of ", // difference between Scala 2 and 3
+        ", got io.scalaland.chimney.fixtures.products.Bar"
+      )
+    }
 
-    def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+    test("""should allow transformation from using Eta-expanded method or lambda""") {
+      import products.{Foo, Bar, BarParams}, nestedpath.*
 
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor(uncurriedConstructor _)
-      .transform ==> Bar(6, (6.28, 6.28))
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor { (x: Int, z: (Double, Double)) =>
-        uncurriedConstructor(x, z)
-      }
-      .transform ==> Bar(6, (6.28, 6.28))
+      def nullaryConstructor(): Bar = Bar(0, (0.0, 0.0))
 
-    def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
+      NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .into[NestedProduct[Bar]]
+        .withConstructorTo(_.value)(nullaryConstructor _)
+        .transform ==> NestedProduct(Bar(0, (0.0, 0.0)))
+      NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .into[NestedProduct[Bar]]
+        .withConstructorTo(_.value) { () =>
+          nullaryConstructor()
+        }
+        .transform ==> NestedProduct(Bar(0, (0.0, 0.0)))
 
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor(curriedConstructor _)
-      .transform ==> Bar(9, (9.42, 9.42))
-    Foo(3, "pi", (3.14, 3.14))
-      .into[Bar]
-      .withConstructor { (x: Int) => (z: (Double, Double)) =>
-        curriedConstructor(x)(z)
-      }
-      .transform ==> Bar(9, (9.42, 9.42))
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
 
-    def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
+      NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .into[NestedProduct[Bar]]
+        .withConstructorTo(_.value)(uncurriedConstructor _)
+        .transform ==> NestedProduct(Bar(6, (6.28, 6.28)))
+      NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .into[NestedProduct[Bar]]
+        .withConstructorTo(_.value) { (x: Int, z: (Double, Double)) =>
+          uncurriedConstructor(x, z)
+        }
+        .transform ==> NestedProduct(Bar(6, (6.28, 6.28)))
 
-    Foo(3, "pi", (3.14, 3.14))
-      .into[BarParams[Int, Double]]
-      .withConstructor(typeParametricConstructor[Int, Double] _)
-      .transform ==> BarParams(3, (3.14, 12.56))
-  }
+      def curriedConstructor(x: Int)(z: (Double, Double)): Bar = Bar(x * 3, (z._1 * 3, z._2 * 3))
 
-  test("""allow defining transformers with overrides""") {
-    import products.NonCaseDomain.*
+      NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .into[NestedProduct[Bar]]
+        .withConstructorTo(_.value)(curriedConstructor _)
+        .transform ==> NestedProduct(Bar(9, (9.42, 9.42)))
+      NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .into[NestedProduct[Bar]]
+        .withConstructorTo(_.value) { (x: Int) => (z: (Double, Double)) =>
+          curriedConstructor(x)(z)
+        }
+        .transform ==> NestedProduct(Bar(9, (9.42, 9.42)))
 
-    implicit val transformer: Transformer[ClassSource, TraitSource] = Transformer
-      .define[ClassSource, TraitSource]
-      .withConstructor { (name: String, id: String) =>
-        // swap
-        new TraitSourceImpl(name = id, id = name): TraitSource
-      }
-      // another swap
-      .withFieldRenamed(_.id, _.name)
-      .withFieldRenamed(_.name, _.id)
-      .buildTransformer
+      def typeParametricConstructor[A, B](x: A, z: (B, Double)): BarParams[A, B] = BarParams(x, (z._1, z._2 * 4))
 
-    val result = (new ClassSource("id", "name")).transformInto[TraitSource]
-    result.id ==> "id"
-    result.name ==> "name"
+      NestedProduct(Foo(3, "pi", (3.14, 3.14)))
+        .into[NestedProduct[BarParams[Int, Double]]]
+        .withConstructorTo(_.value)(typeParametricConstructor[Int, Double] _)
+        .transform ==> NestedProduct(BarParams(3, (3.14, 12.56)))
+    }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.NonCaseDomain.*, nestedpath.*
+
+      implicit val transformer: Transformer[NestedProduct[ClassSource], NestedProduct[TraitSource]] = Transformer
+        .define[NestedProduct[ClassSource], NestedProduct[TraitSource]]
+        .withConstructorTo(_.value) { (name: String, id: String) =>
+          // swap
+          new TraitSourceImpl(name = id, id = name): TraitSource
+        }
+        // another swap
+        .withFieldRenamed(_.value.id, _.value.name)
+        .withFieldRenamed(_.value.name, _.value.id)
+        .buildTransformer
+
+      val result = NestedProduct(new ClassSource("id", "name")).transformInto[NestedProduct[TraitSource]]
+      result.value.id ==> "id"
+      result.value.name ==> "name"
+    }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -348,7 +348,7 @@ class TotalTransformerProductSpec extends ChimneySpec {
 
       import trip.*
 
-      Person("John", 10, 140).into[User].withFieldComputed(_.age, _.age * 2).transform ==> User("John", 20, 140)
+      Person("John", 10, 140).into[User].withFieldComputedFrom(_.age)(_.age, _ * 2).transform ==> User("John", 20, 140)
 
       NestedProduct(Person("John", 10, 140))
         .into[NestedValueClass[User]]

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -106,7 +106,7 @@ class ChimneyExtendedRunner(runner: Runner)(
   *
   * during development:
   * {{{
-  * # sbt publish-local-for-testsing
+  * # sbt publish-local-for-tests
   * # fix the version to what sbt generated, fix tmp directory to something to be able to preview generated files
   * scala-cli run scripts/test-snippets.scala -- --extra "chimney-version=1.x.y-n-g1234567-SNAPSHOT" --test-only "supported-transformations.md*" "$PWD/docs/docs" "/var/folders/m_/sm90t09d5591cgz5h242bkm80000gn/T/docs-snippets13141962741435068727"
   * }}}


### PR DESCRIPTION
- [x] withFieldComputedFrom
  - [x] DSL
  - [x] passing tests
  - [x] scaladoc
  - [x] mkdocs
- [x] withFieldComputedPartialFrom
  - [x] DSL
  - [x] passing tests
  - [x] scaladoc
  - [x] mkdocs
- [x] withConstructorTo
  - [x] DSL
  - [x] passing tests
  - [x] scaladoc
  - [x] mkdocs
- [x] withConstructorPartialTo
  - [x] DSL
  - [x] passing tests
  - [x] scaladoc
  - [x] mkdocs
- [x] withConstructorEitherTo
  - [x] DSL
  - [x] passing tests
  - [x] scaladoc
  - [x] mkdocs
- [x] refactor config internals to limit amount of used types (merge Computed/CaseComputed/ComputedFrom and ComputedPartial/CaseComptuedPartial/ComputedPartialFrom)
- [x] add tests and fix currying for withContructorEither