### PR TITLE
Test semiautomatic macros

### DIFF
--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -221,7 +221,7 @@ object TransformerDefinitionMacros {
           '{
             WithRuntimeDataStore
               .update($ti, $fallback)
-              .asInstanceOf[TransformerDefinition[From, To, Fallback[FromFallback, Path.Root, Overrides], Flags]]
+              .asInstanceOf[TransformerDefinition[From, To, Fallback[FromFallback, fromPath, Overrides], Flags]]
         }
     }(selectorFrom)
 

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecProductSpec.scala
@@ -19,7 +19,7 @@ class CodecProductSpec extends ChimneySpec {
   }
 
   group(
-    "settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+    "setting .withSealedSubtypeRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
   ) {
 
     import fixtures.renames.Subtypes.*
@@ -36,7 +36,7 @@ class CodecProductSpec extends ChimneySpec {
   }
 
   group(
-    "settings .withEnumCaseRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+    "setting .withEnumCaseRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
   ) {
 
     import fixtures.renames.Subtypes.*

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoProductSpec.scala
@@ -20,7 +20,7 @@ class IsoProductSpec extends ChimneySpec {
   }
 
   group(
-    "settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+    "setting .withSealedSubtypeRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
   ) {
 
     import fixtures.renames.Subtypes.*
@@ -37,7 +37,7 @@ class IsoProductSpec extends ChimneySpec {
   }
 
   group(
-    "settings .withEnumCaseRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
+    "setting .withEnumCaseRenamed[FromSubtype, ToSubtype] should be correctly forwarded to Transformer/PartialTransformer"
   ) {
 
     import fixtures.renames.Subtypes.*

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialMergingProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialMergingProductSpec.scala
@@ -162,6 +162,24 @@ class PartialMergingProductSpec extends ChimneySpec {
         .transform
         .asOption ==> Some(Nested((1, "const", 3.0, 4, "computed", 6.0, 1)))
     }
+
+    test("should work with semiautomatic derivation") {
+      import merges.Disjoint.*, merges.Nested
+
+      PartialTransformer
+        .define[Foo[Double], Baz[Double]]
+        .withFallback(Bar(4, "e", 6.0))
+        .buildTransformer
+        .transform(Foo(1, "b", 3.0))
+        .asOption ==> Some(Baz(1, "b", 3.0, 4, "e", 6.0))
+
+      PartialTransformer
+        .define[Nested[Foo[Double]], Nested[Baz[Double]]]
+        .withFallback(Nested(Bar(4, "e", 6.0)))
+        .buildTransformer
+        .transform(Nested(Foo(1, "b", 3.0)))
+        .asOption ==> Some(Nested(Baz(1, "b", 3.0, 4, "e", 6.0)))
+    }
   }
 
   group("setting .withFallbackFrom(selectorFrom)(fallbackValue)") {
@@ -324,6 +342,24 @@ class PartialMergingProductSpec extends ChimneySpec {
         .withFieldRenamed(_.value.value.a, _.value.value._7)
         .transform
         .asOption ==> Some(Nested(Nested((1, "const", 3.0, 4, "computed", 6.0, 1))))
+    }
+
+    test("should work with semiautomatic derivation") {
+      import merges.Disjoint.*, merges.Nested
+
+      PartialTransformer
+        .define[Nested[Foo[Double]], Nested[Baz[Double]]]
+        .withFallbackFrom(_.value)(Bar(4, "e", 6.0))
+        .buildTransformer
+        .transform(Nested(Foo(1, "b", 3.0)))
+        .asOption ==> Some(Nested(Baz(1, "b", 3.0, 4, "e", 6.0)))
+
+      PartialTransformer
+        .define[Nested[Nested[Foo[Double]]], Nested[Nested[Baz[Double]]]]
+        .withFallbackFrom(_.value)(Nested(Bar(4, "e", 6.0)))
+        .buildTransformer
+        .transform(Nested(Nested(Foo(1, "b", 3.0))))
+        .asOption ==> Some(Nested(Nested(Baz(1, "b", 3.0, 4, "e", 6.0))))
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialMergingSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialMergingSealedHierarchySpec.scala
@@ -3,9 +3,9 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 
-class PartialMergingSealedHiearchySpec extends ChimneySpec {
+class PartialMergingSealedHierarchySpec extends ChimneySpec {
 
-  import TotalMergingSealedHiearchySpec.*
+  import TotalMergingSealedHierarchySpec.*
 
   group("setting .withFallback(fallbackValue)") {
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerCustomConstructorSpec.scala
@@ -117,6 +117,32 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
       result.id ==> "id"
       result.name ==> "name"
     }
+
+    test("""should allow defining transformers with overrides""") {
+      import products.{Foo, Bar}
+
+      val uncurriedExpected = Bar(6, (6.28, 6.28))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+      val result = PartialTransformer
+        .define[Foo, Bar]
+        .withConstructor(uncurriedConstructor _)
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14)))
+      result.asOption ==> Some(uncurriedExpected)
+      result.asEither ==> Right(uncurriedExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = PartialTransformer
+        .define[Foo, Bar]
+        .withConstructor((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14)))
+      result2.asOption ==> Some(uncurriedExpected)
+      result2.asEither ==> Right(uncurriedExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+    }
   }
 
   group("setting .withConstructorTo(_.field)(fn)") {
@@ -235,6 +261,32 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
       result.value.id ==> "id"
       result.value.name ==> "name"
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}, nestedpath.*
+
+      val uncurriedExpected = NestedProduct(Bar(6, (6.28, 6.28)))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+      val result = PartialTransformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorTo(_.value)(uncurriedConstructor _)
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14))))
+      result.asOption ==> Some(uncurriedExpected)
+      result.asEither ==> Right(uncurriedExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = PartialTransformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorTo(_.value)((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14))))
+      result2.asOption ==> Some(uncurriedExpected)
+      result2.asEither ==> Right(uncurriedExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+    }
   }
 
   group("setting .withConstructorPartial(fn)") {
@@ -352,6 +404,33 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
       val result = (new ClassSource("id", "name")).transformIntoPartial[TraitSource].asOption.get
       result.id ==> "id"
       result.name ==> "name"
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val uncurriedExpected = Bar(6, (6.28, 6.28))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): partial.Result[Bar] =
+        partial.Result.fromValue(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+      val result = PartialTransformer
+        .define[Foo, Bar]
+        .withConstructorPartial(uncurriedConstructor _)
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14)))
+      result.asOption ==> Some(uncurriedExpected)
+      result.asEither ==> Right(uncurriedExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = PartialTransformer
+        .define[Foo, Bar]
+        .withConstructorPartial((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14)))
+      result2.asOption ==> Some(uncurriedExpected)
+      result2.asEither ==> Right(uncurriedExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
     }
   }
 
