### PR TITLE
Make Path DSL behavior more consitent and intuitive

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -90,47 +90,62 @@ private[chimney] trait DslMacroUtils {
                 }
               applyTypes(init.Underlying, name.Underlying)
             }
-          // matches `.matchingSome`
+          // matches `.matchingSome` == `.matching[Some[A]].value`
           case Apply(TypeApply(Select(Apply(_, List(t2)), TermName("matchingSome")), List(_, tpeSomeA)), _) =>
             unpackSelects(t2).map { init =>
               val someA = ExistentialType(c.WeakTypeTag(tpeSomeA.tpe))
+              val value = ExistentialString(TermName("value")) // hardcoded
 
-              def applyTypes[Init <: runtime.Path: c.WeakTypeTag, SomeA: c.WeakTypeTag] =
+              def applyTypes[
+                  Init <: runtime.Path: c.WeakTypeTag,
+                  SomeA: c.WeakTypeTag,
+                  Value <: String: c.WeakTypeTag
+              ] =
                 new ExistentialPath {
-                  type Underlying = runtime.Path.Matching[Init, SomeA]
-                  val Underlying: WeakTypeTag[runtime.Path.Matching[Init, SomeA]] =
-                    weakTypeTag[runtime.Path.Matching[Init, SomeA]]
+                  type Underlying = runtime.Path.Select[runtime.Path.Matching[Init, SomeA], Value]
+                  val Underlying: WeakTypeTag[runtime.Path.Select[runtime.Path.Matching[Init, SomeA], Value]] =
+                    weakTypeTag[runtime.Path.Select[runtime.Path.Matching[Init, SomeA], Value]]
                 }
 
-              applyTypes(init.Underlying, someA.Underlying)
+              applyTypes(init.Underlying, someA.Underlying, value.Underlying)
             }
-          // matches `.matchingLeft`
+          // matches `.matchingLeft` == `.matching[Left[L, R]].value`
           case Apply(TypeApply(Select(Apply(_, List(t2)), TermName("matchingLeft")), List(_, _, tpeLeftL, _)), _) =>
             unpackSelects(t2).map { init =>
               val leftL = ExistentialType(c.WeakTypeTag(tpeLeftL.tpe))
+              val value = ExistentialString(TermName("value")) // hardcoded
 
-              def applyTypes[Init <: runtime.Path: c.WeakTypeTag, LeftL: c.WeakTypeTag] =
+              def applyTypes[
+                  Init <: runtime.Path: c.WeakTypeTag,
+                  LeftL: c.WeakTypeTag,
+                  Value <: String: c.WeakTypeTag
+              ] =
                 new ExistentialPath {
-                  type Underlying = runtime.Path.Matching[Init, LeftL]
-                  val Underlying: WeakTypeTag[runtime.Path.Matching[Init, LeftL]] =
-                    weakTypeTag[runtime.Path.Matching[Init, LeftL]]
+                  type Underlying = runtime.Path.Select[runtime.Path.Matching[Init, LeftL], Value]
+                  val Underlying: WeakTypeTag[runtime.Path.Select[runtime.Path.Matching[Init, LeftL], Value]] =
+                    weakTypeTag[runtime.Path.Select[runtime.Path.Matching[Init, LeftL], Value]]
                 }
 
-              applyTypes(init.Underlying, leftL.Underlying)
+              applyTypes(init.Underlying, leftL.Underlying, value.Underlying)
             }
-          // matches `.matchingRight`
+          // matches `.matchingRight` == `.matching[Right[L, R]].value`
           case Apply(TypeApply(Select(Apply(_, List(t2)), TermName("matchingRight")), List(_, _, _, tpeRightR)), _) =>
             unpackSelects(t2).map { init =>
               val rightR = ExistentialType(c.WeakTypeTag(tpeRightR.tpe))
+              val value = ExistentialString(TermName("value")) // hardcoded
 
-              def applyTypes[Init <: runtime.Path: c.WeakTypeTag, RightR: c.WeakTypeTag] =
+              def applyTypes[
+                  Init <: runtime.Path: c.WeakTypeTag,
+                  RightR: c.WeakTypeTag,
+                  Value <: String: c.WeakTypeTag
+              ] =
                 new ExistentialPath {
-                  type Underlying = runtime.Path.Matching[Init, RightR]
-                  val Underlying: WeakTypeTag[runtime.Path.Matching[Init, RightR]] =
-                    weakTypeTag[runtime.Path.Matching[Init, RightR]]
+                  type Underlying = runtime.Path.Select[runtime.Path.Matching[Init, RightR], Value]
+                  val Underlying: WeakTypeTag[runtime.Path.Select[runtime.Path.Matching[Init, RightR], Value]] =
+                    weakTypeTag[runtime.Path.Select[runtime.Path.Matching[Init, RightR], Value]]
                 }
 
-              applyTypes(init.Underlying, rightR.Underlying)
+              applyTypes(init.Underlying, rightR.Underlying, value.Underlying)
             }
           // matches `.everyItem`
           case Apply(Select(Apply(_, List(t2)), TermName("everyItem")), _) =>

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/utils/DslMacroUtils.scala
@@ -118,40 +118,46 @@ private[chimney] class DslMacroUtils()(using quotes: Quotes) {
                   Type.of[runtime.Path.Matching[Init, Subtype]]
               }
             }
