### PR TITLE
Use dedicated PathElement for values provided manually

### DIFF
--- a/chimney-cats/src/test/scala/io/scalaland/chimney/cats/PartialResultToCatsDataConversionSpec.scala
+++ b/chimney-cats/src/test/scala/io/scalaland/chimney/cats/PartialResultToCatsDataConversionSpec.scala
@@ -62,9 +62,9 @@ class PartialResultToCatsDataConversionSpec extends ChimneySpec {
           .withFieldConstPartial(_.height, NonEmptyList.of("abc", "def").invalid.asResult)
           .transform
 
-        val expectedErr1 = Error.fromString("foo").prependErrorPath(PathElement.Accessor("name"))
-        val expectedErr2 = Error.fromString("abc").prependErrorPath(PathElement.Accessor("height"))
-        val expectedErr3 = Error.fromString("def").prependErrorPath(PathElement.Accessor("height"))
+        val expectedErr1 = Error.fromString("foo").prependErrorPath(PathElement.Provided("_.name", None))
+        val expectedErr2 = Error.fromString("abc").prependErrorPath(PathElement.Provided("_.height", None))
+        val expectedErr3 = Error.fromString("def").prependErrorPath(PathElement.Provided("_.height", None))
 
         result.asValidated ==> Validated.invalid(
           partial.Result.fromErrors(expectedErr1, expectedErr2, expectedErr3)
@@ -97,9 +97,9 @@ class PartialResultToCatsDataConversionSpec extends ChimneySpec {
           )
           .transform
 
-        val expectedErr1 = Error.fromThrowable(ex1).prependErrorPath(PathElement.Accessor("name"))
-        val expectedErr2 = Error.fromThrowable(ex2).prependErrorPath(PathElement.Accessor("height"))
-        val expectedErr3 = Error.fromThrowable(ex3).prependErrorPath(PathElement.Accessor("height"))
+        val expectedErr1 = Error.fromThrowable(ex1).prependErrorPath(PathElement.Provided("_.name", None))
+        val expectedErr2 = Error.fromThrowable(ex2).prependErrorPath(PathElement.Provided("_.height", None))
+        val expectedErr3 = Error.fromThrowable(ex3).prependErrorPath(PathElement.Provided("_.height", None))
 
         result.asValidated ==> Validated.invalid(
           partial.Result.fromErrors(expectedErr1, expectedErr2, expectedErr3)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -165,6 +165,10 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
         c.Expr[partial.PathElement.MapKey](q"_root_.io.scalaland.chimney.partial.PathElement.MapKey($key)")
       def MapValue(value: Expr[Any]): Expr[partial.PathElement.MapValue] =
         c.Expr[partial.PathElement.MapValue](q"_root_.io.scalaland.chimney.partial.PathElement.MapValue($value)")
+      def Provided(targetPath: Expr[String], sourcePath: Expr[Option[String]]): Expr[partial.PathElement.Provided] =
+        c.Expr[partial.PathElement.Provided](
+          q"_root_.io.scalaland.chimney.partial.PathElement.Provided($targetPath, $sourcePath)"
+        )
     }
 
     object RuntimeDataStore extends RuntimeDataStoreModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -89,6 +89,7 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       val Index: Type[partial.PathElement.Index] = weakTypeTag[partial.PathElement.Index]
       val MapKey: Type[partial.PathElement.MapKey] = weakTypeTag[partial.PathElement.MapKey]
       val MapValue: Type[partial.PathElement.MapValue] = weakTypeTag[partial.PathElement.MapValue]
+      val Provided: Type[partial.PathElement.Provided] = weakTypeTag[partial.PathElement.Provided]
     }
 
     val PreferTotalTransformer: Type[io.scalaland.chimney.dsl.PreferTotalTransformer.type] =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyExprsPlatform.scala
@@ -153,6 +153,9 @@ private[compiletime] trait ChimneyExprsPlatform extends ChimneyExprs { this: Chi
 
       def MapValue(key: Expr[Any]): Expr[partial.PathElement.MapValue] =
         '{ partial.PathElement.MapValue(${ key }) }
+
+      def Provided(targetPath: Expr[String], sourcePath: Expr[Option[String]]): Expr[partial.PathElement.Provided] =
+        '{ partial.PathElement.Provided(${ targetPath }, ${ sourcePath }) }
     }
 
     object RuntimeDataStore extends RuntimeDataStoreModule {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -36,6 +36,7 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
       val Index: Type[partial.PathElement.Index] = quoted.Type.of[partial.PathElement.Index]
       val MapKey: Type[partial.PathElement.MapKey] = quoted.Type.of[partial.PathElement.MapKey]
       val MapValue: Type[partial.PathElement.MapValue] = quoted.Type.of[partial.PathElement.MapValue]
+      val Provided: Type[partial.PathElement.Provided] = quoted.Type.of[partial.PathElement.Provided]
     }
 
     val PreferTotalTransformer: Type[io.scalaland.chimney.dsl.PreferTotalTransformer.type] =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyExprs.scala
@@ -110,6 +110,7 @@ private[compiletime] trait ChimneyExprs { this: ChimneyDefinitions =>
       def Index(index: Expr[Int]): Expr[partial.PathElement.Index]
       def MapKey(key: Expr[Any]): Expr[partial.PathElement.MapKey]
       def MapValue(key: Expr[Any]): Expr[partial.PathElement.MapValue]
+      def Provided(targetPath: Expr[String], sourcePath: Expr[Option[String]]): Expr[partial.PathElement.Provided]
     }
 
     val RuntimeDataStore: RuntimeDataStoreModule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -30,6 +30,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       val Index: Type[partial.PathElement.Index]
       val MapKey: Type[partial.PathElement.MapKey]
       val MapValue: Type[partial.PathElement.MapValue]
+      val Provided: Type[partial.PathElement.Provided]
     }
 
     val PreferTotalTransformer: Type[io.scalaland.chimney.dsl.PreferTotalTransformer.type]