@@ -473,6 +552,33 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
       result.value.id ==> "id"
       result.value.name ==> "name"
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}, nestedpath.*
+
+      val uncurriedExpected = NestedProduct(Bar(6, (6.28, 6.28)))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): partial.Result[Bar] =
+        partial.Result.fromValue(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+      val result = PartialTransformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value)(uncurriedConstructor _)
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14))))
+      result.asOption ==> Some(uncurriedExpected)
+      result.asEither ==> Right(uncurriedExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = PartialTransformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorPartialTo(_.value)((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14))))
+      result2.asOption ==> Some(uncurriedExpected)
+      result2.asEither ==> Right(uncurriedExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
+    }
   }
 
   group("setting .withConstructorEither(fn)") {
@@ -589,6 +695,33 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
       val result = (new ClassSource("id", "name")).transformIntoPartial[TraitSource].asOption.get
       result.id ==> "id"
       result.name ==> "name"
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val uncurriedExpected = Bar(6, (6.28, 6.28))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Either[String, Bar] =
+        Right(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+      val result = PartialTransformer
+        .define[Foo, Bar]
+        .withConstructorEither(uncurriedConstructor _)
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14)))
+      result.asOption ==> Some(uncurriedExpected)
+      result.asEither ==> Right(uncurriedExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = PartialTransformer
+        .define[Foo, Bar]
+        .withConstructorEither((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14)))
+      result2.asOption ==> Some(uncurriedExpected)
+      result2.asEither ==> Right(uncurriedExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
     }
   }
 