-          // matches `.matchingSome`
+          // matches `.matchingSome` == `.matching[Some[A]].value`
           case Apply(
                 TypeApply(Apply(TypeApply(Ident("matchingSome"), _), List(t2)), _),
                 List(IsOptionOf(_, _, someA))
               ) =>
             unpackSelects(t2).map { init =>
-              import init.Underlying as Init, someA.Underlying as SomeA
+              val name = ExistentialString("value") // hardcoded
+              import init.Underlying as Init, someA.Underlying as SomeA, name.Underlying as Value
               new ExistentialPath {
-                type Underlying = runtime.Path.Matching[Init, SomeA]
-                val Underlying: Type[runtime.Path.Matching[Init, SomeA]] = Type.of[runtime.Path.Matching[Init, SomeA]]
+                type Underlying = runtime.Path.Select[runtime.Path.Matching[Init, SomeA], Value]
+                val Underlying: Type[runtime.Path.Select[runtime.Path.Matching[Init, SomeA], Value]] =
+                  Type.of[runtime.Path.Select[runtime.Path.Matching[Init, SomeA], Value]]
               }
             }
-          // matches `.matchingLeft`
+          // matches `.matchingLeft` == `.matching[Left[L, R]].value`
           case Apply(
                 TypeApply(Apply(TypeApply(Ident("matchingLeft"), _), List(t2)), _),
                 List(IsEitherOf(_, _, _, left, _))
               ) =>
             unpackSelects(t2).map { init =>
-              import init.Underlying as Init, left.Underlying as Left
+              val name = ExistentialString("value") // hardcoded
+              import init.Underlying as Init, left.Underlying as Left, name.Underlying as Value
               new ExistentialPath {
-                type Underlying = runtime.Path.Matching[Init, Left]
-                val Underlying: Type[runtime.Path.Matching[Init, Left]] = Type.of[runtime.Path.Matching[Init, Left]]
+                type Underlying = runtime.Path.Select[runtime.Path.Matching[Init, Left], Value]
+                val Underlying: Type[runtime.Path.Select[runtime.Path.Matching[Init, Left], Value]] =
+                  Type.of[runtime.Path.Select[runtime.Path.Matching[Init, Left], Value]]
               }
             }
-          // matches `.matchingRight`
+          // matches `.matchingRight` == `.matching[Right[L, R]].value`
           case Apply(
                 TypeApply(Apply(TypeApply(Ident("matchingRight"), _), List(t2)), _),
                 List(IsEitherOf(_, _, _, _, right))
               ) =>
             unpackSelects(t2).map { init =>
-              import init.Underlying as Init, right.Underlying as Right
+              val name = ExistentialString("value") // hardcoded
+              import init.Underlying as Init, right.Underlying as Right, name.Underlying as Value
               new ExistentialPath {
-                type Underlying = runtime.Path.Matching[Init, Right]
-                val Underlying: Type[runtime.Path.Matching[Init, Right]] = Type.of[runtime.Path.Matching[Init, Right]]
+                type Underlying = runtime.Path.Select[runtime.Path.Matching[Init, Right], Value]
+                val Underlying: Type[runtime.Path.Select[runtime.Path.Matching[Init, Right], Value]] =
+                  Type.of[runtime.Path.Select[runtime.Path.Matching[Init, Right], Value]]
               }
             }
           // matches `.everyItem`

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -206,18 +206,28 @@ private[compiletime] trait Configurations { this: Derivation =>
     }
 
     object AtItem {
-      def unapply(path: Path): Option[Path] =
-        path.segments.headOption.collect { case Segment.EveryItem => new Path(path.segments.tail) }
+      def unapply(path: Path): Option[Path] = path.segments match {
+        case Segment.EveryItem +: rest     => Some(new Path(rest))
+        case Segment.EveryMapKey +: rest   => Some(new Path(Segment.Select("_1") +: rest))
+        case Segment.EveryMapValue +: rest => Some(new Path(Segment.Select("_2") +: rest))
+        case _                             => None
+      }
     }
 
     object AtMapKey {
-      def unapply(path: Path): Option[Path] =
-        path.segments.headOption.collect { case Segment.EveryMapKey => new Path(path.segments.tail) }
+      def unapply(path: Path): Option[Path] = path.segments match {
+        case Segment.EveryMapKey +: rest                       => Some(new Path(rest))
+        case Segment.EveryItem +: Segment.Select("_1") +: rest => Some(new Path(rest))
+        case _                                                 => None
+      }
     }
 
     object AtMapValue {
-      def unapply(path: Path): Option[Path] =
-        path.segments.headOption.collect { case Segment.EveryMapValue => new Path(path.segments.tail) }
+      def unapply(path: Path): Option[Path] = path.segments match {
+        case Segment.EveryMapValue +: rest                     => Some(new Path(rest))
+        case Segment.EveryItem +: Segment.Select("_2") +: rest => Some(new Path(rest))
+        case _                                                 => None
+      }
     }
 
     sealed private trait Segment extends scala.Product with Serializable

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -405,22 +405,28 @@ private[compiletime] trait Configurations { this: Derivation =>
     )
     def filterCurrentOverridesForSome: Set[TransformerOverride.ForField] = ListSet.from(
       runtimeOverrides.collect {
-        case (TargetPath(Path.AtSubtype(tpe, path)), runtimeFieldOverride: TransformerOverride.ForField)
-            if path == Path.Root && tpe.Underlying <:< Type[Some[Any]] =>
+        case (
+              TargetPath(Path.AtSubtype(tpe, Path.AtField("value", path))),
+              runtimeFieldOverride: TransformerOverride.ForField
+            ) if path == Path.Root && tpe.Underlying <:< Type[Some[Any]] =>
           runtimeFieldOverride
       }
     )
     def filterCurrentOverridesForLeft: Set[TransformerOverride.ForField] = ListSet.from(
       runtimeOverrides.collect {
-        case (TargetPath(Path.AtSubtype(tpe, path)), runtimeFieldOverride: TransformerOverride.ForField)
-            if path == Path.Root && tpe.Underlying <:< Type[Left[Any, Any]] =>
+        case (
+              TargetPath(Path.AtSubtype(tpe, Path.AtField("value", path))),
+              runtimeFieldOverride: TransformerOverride.ForField
+            ) if path == Path.Root && tpe.Underlying <:< Type[Left[Any, Any]] =>
           runtimeFieldOverride
       }
     )
     def filterCurrentOverridesForRight: Set[TransformerOverride.ForField] = ListSet.from(
       runtimeOverrides.collect {
-        case (TargetPath(Path.AtSubtype(tpe, path)), runtimeFieldOverride: TransformerOverride.ForField)
-            if path == Path.Root && tpe.Underlying <:< Type[Right[Any, Any]] =>
+        case (
+              TargetPath(Path.AtSubtype(tpe, Path.AtField("value", path))),
+              runtimeFieldOverride: TransformerOverride.ForField
+            ) if path == Path.Root && tpe.Underlying <:< Type[Right[Any, Any]] =>
           runtimeFieldOverride
       }
     )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformEitherToEitherRuleModule.scala
@@ -31,8 +31,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
       useOverrideIfPresentOr("matchingLeft", ctx.config.filterCurrentOverridesForLeft) {
         deriveRecursiveTransformationExpr[FromL, ToL](
           ctx.src.upcastToExprOf[Left[FromL, FromR]].value,
-          Path(_.matching[Left[FromL, FromR]]),
-          Path(_.matching[Left[ToL, ToR]])
+          Path(_.matching[Left[FromL, FromR]].select("value")),
+          Path(_.matching[Left[ToL, ToR]].select("value"))
         )
       }
         .flatMap { (derivedToL: TransformationExpr[ToL]) =>
@@ -47,8 +47,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
       useOverrideIfPresentOr("matchingRight", ctx.config.filterCurrentOverridesForRight) {
         deriveRecursiveTransformationExpr[FromR, ToR](
           ctx.src.upcastToExprOf[Right[FromL, FromR]].value,
-          Path(_.matching[Right[FromL, FromR]]),
-          Path(_.matching[Right[ToL, ToR]])
+          Path(_.matching[Right[FromL, FromR]].select("value")),
+          Path(_.matching[Right[ToL, ToR]].select("value"))
         )
       }
         .flatMap { (derivedToR: TransformationExpr[ToR]) =>
@@ -66,8 +66,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
           useOverrideIfPresentOr("matchingLeft", ctx.config.filterCurrentOverridesForLeft) {
             deriveRecursiveTransformationExpr[FromL, ToL](
               leftExpr,
-              Path(_.matching[Left[FromL, FromR]]),
-              Path(_.matching[Left[ToL, ToR]])
+              Path(_.matching[Left[FromL, FromR]].select("value")),
+              Path(_.matching[Left[ToL, ToR]].select("value"))
             )
           }
         }
@@ -78,8 +78,8 @@ private[compiletime] trait TransformEitherToEitherRuleModule {
           useOverrideIfPresentOr("matchingRight", ctx.config.filterCurrentOverridesForRight) {
             deriveRecursiveTransformationExpr[FromR, ToR](
               rightExpr,
-              Path(_.matching[Right[FromL, FromR]]),
-              Path(_.matching[Right[ToL, ToR]])
+              Path(_.matching[Right[FromL, FromR]].select("value")),
+              Path(_.matching[Right[ToL, ToR]].select("value"))
             )
           }
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformOptionToOptionRuleModule.scala
@@ -40,8 +40,8 @@ private[compiletime] trait TransformOptionToOptionRuleModule {
           useOverrideIfPresentOr("matchingSome", ctx.config.filterCurrentOverridesForSome) {
             deriveRecursiveTransformationExpr[InnerFrom, InnerTo](
               newFromExpr,
-              Path(_.matching[Some[InnerFrom]]),
-              Path(_.matching[Some[InnerTo]])
+              Path(_.matching[Some[InnerFrom]].select("value")),
+              Path(_.matching[Some[InnerTo]].select("value"))
             )
           }
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformPartialOptionToNonOptionRuleModule.scala
@@ -49,7 +49,7 @@ private[compiletime] trait TransformPartialOptionToNonOptionRuleModule { this: D
               await(
                 deriveRecursiveTransformationExpr[InnerFrom, To](
                   from2Expr,
-                  followFrom = Path(_.matching[Some[InnerFrom]])
+                  followFrom = Path(_.matching[Some[InnerFrom]].select("value"))
                 )
               ).ensurePartial
             }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerLensLikeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerLensLikeSpec.scala
@@ -33,9 +33,19 @@ class PartialTransformerLensLikeSpec extends ChimneySpec {
       .withFieldConst(_.option.matchingSome.value, 20)
       .transform
       .asOption ==> Some(WithOption(Some(Foo(20, "example"))))
+    WithOption(Some(Foo(10, "example")))
+      .intoPartial[WithOption[Foo[Int]]]
+      .withFieldConst(_.option.matching[Some[Foo[Int]]].value.value, 20)
+      .transform
+      .asOption ==> Some(WithOption(Some(Foo(20, "example"))))
     Foo(WithOption(Some(10)), "example")
       .intoPartial[Foo[WithOption[Int]]]
       .withFieldConst(_.value.option.matchingSome, 20)
+      .transform
+      .asOption ==> Some(Foo(WithOption(Some(20)), "example"))
+    Foo(WithOption(Some(10)), "example")
+      .intoPartial[Foo[WithOption[Int]]]
+      .withFieldConst(_.value.option.matching[Some[Int]].value, 20)
       .transform
       .asOption ==> Some(Foo(WithOption(Some(20)), "example"))
   }
@@ -47,10 +57,22 @@ class PartialTransformerLensLikeSpec extends ChimneySpec {
       .withFieldConst(_.either.matchingRight.value, 30)
       .transform
       .asOption ==> Some(WithEither(Left(Foo(20, "example"))))
+    WithEither[Foo[Int], Foo[Int]](Left(Foo(10, "example")))
+      .intoPartial[WithEither[Foo[Int], Foo[Int]]]
+      .withFieldConst(_.either.matching[Left[Foo[Int], Foo[Int]]].value.value, 20)
+      .withFieldConst(_.either.matching[Right[Foo[Int], Foo[Int]]].value.value, 30)
+      .transform
+      .asOption ==> Some(WithEither(Left(Foo(20, "example"))))
     WithEither[Foo[Int], Foo[Int]](Right(Foo(10, "example")))
       .intoPartial[WithEither[Foo[Int], Foo[Int]]]
       .withFieldConst(_.either.matchingLeft.value, 20)
       .withFieldConst(_.either.matchingRight.value, 30)
+      .transform
+      .asOption ==> Some(WithEither(Right(Foo(30, "example"))))
+    WithEither[Foo[Int], Foo[Int]](Right(Foo(10, "example")))
+      .intoPartial[WithEither[Foo[Int], Foo[Int]]]
+      .withFieldConst(_.either.matching[Left[Foo[Int], Foo[Int]]].value.value, 20)
+      .withFieldConst(_.either.matching[Right[Foo[Int], Foo[Int]]].value.value, 30)
       .transform
       .asOption ==> Some(WithEither(Right(Foo(30, "example"))))
     Foo[WithEither[Int, Int]](WithEither(Left(10)), "example")
@@ -59,10 +81,22 @@ class PartialTransformerLensLikeSpec extends ChimneySpec {
       .withFieldConst(_.value.either.matchingRight, 30)
       .transform
       .asOption ==> Some(Foo(WithEither(Left(20)), "example"))
+    Foo[WithEither[Int, Int]](WithEither(Left(10)), "example")
+      .intoPartial[Foo[WithEither[Int, Int]]]
+      .withFieldConst(_.value.either.matching[Left[Int, Int]].value, 20)
+      .withFieldConst(_.value.either.matching[Right[Int, Int]].value, 30)
+      .transform
+      .asOption ==> Some(Foo(WithEither(Left(20)), "example"))
     Foo[WithEither[Int, Int]](WithEither(Right(10)), "example")
       .intoPartial[Foo[WithEither[Int, Int]]]
       .withFieldConst(_.value.either.matchingLeft, 20)
       .withFieldConst(_.value.either.matchingRight, 30)
+      .transform
+      .asOption ==> Some(Foo(WithEither(Right(30)), "example"))
+    Foo[WithEither[Int, Int]](WithEither(Right(10)), "example")
+      .intoPartial[Foo[WithEither[Int, Int]]]
+      .withFieldConst(_.value.either.matching[Left[Int, Int]].value, 20)
+      .withFieldConst(_.value.either.matching[Right[Int, Int]].value, 30)
       .transform
       .asOption ==> Some(Foo(WithEither(Right(30)), "example"))
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
@@ -608,6 +608,12 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
       .withFieldConst(_.everyMapValue.value, "ov2")
       .transform
       .asOption ==> Some(Map(Bar("ov1") -> Bar("ov2")))
+    Iterable(Foo("a") -> Foo("b"))
+      .intoPartial[Map[Bar, Bar]]
+      .withFieldRenamed(_.everyItem._1.value, _.everyMapKey.value)
+      .withFieldRenamed(_.everyItem._2.value, _.everyMapValue.value)
+      .transform
+      .asOption ==> Some(Map(Bar("a") -> Bar("b")))
 
     import fixtures.products.Renames.*
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerStdLibTypesSpec.scala
@@ -199,9 +199,14 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
 
   test("transform into Option-type with an override") {
     "abc".intoPartial[Option[String]].withFieldConst(_.matchingSome, "def").transform.asOption ==> Some(Some("def"))
-    Option("abc").intoPartial[Option[String]].withFieldConst(_.matchingSome, "def").transform.asOption ==> Some(
+    "abc".intoPartial[Option[String]].withFieldConst(_.matching[Some[String]].value, "def").transform.asOption ==> Some(
       Some("def")
     )
+    Option("abc")
+      .intoPartial[Option[String]]
+      .withFieldConst(_.matching[Some[String]].value, "def")
+      .transform
+      .asOption ==> Some(Some("def"))
 
     import fixtures.products.Renames.*
 
@@ -209,6 +214,14 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
       .intoPartial[Option[UserPLStd]]
       .withFieldRenamed(_.matchingSome.name, _.matchingSome.imie)
       .withFieldRenamed(_.matchingSome.age, _.matchingSome.wiek)
+      .transform
+      .asOption
+      .get ==> Option(UserPLStd(1, "Kuba", Some(28)))
+
+    Option(User(1, "Kuba", Some(28)))
+      .intoPartial[Option[UserPLStd]]
+      .withFieldRenamed(_.matching[Some[User]].value.name, _.matching[Some[UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Some[User]].value.age, _.matching[Some[UserPLStd]].value.wiek)
       .transform
       .asOption
       .get ==> Option(UserPLStd(1, "Kuba", Some(28)))
@@ -251,10 +264,22 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
       .withFieldConst(_.matchingRight, "c")
       .transform
       .asOption ==> Some(Left("b"))
+    (Left("a"): Either[String, String])
+      .intoPartial[Either[String, String]]
+      .withFieldConst(_.matching[Left[String, String]].value, "b")
+      .withFieldConst(_.matching[Right[String, String]].value, "c")
+      .transform
+      .asOption ==> Some(Left("b"))
     (Right("a"): Either[String, String])
       .intoPartial[Either[String, String]]
       .withFieldConst(_.matchingLeft, "b")
       .withFieldConst(_.matchingRight, "c")
+      .transform
+      .asOption ==> Some(Right("c"))
+    (Right("a"): Either[String, String])
+      .intoPartial[Either[String, String]]
+      .withFieldConst(_.matching[Left[String, String]].value, "b")
+      .withFieldConst(_.matching[Right[String, String]].value, "c")
       .transform
       .asOption ==> Some(Right("c"))
     Left("a")
@@ -262,9 +287,19 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
       .withFieldConst(_.matchingLeft, "b")
       .transform
       .asOption ==> Some(Left("b"))
+    Left("a")
+      .intoPartial[Either[String, String]]
+      .withFieldConst(_.matching[Left[String, String]].value, "b")
+      .transform
+      .asOption ==> Some(Left("b"))
     Right("a")
       .intoPartial[Either[String, String]]
       .withFieldConst(_.matchingRight, "c")
+      .transform
+      .asOption ==> Some(Right("c"))
+    Right("a")
+      .intoPartial[Either[String, String]]
+      .withFieldConst(_.matching[Right[String, String]].value, "c")
       .transform
       .asOption ==> Some(Right("c"))
 
@@ -279,12 +314,30 @@ class PartialTransformerStdLibTypesSpec extends ChimneySpec {
       .transform
       .asOption
       .get ==> Left(UserPLStd(1, "Kuba", Some(28)))
+    (Left(User(1, "Kuba", Some(28))): Either[User, User])
+      .intoPartial[Either[UserPLStd, UserPLStd]]
+      .withFieldRenamed(_.matching[Left[User, User]].value.name, _.matching[Left[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Left[User, User]].value.age, _.matching[Left[UserPLStd, UserPLStd]].value.wiek)
+      .withFieldRenamed(_.matching[Right[User, User]].value.name, _.matching[Right[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Right[User, User]].value.age, _.matching[Right[UserPLStd, UserPLStd]].value.wiek)
+      .transform
+      .asOption
+      .get ==> Left(UserPLStd(1, "Kuba", Some(28)))
     (Right(User(1, "Kuba", Some(28))): Either[User, User])
       .intoPartial[Either[UserPLStd, UserPLStd]]
       .withFieldRenamed(_.matchingLeft.name, _.matchingLeft.imie)
       .withFieldRenamed(_.matchingLeft.age, _.matchingLeft.wiek)
       .withFieldRenamed(_.matchingRight.name, _.matchingRight.imie)
       .withFieldRenamed(_.matchingRight.age, _.matchingRight.wiek)
+      .transform
+      .asOption
+      .get ==> Right(UserPLStd(1, "Kuba", Some(28)))
+    (Right(User(1, "Kuba", Some(28))): Either[User, User])
+      .intoPartial[Either[UserPLStd, UserPLStd]]
+      .withFieldRenamed(_.matching[Left[User, User]].value.name, _.matching[Left[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Left[User, User]].value.age, _.matching[Left[UserPLStd, UserPLStd]].value.wiek)
+      .withFieldRenamed(_.matching[Right[User, User]].value.name, _.matching[Right[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Right[User, User]].value.age, _.matching[Right[UserPLStd, UserPLStd]].value.wiek)
       .transform
       .asOption
       .get ==> Right(UserPLStd(1, "Kuba", Some(28)))

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerLensLikeSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerLensLikeSpec.scala
@@ -29,9 +29,17 @@ class TotalTransformerLensLikeSpec extends ChimneySpec {
       .into[WithOption[Foo[Int]]]
       .withFieldConst(_.option.matchingSome.value, 20)
       .transform ==> WithOption(Some(Foo(20, "example")))
+    WithOption(Some(Foo(10, "example")))
+      .into[WithOption[Foo[Int]]]
+      .withFieldConst(_.option.matching[Some[Foo[Int]]].value.value, 20)
+      .transform ==> WithOption(Some(Foo(20, "example")))
     Foo(WithOption(Some(10)), "example")
       .into[Foo[WithOption[Int]]]
       .withFieldConst(_.value.option.matchingSome, 20)
+      .transform ==> Foo(WithOption(Some(20)), "example")
+    Foo(WithOption(Some(10)), "example")
+      .into[Foo[WithOption[Int]]]
+      .withFieldConst(_.value.option.matching[Some[Int]].value, 20)
       .transform ==> Foo(WithOption(Some(20)), "example")
   }
 
@@ -41,20 +49,40 @@ class TotalTransformerLensLikeSpec extends ChimneySpec {
       .withFieldConst(_.either.matchingLeft.value, 20)
       .withFieldConst(_.either.matchingRight.value, 30)
       .transform ==> WithEither(Left(Foo(20, "example")))
+    WithEither[Foo[Int], Foo[Int]](Left(Foo(10, "example")))
+      .into[WithEither[Foo[Int], Foo[Int]]]
+      .withFieldConst(_.either.matching[Left[Foo[Int], Foo[Int]]].value.value, 20)
+      .withFieldConst(_.either.matching[Right[Foo[Int], Foo[Int]]].value.value, 30)
+      .transform ==> WithEither(Left(Foo(20, "example")))
     WithEither[Foo[Int], Foo[Int]](Right(Foo(10, "example")))
       .into[WithEither[Foo[Int], Foo[Int]]]
       .withFieldConst(_.either.matchingLeft.value, 20)
       .withFieldConst(_.either.matchingRight.value, 30)
+      .transform ==> WithEither(Right(Foo(30, "example")))
+    WithEither[Foo[Int], Foo[Int]](Right(Foo(10, "example")))
+      .into[WithEither[Foo[Int], Foo[Int]]]
+      .withFieldConst(_.either.matching[Left[Foo[Int], Foo[Int]]].value.value, 20)
+      .withFieldConst(_.either.matching[Right[Foo[Int], Foo[Int]]].value.value, 30)
       .transform ==> WithEither(Right(Foo(30, "example")))
     Foo[WithEither[Int, Int]](WithEither(Left(10)), "example")
       .into[Foo[WithEither[Int, Int]]]
       .withFieldConst(_.value.either.matchingLeft, 20)
       .withFieldConst(_.value.either.matchingRight, 30)
       .transform ==> Foo(WithEither(Left(20)), "example")
+    Foo[WithEither[Int, Int]](WithEither(Left(10)), "example")
+      .into[Foo[WithEither[Int, Int]]]
+      .withFieldConst(_.value.either.matching[Left[Int, Int]].value, 20)
+      .withFieldConst(_.value.either.matching[Right[Int, Int]].value, 30)
+      .transform ==> Foo(WithEither(Left(20)), "example")
     Foo[WithEither[Int, Int]](WithEither(Right(10)), "example")
       .into[Foo[WithEither[Int, Int]]]
       .withFieldConst(_.value.either.matchingLeft, 20)
       .withFieldConst(_.value.either.matchingRight, 30)
+      .transform ==> Foo(WithEither(Right(30)), "example")
+    Foo[WithEither[Int, Int]](WithEither(Right(10)), "example")
+      .into[Foo[WithEither[Int, Int]]]
+      .withFieldConst(_.value.either.matching[Left[Int, Int]].value, 20)
+      .withFieldConst(_.value.either.matching[Right[Int, Int]].value, 30)
       .transform ==> Foo(WithEither(Right(30)), "example")
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
@@ -259,6 +259,11 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
       .withFieldConst(_.everyMapKey.value, "ov1")
       .withFieldConst(_.everyMapValue.value, "ov2")
       .transform ==> Map(Bar("ov1") -> Bar("ov2"))
+    Iterable(Foo("a") -> Foo("b"))
+      .into[Map[Bar, Bar]]
+      .withFieldRenamed(_.everyItem._1.value, _.everyMapKey.value)
+      .withFieldRenamed(_.everyItem._2.value, _.everyMapValue.value)
+      .transform ==> Map(Bar("a") -> Bar("b"))
 
     import fixtures.products.Renames.*
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerStdLibTypesSpec.scala
@@ -64,7 +64,11 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
 
   test("transform into Option-type with an override") {
     Foo("abc").into[Option[Foo]].withFieldConst(_.matchingSome.value, "def").transform ==> Some(Foo("def"))
+    Foo("abc").into[Option[Foo]].withFieldConst(_.matching[Some[Foo]].value.value, "def").transform ==> Some(Foo("def"))
     Option(Foo("abc")).into[Option[Foo]].withFieldConst(_.matchingSome.value, "def").transform ==> Some(Foo("def"))
+    Option(Foo("abc")).into[Option[Foo]].withFieldConst(_.matching[Some[Foo]].value.value, "def").transform ==> Some(
+      Foo("def")
+    )
 
     import fixtures.products.Renames.*
 
@@ -72,6 +76,11 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
       .into[Option[UserPLStd]]
       .withFieldRenamed(_.matchingSome.name, _.matchingSome.imie)
       .withFieldRenamed(_.matchingSome.age, _.matchingSome.wiek)
+      .transform ==> Option(UserPLStd(1, "Kuba", Some(28)))
+    Option(User(1, "Kuba", Some(28)))
+      .into[Option[UserPLStd]]
+      .withFieldRenamed(_.matching[Some[User]].value.name, _.matching[Some[UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Some[User]].value.age, _.matching[Some[UserPLStd]].value.wiek)
       .transform ==> Option(UserPLStd(1, "Kuba", Some(28)))
   }
 
@@ -92,13 +101,31 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
       .withFieldConst(_.matchingLeft.value, "b")
       .withFieldConst(_.matchingRight.value, "c")
       .transform ==> Left(Bar("b"))
+    (Left(Foo("a")): Either[Foo, Foo])
+      .into[Either[Bar, Bar]]
+      .withFieldConst(_.matching[Left[Bar, Bar]].value.value, "b")
+      .withFieldConst(_.matching[Right[Bar, Bar]].value.value, "c")
+      .transform ==> Left(Bar("b"))
     (Right(Foo("a")): Either[Foo, Foo])
       .into[Either[Bar, Bar]]
       .withFieldConst(_.matchingLeft.value, "b")
       .withFieldConst(_.matchingRight.value, "c")
       .transform ==> Right(Bar("c"))
+    (Right(Foo("a")): Either[Foo, Foo])
+      .into[Either[Bar, Bar]]
+      .withFieldConst(_.matching[Left[Bar, Bar]].value.value, "b")
+      .withFieldConst(_.matching[Right[Bar, Bar]].value.value, "c")
+      .transform ==> Right(Bar("c"))
     Left(Foo("a")).into[Either[Bar, Bar]].withFieldConst(_.matchingLeft.value, "b").transform ==> Left(Bar("b"))
+    Left(Foo("a"))
+      .into[Either[Bar, Bar]]
+      .withFieldConst(_.matching[Left[Bar, Bar]].value.value, "b")
+      .transform ==> Left(Bar("b"))
     Right(Foo("a")).into[Either[Bar, Bar]].withFieldConst(_.matchingRight.value, "c").transform ==> Right(Bar("c"))
+    Right(Foo("a"))
+      .into[Either[Bar, Bar]]
+      .withFieldConst(_.matching[Right[Bar, Bar]].value.value, "c")
+      .transform ==> Right(Bar("c"))
 
     import fixtures.products.Renames.*
 
@@ -109,12 +136,26 @@ class TotalTransformerStdLibTypesSpec extends ChimneySpec {
       .withFieldRenamed(_.matchingRight.name, _.matchingRight.imie)
       .withFieldRenamed(_.matchingRight.age, _.matchingRight.wiek)
       .transform ==> Left(UserPLStd(1, "Kuba", Some(28)))
+    (Left(User(1, "Kuba", Some(28))): Either[User, User])
+      .into[Either[UserPLStd, UserPLStd]]
+      .withFieldRenamed(_.matching[Left[User, User]].value.name, _.matching[Left[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Left[User, User]].value.age, _.matching[Left[UserPLStd, UserPLStd]].value.wiek)
+      .withFieldRenamed(_.matching[Right[User, User]].value.name, _.matching[Right[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Right[User, User]].value.age, _.matching[Right[UserPLStd, UserPLStd]].value.wiek)
+      .transform ==> Left(UserPLStd(1, "Kuba", Some(28)))
     (Right(User(1, "Kuba", Some(28))): Either[User, User])
       .into[Either[UserPLStd, UserPLStd]]
       .withFieldRenamed(_.matchingLeft.name, _.matchingLeft.imie)
       .withFieldRenamed(_.matchingLeft.age, _.matchingLeft.wiek)
       .withFieldRenamed(_.matchingRight.name, _.matchingRight.imie)
       .withFieldRenamed(_.matchingRight.age, _.matchingRight.wiek)
+      .transform ==> Right(UserPLStd(1, "Kuba", Some(28)))
+    (Right(User(1, "Kuba", Some(28))): Either[User, User])
+      .into[Either[UserPLStd, UserPLStd]]
+      .withFieldRenamed(_.matching[Left[User, User]].value.name, _.matching[Left[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Left[User, User]].value.age, _.matching[Left[UserPLStd, UserPLStd]].value.wiek)
+      .withFieldRenamed(_.matching[Right[User, User]].value.name, _.matching[Right[UserPLStd, UserPLStd]].value.imie)
+      .withFieldRenamed(_.matching[Right[User, User]].value.age, _.matching[Right[UserPLStd, UserPLStd]].value.wiek)
       .transform ==> Right(UserPLStd(1, "Kuba", Some(28)))
   }
 

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -1574,8 +1574,9 @@ The requirements to use a rename are as follows:
   - you have to have a `val`/nullary method/Bean getter with a name matching constructor's argument (or Bean setter if
     setters are enabled) to point which argument you are targeting
   - the field rename can be _nested_, you can pass `_.foo.bar.baz` there, additionally you can use:
-     - `.matching[Subtype]` to select just one subtype of ADT e.g `_.adt.matching[Subtype].subtypeField` (do not use for
-       matching on `Option` or `Either`! Use dedicated matchers described below)
+     - `.matching[Subtype]` to select just one subtype of ADT e.g `_.adt.matching[Subtype].subtypeField` (not
+       recommended for matching on `Option` or `Either`, as the subtype might be lengthy and require a subsequent
+       `.value`. Use dedicated matchers described below).
      - `.matchingSome` to select values inside `Option` e.g. `_.option.matchingSome.field`
      - `.matchingLeft` and `.matchingRight` to select values inside `Either` e.g. `_.either.matchingLeft.field` or
        `_.either.matchingRight.field`
@@ -1823,8 +1824,9 @@ The requirements to use a value provision are as follows:
   - you have to have a `val`/nullary method/Bean getter with a name matching constructor's argument (or Bean setter if
     setters are enabled)
   - the path can be _nested_, you can pass `_.foo.bar.baz` there, and additionally you can use:
-     - `.matching[Subtype]` to select just one subtype of ADT e.g `_.adt.matching[Subtype].subtypeField` (do not use for
-       matching on `Option` or `Either`! Use dedicated matchers described below)
+     - `.matching[Subtype]` to select just one subtype of ADT e.g `_.adt.matching[Subtype].subtypeField` (not
+       recommended for matching on `Option` or `Either`, as the subtype might be lengthy and require a subsequent
+       `.value`. Use dedicated matchers described below).
      - `.matchingSome` to select values inside `Option` e.g. `_.option.matchingSome.field`
      - `.matchingLeft` and `.matchingRight` to select values inside `Either` e.g. `_.either.matchingLeft.field` or
        `_.either.matchingRight.field`
@@ -2109,8 +2111,9 @@ The requirements to use a value computation are as follows:
   - you have to have a `val`/nullary method/Bean getter with a name matching constructor's argument (or Bean setter if
     setters are enabled)
   - the path can be _nested_, you can pass `_.foo.bar.baz` there, and additionally you can use:
-     - `.matching[Subtype]` to select just one subtype of ADT e.g `_.adt.matching[Subtype].subtypeField` (do not use for
-       matching on `Option` or `Either`! Use dedicated matchers described below)
+     - `.matching[Subtype]` to select just one subtype of ADT e.g `_.adt.matching[Subtype].subtypeField` (not
+       recommended for matching on `Option` or `Either`, as the subtype might be lengthy and require a subsequent
+       `.value`. Use dedicated matchers described below).
      - `.matchingSome` to select values inside `Option` e.g. `_.option.matchingSome.field`
      - `.matchingLeft` and `.matchingRight` to select values inside `Either` e.g. `_.either.matchingLeft.field` or
        `_.either.matchingRight.field`


### PR DESCRIPTION
 - [x] `.everyItem._1` <=> `.everyMapKey`
 - [x] `.everyItem._2` <=> `.everyMapValue`
 - [x] `.matchingSome` <=> `.matching[Some].value`
 - [x] `.matchingLeft` <=> `.matching[Left].value`
 - [x] `.matchingRight` <=> `.matching[Right].value`
 - [x] tests
 - [x] update docs