@@ -385,6 +386,7 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
       implicit val PathElementIndex: Type[partial.PathElement.Index] = PathElement.Index
       implicit val PathElementMapKey: Type[partial.PathElement.MapKey] = PathElement.MapKey
       implicit val PathElementMapValue: Type[partial.PathElement.MapValue] = PathElement.MapValue
+      implicit val PathElementProvided: Type[partial.PathElement.Provided] = PathElement.Provided
 
       implicit val RuntimeDataStoreType: Type[dsls.TransformerDefinitionCommons.RuntimeDataStore] = RuntimeDataStore
 

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/Path.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/Path.scala
@@ -18,7 +18,9 @@ final case class Path(private val elements: List[PathElement]) extends AnyVal {
     *
     * @since 0.7.0
     */
-  def prepend(pathElement: PathElement): Path = Path(pathElement :: elements)
+  def prepend(pathElement: PathElement): Path =
+    if (elements.nonEmpty && elements.head.isInstanceOf[PathElement.Provided]) this
+    else Path(pathElement :: elements)
 
   /** Returns conventional string based representation of a path
     *
@@ -31,10 +33,14 @@ final case class Path(private val elements: List[PathElement]) extends AnyVal {
       val it = elements.iterator
       while (it.hasNext) {
         val curr = it.next()
-        if (sb.nonEmpty && PathElement.shouldPrependWithDot(curr)) {
-          sb += '.'
+        if (curr.isInstanceOf[PathElement.Provided]) {
+          sb ++= curr.asString
+        } else {
+          if (sb.nonEmpty && PathElement.shouldPrependWithDot(curr)) {
+            sb += '.'
+          }
+          sb ++= curr.asString
         }
-        sb ++= curr.asString
       }
       sb.result()
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/partial/PathElement.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/partial/PathElement.scala
@@ -25,7 +25,7 @@ sealed trait PathElement {
   */
 object PathElement {
 
-  /** Object property accessor (e.g case class param name).
+  /** Object property accessor (e.g. case class param name).
     *
     * @param name
     *   field name
@@ -69,6 +69,18 @@ object PathElement {
     override def asString: String = s"keys($key)"
   }
 
+  /** At the beginning of a Path that should be modified further, because e.g. it was created by withFieldConst,
+    * withFieldComputed, withFieldConstPartial, withFieldComputedPartial and the whole Path is already constructed.
+    *
+    * @since 1.6.0
+    */
+  final case class Provided(targetPath: String, sourcePath: Option[String]) extends PathElement {
+    override def asString: String = sourcePath match {
+      case Some(src) => s"<provided for path `$targetPath`, computed from expr `$src`>"
+      case None      => s"<provided for path `$targetPath`, const value>"
+    }
+  }
+
   /** Specifies if path element in conventional string representation should be prepended with a dot.
     *
     * @param pathElement
@@ -81,5 +93,6 @@ object PathElement {
     case _: Index    => false
     case _: MapValue => false
     case _: MapKey   => true
+    case _: Provided => false
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -592,6 +592,9 @@ class IssuesSpec extends ChimneySpec {
       )
     }
 
+    // This whole approach was broken in #209: it showed a path to _target_ field, in a structure that prepends data by
+    // _source_ path, so for nested structures it was a random mixture of source and target fields.
+
     test("withFieldComputedPartial") {
       val result = RawData("any")
         .intoPartial[Data]
@@ -599,7 +602,7 @@ class IssuesSpec extends ChimneySpec {
         .transform
 
       result.asErrorPathMessageStrings ==> Iterable(
-        "id" -> "always fails"
+        "<provided for path `_.id`, computed from expr `rawdata`>" -> "always fails"
       )
 
       val definedPT = PartialTransformer
@@ -608,7 +611,7 @@ class IssuesSpec extends ChimneySpec {
         .buildTransformer
 
       definedPT.transform(RawData("any")).asErrorPathMessageStrings ==> Iterable(
-        "id" -> "always fails"
+        "<provided for path `_.id`, computed from expr `rawdata`>" -> "always fails"
       )
     }
 
@@ -619,7 +622,7 @@ class IssuesSpec extends ChimneySpec {
         .transform
 
       result.asErrorPathMessageStrings ==> Iterable(
-        "id" -> "always fails"
+        "<provided for path `_.id`, const value>" -> "always fails"
       )
 
       val definedPT = PartialTransformer
@@ -628,7 +631,7 @@ class IssuesSpec extends ChimneySpec {
         .buildTransformer
 
       definedPT.transform(RawData("any")).asErrorPathMessageStrings ==> Iterable(
-        "id" -> "always fails"
+        "<provided for path `_.id`, const value>" -> "always fails"
       )
     }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerErrorPathSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerErrorPathSpec.scala
@@ -74,15 +74,15 @@ class PartialTransformerErrorPathSpec extends ChimneySpec {
       .transform
     result.asErrorPathMessages ==> Iterable(
       "inner.str" -> partial.ErrorMessage.EmptyValue,
-      "inner.int2" -> partial.ErrorMessage.EmptyValue,
-      "inner.double" -> partial.ErrorMessage.EmptyValue,
-      "b" -> partial.ErrorMessage.EmptyValue
+      "<provided for path `_.int2`, const value>" -> partial.ErrorMessage.EmptyValue,
+      "<provided for path `_.double`, computed from expr `innerfoo`>" -> partial.ErrorMessage.EmptyValue,
+      "<provided for path `_.b`, const value>" -> partial.ErrorMessage.EmptyValue
     )
     result.asErrorPathMessageStrings ==> Iterable(
       "inner.str" -> "empty value",
-      "inner.int2" -> "empty value",
-      "inner.double" -> "empty value",
-      "b" -> "empty value"
+      "<provided for path `_.int2`, const value>" -> "empty value",
+      "<provided for path `_.double`, computed from expr `innerfoo`>" -> "empty value",
+      "<provided for path `_.b`, const value>" -> "empty value"
     )
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -384,7 +384,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result7.asOption ==> None
       result7.asEither.isLeft ==> true
       result7.asErrorPathMessageStrings ==> Iterable(
-        "age" -> "empty value"
+        "<provided for path `_.age`, const value>" -> "empty value"
       )
 
       val result8 = NestedProduct(Person("John", 10, 140))
@@ -565,7 +565,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result7.asOption ==> None
       result7.asEither.isLeft ==> true
       result7.asErrorPathMessageStrings ==> Iterable(
-        "age" -> "error happened"
+        "<provided for path `_.age`, computed from expr `person`>" -> "error happened"
       )
 
       val result8 = NestedProduct(Person("John", 10, 140))
@@ -746,7 +746,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result7.asOption ==> None
       result7.asEither.isLeft ==> true
       result7.asErrorPathMessageStrings ==> Iterable(
-        "age" -> "error happened"
+        "<provided for path `_.age`, computed from expr `person.age`>.age" -> "error happened"
       )
 
       val result8 = NestedProduct(Person("John", 10, 140))
@@ -942,7 +942,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result7.asOption ==> None
       result7.asEither.isLeft ==> true
       result7.asErrorPathMessageStrings ==> Iterable(
-        "age" -> "empty value"
+        "<provided for path `_.age`, computed from expr `person`>" -> "empty value"
       )
 
       val result8 = NestedProduct(Person("John", 10, 140))
@@ -1138,7 +1138,7 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result7.asOption ==> None
       result7.asEither.isLeft ==> true
       result7.asErrorPathMessageStrings ==> Iterable(
-        "age" -> "empty value"
+        "<provided for path `_.age`, computed from expr `person.age`>.age" -> "empty value"
       )
 
       val result8 = NestedProduct(Person("John", 10, 140))
@@ -2642,15 +2642,15 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result.asEither ==> Left(
         partial.Result.Errors
           .single(partial.Error.fromEmptyValue)
-          .prependErrorPath(partial.PathElement.Accessor("height"))
+          .prependErrorPath(partial.PathElement.Provided("_.height", None))
       )
       result.asErrorPathMessageStrings ==> Iterable(
-        "height" -> "empty value"
+        "<provided for path `_.height`, const value>" -> "empty value"
       )
     }
 
     test("not defined at") {
-      val person = Person("John", 10, 140)
+      val person = Person("John", 10, 140.0)
       val result = person
         .intoPartial[User]
         .withFieldComputedPartial(
@@ -2665,15 +2665,15 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result.asEither ==> Left(
         partial.Result.Errors
           .single(partial.Error.fromNotDefinedAt(person))
-          .prependErrorPath(partial.PathElement.Accessor("height"))
+          .prependErrorPath(partial.PathElement.Provided("_.height", Some("person")))
       )
       result.asErrorPathMessageStrings ==> Iterable(
-        "height" -> s"not defined at $person"
+        "<provided for path `_.height`, computed from expr `person`>" -> s"not defined at $person"
       )
     }
 
     test("custom string errors") {
-      val result = Person("John", 10, 140)
+      val result = Person("John", 10, 140.0)
         .intoPartial[User]
         .withFieldConstPartial(_.height, partial.Result.fromErrorStrings("abc", "def"))
         .transform
@@ -2685,11 +2685,11 @@ class PartialTransformerProductSpec extends ChimneySpec {
             partial.Error.fromString("abc"),
             partial.Error.fromString("def")
           )
-          .prependErrorPath(partial.PathElement.Accessor("height"))
+          .prependErrorPath(partial.PathElement.Provided("_.height", None))
       )
       result.asErrorPathMessageStrings ==> Iterable(
-        "height" -> "abc",
-        "height" -> "def"
+        "<provided for path `_.height`, const value>" -> "abc",
+        "<provided for path `_.height`, const value>" -> "def"
       )
     }
 
@@ -2706,10 +2706,10 @@ class PartialTransformerProductSpec extends ChimneySpec {
           .single(
             partial.Error.fromThrowable(MyException)
           )
-          .prependErrorPath(partial.PathElement.Accessor("height"))
+          .prependErrorPath(partial.PathElement.Provided("_.height", None))
       )
       result.asErrorPathMessageStrings ==> Iterable(
-        "height" -> "my exception"
+        "<provided for path `_.height`, const value>" -> "my exception"
       )
     }
   }
@@ -2762,9 +2762,9 @@ class PartialTransformerProductSpec extends ChimneySpec {
 
       result.asOption ==> None
       result.asErrorPathMessageStrings ==> Iterable(
-        "name" -> "empty value",
-        "age" -> "For input string: \"foo\"",
-        "height" -> "empty value"
+        "<provided for path `_.name`, computed from expr `personform`>" -> "empty value",
+        "<provided for path `_.age`, computed from expr `personform`>" -> "For input string: \"foo\"",
+        "<provided for path `_.height`, computed from expr `personform`>" -> "empty value"
       )
     }
   }
@@ -2811,23 +2811,19 @@ class PartialTransformerProductSpec extends ChimneySpec {
         partial.Result.Errors(
           partial.Error
             .fromString("bad trip id")
-            .prependErrorPath(partial.PathElement.Accessor("id")),
+            .prependErrorPath(partial.PathElement.Provided("_.id", Some("tripform"))),
           partial.Error
             .fromString("bad height value")
-            .prependErrorPath(partial.PathElement.Accessor("height"))
-            .prependErrorPath(partial.PathElement.Index(0))
-            .prependErrorPath(partial.PathElement.Accessor("people")),
+            .prependErrorPath(partial.PathElement.Provided("_.height", Some("personform"))),
           partial.Error
             .fromString("bad age value")
-            .prependErrorPath(partial.PathElement.Accessor("age"))
-            .prependErrorPath(partial.PathElement.Index(1))
-            .prependErrorPath(partial.PathElement.Accessor("people"))
+            .prependErrorPath(partial.PathElement.Provided("_.age", Some("personform")))
         )
       )
       result.asErrorPathMessageStrings ==> Iterable(
-        "id" -> "bad trip id",
-        "people(0).height" -> "bad height value",
-        "people(1).age" -> "bad age value"
+        "<provided for path `_.id`, computed from expr `tripform`>" -> "bad trip id",
+        "<provided for path `_.height`, computed from expr `personform`>" -> "bad height value",
+        "<provided for path `_.age`, computed from expr `personform`>" -> "bad age value"
       )
     }
   }

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -690,16 +690,28 @@ new extension methods: `asValidatedNec`, `asValidatedNel`, `asValidatedChain` an
     //   e = NonEmptyList(
     //     head = Error(
     //       message = StringMessage(message = "John's email: does not contain '@' character"),
-    //       path = Path(elements = List(Index(index = 0), Accessor(name = "email")))
+    //       path = Path(
+    //         elements = List(
+    //           Provided(targetPath = "_.email", sourcePath = Some(value = "registrationform"))
+    //         )
+    //       )
     //     ),
     //     tail = List(
     //       Error(
     //         message = StringMessage(message = "John's age: must have at least 18 years"),
-    //         path = Path(elements = List(Index(index = 0), Accessor(name = "age")))
+    //         path = Path(
+    //           elements = List(
+    //             Provided(targetPath = "_.age", sourcePath = Some(value = "registrationform"))
+    //           )
+    //         )
     //       ),
     //       Error(
     //         message = StringMessage(message = "Bob's age: invalid number"),
-    //         path = Path(elements = List(Index(index = 2), Accessor(name = "age")))
+    //         path = Path(
+    //           elements = List(
+    //             Provided(targetPath = "_.age", sourcePath = Some(value = "registrationform"))
+    //           )
+    //         )
     //       )
     //     )
     //   )

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -1804,9 +1804,16 @@ These cases can be handled only with `PartialTransformer` using `.withFieldConst
         .map(_.asErrorPathMessages)
     )
     // expected output:    
-    // Left(value = List(("c", EmptyValue)))
-    // Left(value = List(("c", ThrowableMessage(throwable = java.lang.NullPointerException))))
-    // Left(value = List(("c", StringMessage(message = "bad value"))))
+    // Left(value = List(("<provided for path `_.c`, const value>", EmptyValue)))
+    // Left(
+    //   value = List(
+    //     (
+    //       "<provided for path `_.c`, const value>",
+    //       ThrowableMessage(throwable = java.lang.NullPointerException)
+    //     )
+    //   )
+    // )
+    // Left(value = List(("<provided for path `_.c`, const value>", StringMessage(message = "bad value"))))
     ``` 
 
 As you can see, the transformed value will automatically preserve the field name for which a failure happened.
@@ -2034,7 +2041,11 @@ These cases can be handled only with `PartialTransformer` using
         .map(_.asErrorPathMessages)
     )
     // expected output:
-    // Left(value = List(("c", StringMessage(message = "bad value"))))
+    // Left(
+    //   value = List(
+    //     ("<provided for path `_.c`, computed from expr `foo`>", StringMessage(message = "bad value"))
+    //   )
+    // )
     
     // failure depends on the input (whether .toLong throws or not)
     pprint.pprintln(
@@ -2059,7 +2070,10 @@ These cases can be handled only with `PartialTransformer` using
     // Right(value = Bar(a = "20", b = 10, c = 20L))
     // Left(
     //   value = List(
-    //     ("c", ThrowableMessage(throwable = java.lang.NumberFormatException: For input string: "value"))
+    //     (
+    //       "<provided for path `_.c`, computed from expr `foo`>",
+    //       ThrowableMessage(throwable = java.lang.NumberFormatException: For input string: "value")
+    //     )
     //   )
     // )
     
@@ -2089,7 +2103,11 @@ These cases can be handled only with `PartialTransformer` using
     //         message = ThrowableMessage(
     //           throwable = java.lang.NumberFormatException: For input string: "value"
     //         ),
-    //         path = Path(elements = List(Index(index = 0), Accessor(name = "c")))
+    //         path = Path(
+    //           elements = List(
+    //             Provided(targetPath = "_.everyItem.c", sourcePath = Some(value = "list.a"))
+    //           )
+    //         )
     //       )
     //     )
     //   )


### PR DESCRIPTION
When using:

 - withFieldConstPartial
 - withFieldCompured (in PartialTransformer)
 - withFieldComputedPartial

we were just prepending to the `Path` the `PathElement.Accessor` with the name of the currently handled target field. But the `Path` is designed to handle path _from source value_. In nested data this results in a chain of fields where the prefix comes from source type and the last field from the target type. It makes no sense.

This PR introduces a dedicated `PathElement` for storing errors from provided values, which may not have source or their source may be unrelated to the currently used From expression.