@@ -708,6 +841,33 @@ class PartialTransformerCustomConstructorSpec extends ChimneySpec {
         NestedProduct(new ClassSource("id", "name")).transformIntoPartial[NestedProduct[TraitSource]].asOption.get
       result.value.id ==> "id"
       result.value.name ==> "name"
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}, nestedpath.*
+
+      val uncurriedExpected = NestedProduct(Bar(6, (6.28, 6.28)))
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Either[String, Bar] =
+        Right(Bar(x * 2, (z._1 * 2, z._2 * 2)))
+
+      val result = PartialTransformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value)(uncurriedConstructor _)
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14))))
+      result.asOption ==> Some(uncurriedExpected)
+      result.asEither ==> Right(uncurriedExpected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+
+      val result2 = PartialTransformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorEitherTo(_.value)((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14))))
+      result2.asOption ==> Some(uncurriedExpected)
+      result2.asEither ==> Right(uncurriedExpected)
+      result2.asErrorPathMessageStrings ==> Iterable.empty
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerJavaBeanSpec.scala
@@ -100,7 +100,7 @@ class PartialTransformerJavaBeanSpec extends ChimneySpec {
     }
   }
 
-  group("""settings .withField*(_.getTo, ...) and .withFieldRenamed(_.from, _.getTo)""") {
+  group("""setting .withField*(_.getTo, ...) and .withFieldRenamed(_.from, _.getTo)""") {
 
     test("transform case class to Java Bean, allowing using getters as a way to rename into matching setters") {
       val source = CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true)

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -268,6 +268,18 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result12.asEither ==> Right(NestedADT.Foo(Renames.UserPLStd(1, "Kuba", Some(28))))
       result12.asErrorPathMessageStrings ==> Iterable.empty
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val expected = Foo(3, "pi", (3.14, 3.14))
+
+      val result =
+        PartialTransformer.define[Bar, Foo].withFieldConst(_.y, "pi").buildTransformer.transform(Bar(3, (3.14, 3.14)))
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+    }
   }
 
   group("setting .withFieldConstPartial(_.field, result)") {
@@ -449,6 +461,21 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result12.asEither ==> Right(expected4)
       result12.asErrorPathMessageStrings ==> Iterable.empty
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val expected = Foo(3, "pi", (3.14, 3.14))
+
+      val result = PartialTransformer
+        .define[Bar, Foo]
+        .withFieldConstPartial(_.y, partial.Result.fromValue("pi"))
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14)))
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+    }
   }
 
   group("setting .withFieldComputed(_.field, source => value)") {
@@ -629,6 +656,21 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result12.asOption ==> Some(expected4)
       result12.asEither ==> Right(expected4)
       result12.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val expected = Foo(3, "3", (3.14, 3.14))
+
+      val result = PartialTransformer
+        .define[Bar, Foo]
+        .withFieldComputed(_.y, _.x.toString)
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14)))
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
     }
   }
 
@@ -816,6 +858,21 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result12.asOption ==> Some(expected4)
       result12.asEither ==> Right(expected4)
       result12.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val expected = Foo(3, "3", (3.14, 3.14))
+
+      val result = PartialTransformer
+        .define[Bar, Foo]
+        .withFieldComputedFrom(_.x)(_.y, _.toString)
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14)))
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
     }
   }
 
@@ -1013,6 +1070,21 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result12.asEither ==> Right(expected4)
       result12.asErrorPathMessageStrings ==> Iterable.empty
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val expected = Foo(3, "3", (3.14, 3.14))
+
+      val result = PartialTransformer
+        .define[Bar, Foo]
+        .withFieldComputedPartial(_.y, bar => partial.Result.fromValue(bar.x.toString))
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14)))
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+    }
   }
 
   group("setting .withFieldComputedPartialFrom(_.field)(_.field, source => value)") {
@@ -1208,6 +1280,21 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result12.asOption ==> Some(expected4)
       result12.asEither ==> Right(expected4)
       result12.asErrorPathMessageStrings ==> Iterable.empty
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      val expected = Foo(3, "3", (3.14, 3.14))
+
+      val result = PartialTransformer
+        .define[Bar, Foo]
+        .withFieldComputedPartialFrom(_.x)(_.y, x => partial.Result.fromValue(x.toString))
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14)))
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
     }
   }
 
@@ -1457,6 +1544,22 @@ class PartialTransformerProductSpec extends ChimneySpec {
       result2.asEither ==> Left(expected2)
       result2.asErrorPathMessageStrings ==> expected2.asErrorPathMessageStrings
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.Renames.*
+
+      val expected = UserPLStd(1, "Kuba", Some(28))
+
+      val result = PartialTransformer
+        .define[User, UserPLStd]
+        .withFieldRenamed(_.name, _.imie)
+        .withFieldRenamed(_.age, _.wiek)
+        .buildTransformer
+        .transform(User(1, "Kuba", Some(28)))
+      result.asOption ==> Some(expected)
+      result.asEither ==> Right(expected)
+      result.asErrorPathMessageStrings ==> Iterable.empty
+    }
   }
 
   group("setting .withFieldUnused(_.from)") {
@@ -1487,6 +1590,18 @@ class PartialTransformerProductSpec extends ChimneySpec {
         .withFieldUnused(_.y)
         .enableUnusedFieldPolicyCheck(FailOnIgnoredSourceVal)
         .transform
+        .asOption ==> Some(Bar(10, (1, 2)))
+    }
+
+    test("should work with semiautomatic derivation") {
+
+      PartialTransformer
+        .define[Foo, Bar]
+        // FIXME: if we swap these 2 it's assertion error in -Xcheck-macros on Scala 3 o_0
+        .withFieldUnused(_.y)
+        .enableUnusedFieldPolicyCheck(FailOnIgnoredSourceVal)
+        .buildTransformer
+        .transform(Foo(10, "test", (1, 2)))
         .asOption ==> Some(Bar(10, (1, 2)))
     }
   }

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
@@ -247,6 +247,36 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
         )
       )
     }
+
+    test("should work with semiautomatic derivation") {
+      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
+        colors1.Red
+
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Black)
+        .asOption ==> Some(colors1.Red)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Red)
+        .asOption ==> Some(colors1.Red)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Green)
+        .asOption ==> Some(colors1.Green)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Blue)
+        .asOption ==> Some(colors1.Blue)
+    }
   }
 
   group("setting .withEnumCaseHandled[Subtype](mapping)") {
@@ -329,6 +359,36 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
           List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
         )
       )
+    }
+
+    test("should work with semiautomatic derivation") {
+      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
+        colors1.Red
+
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Black)
+        .asOption ==> Some(colors1.Red)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Red)
+        .asOption ==> Some(colors1.Red)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Green)
+        .asOption ==> Some(colors1.Green)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Blue)
+        .asOption ==> Some(colors1.Blue)
     }
   }
 
@@ -446,6 +506,36 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
         )
       )
     }
+
+    test("should work with semiautomatic derivation") {
+      def blackIsFail(b: colors2.Black.type): partial.Result[colors1.Color] =
+        partial.Result.fromEmpty
+
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Black)
+        .asOption ==> None
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Red)
+        .asOption ==> Some(colors1.Red)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Green)
+        .asOption ==> Some(colors1.Green)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Blue)
+        .asOption ==> Some(colors1.Blue)
+    }
   }
 
   group("setting .withEnumCaseHandledPartial[Subtype](mapping)") {
@@ -533,9 +623,39 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
         )
       )
     }
+
+    test("should work with semiautomatic derivation") {
+      def blackIsFail(b: colors2.Black.type): partial.Result[colors1.Color] =
+        partial.Result.fromEmpty
+
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Black)
+        .asOption ==> None
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Red)
+        .asOption ==> Some(colors1.Red)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Green)
+        .asOption ==> Some(colors1.Green)
+      PartialTransformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandledPartial(blackIsFail)
+        .buildTransformer
+        .transform(colors2.Blue)
+        .asOption ==> Some(colors1.Blue)
+    }
   }
 
-  group("settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype]") {
+  group("setting .withSealedSubtypeRenamed[FromSubtype, ToSubtype]") {
 
     import fixtures.renames.Subtypes.*
 
@@ -566,9 +686,25 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
         .transform
         .asOption ==> Some(Bar.Baz)
     }
+
+    test("should work with semiautomatic derivation") {
+
+      PartialTransformer
+        .define[Foo3, Bar]
+        .withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Baz)
+        .asOption ==> Some(Bar.Baz)
+      PartialTransformer
+        .define[Foo3, Bar]
+        .withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Bazz)
+        .asOption ==> Some(Bar.Baz)
+    }
   }
 
-  group("settings .withEnumCaseRenamed[FromSubtype, ToSubtype]") {
+  group("setting .withEnumCaseRenamed[FromSubtype, ToSubtype]") {
 
     import fixtures.renames.Subtypes.*
 
@@ -583,6 +719,22 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
         .intoPartial[Bar]
         .withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type]
         .transform
+        .asOption ==> Some(Bar.Baz)
+    }
+
+    test("should work with semiautomatic derivation") {
+
+      PartialTransformer
+        .define[Foo3, Bar]
+        .withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Baz)
+        .asOption ==> Some(Bar.Baz)
+      PartialTransformer
+        .define[Foo3, Bar]
+        .withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Bazz)
         .asOption ==> Some(Bar.Baz)
     }
   }
@@ -620,6 +772,18 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
         .transform
         .asOption ==> Some(colors2.Red)
     }
+
+    test("should work with semiautomatic derivation") {
+
+      PartialTransformer
+        .define[colors1.Color, colors2.Color]
+        // FIXME: if we swap these 2 it's assertion error in -Xcheck-macros on Scala 3 o_0
+        .withSealedSubtypeUnmatched(_.matching[colors2.Black.type])
+        .enableUnmatchedSubtypePolicyCheck(FailOnUnmatchedTargetSubtype)
+        .buildTransformer
+        .transform(colors1.Red)
+        .asOption ==> Some(colors2.Red)
+    }
   }
 
   group("setting .withEnumCaseUnmatched(_.from)") {
@@ -653,6 +817,18 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
         .withEnumCaseUnmatched(_.matching[colors2.Black.type])
         .enableUnmatchedSubtypePolicyCheck(FailOnUnmatchedTargetSubtype)
         .transform
+        .asOption ==> Some(colors2.Red)
+    }
+
+    test("should work with semiautomatic derivation") {
+
+      PartialTransformer
+        .define[colors1.Color, colors2.Color]
+        // FIXME: if we swap these 2 it's assertion error in -Xcheck-macros on Scala 3 o_0
+        .withEnumCaseUnmatched(_.matching[colors2.Black.type])
+        .enableUnmatchedSubtypePolicyCheck(FailOnUnmatchedTargetSubtype)
+        .buildTransformer
+        .transform(colors1.Red)
         .asOption ==> Some(colors2.Red)
     }
   }
@@ -876,7 +1052,7 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
     }
   }
 
-  group("settings .withFieldRenamed(selectorFrom, selectorTo)") {
+  group("setting .withFieldRenamed(selectorFrom, selectorTo)") {
 
     import fixtures.renames.Subtypes.*
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherProductSpec.scala
@@ -110,6 +110,20 @@ class PatcherProductSpec extends ChimneySpec {
         .withFieldComputed(_.id, _ => 2)
         .patch ==> User(2, Email("d@e.f"), Phone(98765432L))
     }
+
+    test("should work with semiautomatic derivation") {
+      import PatchDomain.*
+
+      Patcher
+        .define[User, UpdateDetails]
+        .withFieldComputed(_.id, _ => 2)
+        .buildPatcher
+        .patch(User(1, Email("a@b.c"), Phone(123456789L)), UpdateDetails("d@e.f", 98765432L)) ==> User(
+        2,
+        Email("d@e.f"),
+        Phone(98765432L)
+      )
+    }
   }
 
   group("setting .withFieldComputedFrom(selectorFrom)(selectorTo, value)") {
@@ -121,6 +135,20 @@ class PatcherProductSpec extends ChimneySpec {
         .using(UpdateDetails("d@e.f", 98765432L))
         .withFieldComputedFrom(_.phone)(_.id, _.toInt)
         .patch ==> User(98765432, Email("d@e.f"), Phone(98765432L))
+    }
+
+    test("should work with semiautomatic derivation") {
+      import PatchDomain.*
+
+      Patcher
+        .define[User, UpdateDetails]
+        .withFieldComputedFrom(_.phone)(_.id, _.toInt)
+        .buildPatcher
+        .patch(User(1, Email("a@b.c"), Phone(123456789L)), UpdateDetails("d@e.f", 98765432L)) ==> User(
+        98765432,
+        Email("d@e.f"),
+        Phone(98765432L)
+      )
     }
   }
 
@@ -143,6 +171,19 @@ class PatcherProductSpec extends ChimneySpec {
         .using(User(1, Email("a@b.c"), Phone(123456789L)))
         .withFieldIgnored(_.id)
         .patch ==> UpdateDetails("a@b.c", 123456789L)
+    }
+
+    test("should work with semiautomatic derivation") {
+      import PatchDomain.*
+
+      Patcher
+        .define[UpdateDetails, User]
+        .withFieldIgnored(_.id)
+        .buildPatcher
+        .patch(UpdateDetails("d@e.f", 98765432L), User(1, Email("a@b.c"), Phone(123456789L))) ==> UpdateDetails(
+        "a@b.c",
+        123456789L
+      )
     }
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalMergingProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalMergingProductSpec.scala
@@ -134,6 +134,22 @@ class TotalMergingProductSpec extends ChimneySpec {
         .withFieldRenamed(_.value.a, _.value._7)
         .transform ==> Nested((1, "const", 3.0, 4, "computed", 6.0, 1))
     }
+
+    test("should work with semiautomatic derivation") {
+      import merges.Disjoint.*, merges.Nested
+
+      Transformer
+        .define[Foo[Double], Baz[Double]]
+        .withFallback(Bar(4, "e", 6.0))
+        .buildTransformer
+        .transform(Foo(1, "b", 3.0)) ==> Baz(1, "b", 3.0, 4, "e", 6.0)
+
+      Transformer
+        .define[Nested[Foo[Double]], Nested[Baz[Double]]]
+        .withFallback(Nested(Bar(4, "e", 6.0)))
+        .buildTransformer
+        .transform(Nested(Foo(1, "b", 3.0))) ==> Nested(Baz(1, "b", 3.0, 4, "e", 6.0))
+    }
   }
 
   group("setting .withFallbackFrom(selectorFrom)(fallbackValue)") {
@@ -280,6 +296,22 @@ class TotalMergingProductSpec extends ChimneySpec {
         .withFieldComputedFrom(_.value)(_.value.value._5, _ => "computed")
         .withFieldRenamed(_.value.value.a, _.value.value._7)
         .transform ==> Nested(Nested((1, "const", 3.0, 4, "computed", 6.0, 1)))
+    }
+
+    test("should work with semiautomatic derivation") {
+      import merges.Disjoint.*, merges.Nested
+
+      Transformer
+        .define[Nested[Foo[Double]], Nested[Baz[Double]]]
+        .withFallbackFrom(_.value)(Bar(4, "e", 6.0))
+        .buildTransformer
+        .transform(Nested(Foo(1, "b", 3.0))) ==> Nested(Baz(1, "b", 3.0, 4, "e", 6.0))
+
+      Transformer
+        .define[Nested[Nested[Foo[Double]]], Nested[Nested[Baz[Double]]]]
+        .withFallbackFrom(_.value)(Nested(Bar(4, "e", 6.0)))
+        .buildTransformer
+        .transform(Nested(Nested(Foo(1, "b", 3.0)))) ==> Nested(Nested(Baz(1, "b", 3.0, 4, "e", 6.0)))
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalMergingSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalMergingSealedHierarchySpec.scala
@@ -3,9 +3,9 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 
-class TotalMergingSealedHiearchySpec extends ChimneySpec {
+class TotalMergingSealedHierarchySpec extends ChimneySpec {
 
-  import TotalMergingSealedHiearchySpec.*
+  import TotalMergingSealedHierarchySpec.*
 
   group("setting .withFallback(fallbackValue)") {
 
@@ -51,7 +51,7 @@ class TotalMergingSealedHiearchySpec extends ChimneySpec {
     }
   }
 }
-object TotalMergingSealedHiearchySpec {
+object TotalMergingSealedHierarchySpec {
 
   sealed trait Foo extends Product with Serializable
   object Foo {

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerCustomConstructorSpec.scala
@@ -84,6 +84,23 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
       result.id ==> "id"
       result.name ==> "name"
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+      Transformer
+        .define[Foo, Bar]
+        .withConstructor(uncurriedConstructor _)
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14))) ==> Bar(6, (6.28, 6.28))
+      Transformer
+        .define[Foo, Bar]
+        .withConstructor((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(Foo(3, "pi", (3.14, 3.14))) ==> Bar(6, (6.28, 6.28))
+    }
   }
 
   group("setting .withConstructorTo(_.field)(fn)") {
@@ -166,6 +183,23 @@ class TotalTransformerCustomConstructorSpec extends ChimneySpec {
       val result = NestedProduct(new ClassSource("id", "name")).transformInto[NestedProduct[TraitSource]]
       result.value.id ==> "id"
       result.value.name ==> "name"
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}, nestedpath.*
+
+      def uncurriedConstructor(x: Int, z: (Double, Double)): Bar = Bar(x * 2, (z._1 * 2, z._2 * 2))
+
+      Transformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorTo(_.value)(uncurriedConstructor _)
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14)))) ==> NestedProduct(Bar(6, (6.28, 6.28)))
+      Transformer
+        .define[NestedProduct[Foo], NestedProduct[Bar]]
+        .withConstructorTo(_.value)((x: Int, z: (Double, Double)) => uncurriedConstructor(x, z))
+        .buildTransformer
+        .transform(NestedProduct(Foo(3, "pi", (3.14, 3.14)))) ==> NestedProduct(Bar(6, (6.28, 6.28)))
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeanSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerJavaBeanSpec.scala
@@ -93,7 +93,7 @@ class TotalTransformerJavaBeanSpec extends ChimneySpec {
     }
   }
 
-  group("""settings .withField*(_.getTo, ...) and .withFieldRenamed(_.from, _.getTo)""") {
+  group("""setting .withField*(_.getTo, ...) and .withFieldRenamed(_.from, _.getTo)""") {
 
     test("transform case class to Java Bean, allowing using getters as a way to rename into matching setters") {
       val source = CaseClassWithFlagRenamed("test-id", "test-name", renamedFlag = true)

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -178,6 +178,21 @@ class TotalTransformerProductSpec extends ChimneySpec {
         )
         .transform ==> NestedADT.Foo(Renames.UserPLStd(1, "Kuba", Some(28)))
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      Transformer
+        .define[Bar, Foo]
+        .withFieldConst(_.y, "pi")
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14))) ==> Foo(3, "pi", (3.14, 3.14))
+      Transformer
+        .define[Bar, Foo]
+        .withFieldConst(cc => cc.y, "pi")
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14))) ==> Foo(3, "pi", (3.14, 3.14))
+    }
   }
 
   group("setting .withFieldComputed(_.field, source => value)") {
@@ -281,6 +296,21 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .withFieldComputed(_.everyItem.matching[NestedADT.Foo[User]].foo.age, _ => 20)
         .withFieldComputed(_.everyItem.matching[NestedADT.Bar[User]].bar.age, _ => 30)
         .transform ==> Vector(NestedADT.Foo(User("John", 20, 140)), NestedADT.Bar(User("John", 30, 140)))
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      Transformer
+        .define[Bar, Foo]
+        .withFieldComputed(_.y, _.x.toString)
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14))) ==> Foo(3, "3", (3.14, 3.14))
+      Transformer
+        .define[Bar, Foo]
+        .withFieldComputed(cc => cc.y, _.x.toString)
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14))) ==> Foo(3, "3", (3.14, 3.14))
     }
   }
 
@@ -395,6 +425,21 @@ class TotalTransformerProductSpec extends ChimneySpec {
           _ * 3
         )
         .transform ==> Vector(NestedADT.Foo(User("John", 20, 140)), NestedADT.Bar(User("John", 30, 140)))
+    }
+
+    test("should work with semiautomatic derivation") {
+      import products.{Foo, Bar}
+
+      Transformer
+        .define[Bar, Foo]
+        .withFieldComputedFrom(_.x)(_.y, a => a.toString)
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14))) ==> Foo(3, "3", (3.14, 3.14))
+      Transformer
+        .define[Bar, Foo]
+        .withFieldComputedFrom(aa => aa.x)(cc => cc.y, _.toString)
+        .buildTransformer
+        .transform(Bar(3, (3.14, 3.14))) ==> Foo(3, "3", (3.14, 3.14))
     }
   }
 
@@ -663,6 +708,17 @@ class TotalTransformerProductSpec extends ChimneySpec {
         )
       }
     }
+
+    test("should work with semiautomatic derivation") {
+      import products.Renames.*
+
+      Transformer
+        .define[User, UserPLStd]
+        .withFieldRenamed(_.name, _.imie)
+        .withFieldRenamed(_.age, _.wiek)
+        .buildTransformer
+        .transform(User(1, "Kuba", Some(28))) ==> UserPLStd(1, "Kuba", Some(28))
+    }
   }
 
   group("setting .withFieldUnused(_.from)") {
@@ -694,6 +750,17 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .withFieldUnused(_.y)
         .enableUnusedFieldPolicyCheck(FailOnIgnoredSourceVal)
         .transform ==> Bar(10, (1, 2))
+    }
+
+    test("should work with semiautomatic derivation") {
+
+      Transformer
+        .define[Foo, Bar]
+        // FIXME: if we swap these 2 it's assertion error in -Xcheck-macros on Scala 3 o_0
+        .withFieldUnused(_.y)
+        .enableUnusedFieldPolicyCheck(FailOnIgnoredSourceVal)
+        .buildTransformer
+        .transform(Foo(10, "test", (1, 2))) ==> Bar(10, (1, 2))
     }
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSealedHierarchySpec.scala
@@ -202,6 +202,32 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
         List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
       )
     }
+
+    test("should work with semiautomatic derivation") {
+      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
+        colors1.Red
+
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Black) ==> colors1.Red
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Red) ==> colors1.Red
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Green) ==> colors1.Green
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withSealedSubtypeHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Blue) ==> colors1.Blue
+    }
   }
 
   group("setting .withEnumCaseHandled[Subtype](mapping)") {
@@ -277,9 +303,35 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
         List(shapes2.Point(0, 0), shapes2.Point(0, 4), shapes2.Point(6, 4), shapes2.Point(6, 0))
       )
     }
+
+    test("should work with semiautomatic derivation") {
+      def blackIsRed(@unused b: colors2.Black.type): colors1.Color =
+        colors1.Red
+
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Black) ==> colors1.Red
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Red) ==> colors1.Red
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Green) ==> colors1.Green
+      Transformer
+        .define[colors2.Color, colors1.Color]
+        .withEnumCaseHandled(blackIsRed)
+        .buildTransformer
+        .transform(colors2.Blue) ==> colors1.Blue
+    }
   }
 
-  group("settings .withSealedSubtypeRenamed[FromSubtype, ToSubtype]") {
+  group("setting .withSealedSubtypeRenamed[FromSubtype, ToSubtype]") {
 
     import fixtures.renames.Subtypes.*
 
@@ -302,9 +354,23 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
       (Foo3.Baz: Foo3).into[Bar].withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
       (Foo3.Bazz: Foo3).into[Bar].withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
     }
+
+    test("should work with semiautomatic derivation") {
+
+      Transformer
+        .define[Foo3, Bar]
+        .withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Baz) ==> Bar.Baz
+      Transformer
+        .define[Foo3, Bar]
+        .withSealedSubtypeRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Bazz) ==> Bar.Baz
+    }
   }
 
-  group("settings .withEnumCaseRenamed[FromSubtype, ToSubtype]") {
+  group("setting .withEnumCaseRenamed[FromSubtype, ToSubtype]") {
 
     import fixtures.renames.Subtypes.*
 
@@ -312,6 +378,20 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
 
       (Foo3.Baz: Foo3).into[Bar].withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
       (Foo3.Bazz: Foo3).into[Bar].withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type].transform ==> Bar.Baz
+    }
+
+    test("transform sealed hierarchy's subtype into user-provided subtype") {
+
+      Transformer
+        .define[Foo3, Bar]
+        .withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Baz) ==> Bar.Baz
+      Transformer
+        .define[Foo3, Bar]
+        .withEnumCaseRenamed[Foo3.Bazz.type, Bar.Baz.type]
+        .buildTransformer
+        .transform(Foo3.Bazz) ==> Bar.Baz
     }
   }
 
@@ -347,6 +427,17 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
         .enableUnmatchedSubtypePolicyCheck(FailOnUnmatchedTargetSubtype)
         .transform ==> colors2.Red
     }
+
+    test("should work with semiautomatic derivation") {
+
+      Transformer
+        .define[colors1.Color, colors2.Color]
+        // FIXME: if we swap these 2 it's assertion error in -Xcheck-macros on Scala 3 o_0
+        .withSealedSubtypeUnmatched(_.matching[colors2.Black.type])
+        .enableUnmatchedSubtypePolicyCheck(FailOnUnmatchedTargetSubtype)
+        .buildTransformer
+        .transform(colors1.Red) ==> colors2.Red
+    }
   }
 
   group("setting .withEnumCaseUnmatched(_.from)") {
@@ -380,6 +471,17 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
         .withEnumCaseUnmatched(_.matching[colors2.Black.type])
         .enableUnmatchedSubtypePolicyCheck(FailOnUnmatchedTargetSubtype)
         .transform ==> colors2.Red
+    }
+
+    test("should work with semiautomatic derivation") {
+
+      Transformer
+        .define[colors1.Color, colors2.Color]
+        // FIXME: if we swap these 2 it's assertion error in -Xcheck-macros on Scala 3 o_0
+        .withEnumCaseUnmatched(_.matching[colors2.Black.type])
+        .enableUnmatchedSubtypePolicyCheck(FailOnUnmatchedTargetSubtype)
+        .buildTransformer
+        .transform(colors1.Red) ==> colors2.Red
     }
   }
 
@@ -475,7 +577,7 @@ class TotalTransformerSealedHierarchySpec extends ChimneySpec {
     }
   }
 
-  group("settings .withFieldRenamed(selectorFrom, selectorTo)") {
+  group("setting .withFieldRenamed(selectorFrom, selectorTo)") {
 
     import fixtures.renames.Subtypes.*
 


### PR DESCRIPTION
1. Test macros for `.with*` methods in `TransformerDefinition`, `PartialTransformerDefinition` and `PatcherDefinition`
2. Fix error in 1 macro on Scala 3