### PR TITLE
fix: enable UUID field overrides with patch

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/DerivationPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/DerivationPlatform.scala
@@ -34,9 +34,9 @@ private[compiletime] trait DerivationPlatform
     TransformEitherToEitherRule,
     TransformMapToMapRule,
     TransformIterableToIterableRule,
+    TransformSubtypesRule,
     PatchProductWithProductRule,
     TransformSealedHierarchyToSealedHierarchyRule,
-    TransformSubtypesRule,
     PatchNotMatchedRule
   )
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/DerivationPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/DerivationPlatform.scala
@@ -34,9 +34,9 @@ abstract private[compiletime] class DerivationPlatform(q: scala.quoted.Quotes)
     TransformEitherToEitherRule,
     TransformMapToMapRule,
     TransformIterableToIterableRule,
+    TransformSubtypesRule,
     PatchProductWithProductRule,
     TransformSealedHierarchyToSealedHierarchyRule,
-    TransformSubtypesRule,
     PatchNotMatchedRule
   )
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -22,6 +22,10 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       // From is checked after To, because extraction always succeeds
       (Type[To], Type[From]) match {
+        case (l, r) if r <:< l && ctx.config.areLocalFlagsAndOverridesEmpty =>
+          DerivationResult.attemptNextRuleBecause(
+            s"Type ${Type.prettyPrint[From]} <:< ${Type.prettyPrint[To]}. Falling back to TransformSubtypesRule"
+          )
         case (HasCustomConstructor(constructorOverride), Product.Extraction(fromExtractors)) =>
           mapOverridesAndExtractorsToConstructorArguments[From, To](fromExtractors, constructorOverride)
         case (Product.Constructor(parameters, constructor), Product.Extraction(fromExtractors)) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -22,10 +22,6 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
     def expand[From, To](implicit ctx: TransformationContext[From, To]): DerivationResult[Rule.ExpansionResult[To]] =
       // From is checked after To, because extraction always succeeds
       (Type[To], Type[From]) match {
-        case (l, r) if r <:< l && ctx.config.areLocalFlagsAndOverridesEmpty =>
-          DerivationResult.attemptNextRuleBecause(
-            s"Type ${Type.prettyPrint[From]} <:< ${Type.prettyPrint[To]}. Falling back to TransformSubtypesRule"
-          )
         case (HasCustomConstructor(constructorOverride), Product.Extraction(fromExtractors)) =>
           mapOverridesAndExtractorsToConstructorArguments[From, To](fromExtractors, constructorOverride)
         case (Product.Constructor(parameters, constructor), Product.Extraction(fromExtractors)) =>

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherProductSpec.scala
@@ -3,7 +3,6 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 
-import java.util.UUID
 import scala.annotation.unused
 
 class PatcherProductSpec extends ChimneySpec {
@@ -20,18 +19,27 @@ class PatcherProductSpec extends ChimneySpec {
   }
 
   test(
-    """patch an product type object with a product type patch object containing a "subset" of fields including a UUID"""
+    """patch an product type object with a product type patch object containing a non-self-transformable pojo"""
   ) {
-    case class Foo(id: Int, externalReference: UUID)
-    case class Bar(externalReference: UUID)
+    object UUIDish {
+      def randomUUID(): UUIDish = {
+        val ng = scala.util.Random
+        new UUIDish(ng.nextLong(), ng.nextLong())
+      }
+    }
+    class UUIDish(mostSigBits: Long, leastSigBits: Long) {
+      override def toString: String = s"$mostSigBits::$leastSigBits"
+    }
+    case class Foo(id: Int, externalReference: UUIDish)
+    case class Bar(externalReference: UUIDish)
 
-    val uuid1 = UUID.randomUUID()
-    val uuid2 = UUID.randomUUID()
+    val uuid1 = UUIDish.randomUUID()
+    val uuid2 = UUIDish.randomUUID()
     val foo = Foo(42, uuid1)
     val bar = Bar(uuid2)
 
-    foo.patchUsing(bar) ==> Foo(42, uuid2)
     foo.using(bar).patch ==> Foo(42, uuid2)
+    foo.patchUsing(bar) ==> Foo(42, uuid2)
   }
 
   test(

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherProductSpec.scala
@@ -3,6 +3,7 @@ package io.scalaland.chimney
 import io.scalaland.chimney.dsl.*
 import io.scalaland.chimney.fixtures.*
 
+import java.util.UUID
 import scala.annotation.unused
 
 class PatcherProductSpec extends ChimneySpec {
@@ -16,6 +17,21 @@ class PatcherProductSpec extends ChimneySpec {
 
     foo.patchUsing(bar) ==> Foo(10, "", 10.0)
     foo.using(bar).patch ==> Foo(10, "", 10.0)
+  }
+
+  test(
+    """patch an product type object with a product type patch object containing a "subset" of fields including a UUID"""
+  ) {
+    case class Foo(id: Int, externalReference: UUID)
+    case class Bar(externalReference: UUID)
+
+    val uuid1 = UUID.randomUUID()
+    val uuid2 = UUID.randomUUID()
+    val foo = Foo(42, uuid1)
+    val bar = Bar(uuid2)
+
+    foo.patchUsing(bar) ==> Foo(42, uuid2)
+    foo.using(bar).patch ==> Foo(42, uuid2)
   }
 
   test(


### PR DESCRIPTION
There seems to have been a regression in the 1.7.x release, where patching a UUID field failed compilation. The problem is not limited to UUIDs, but applies to patches where a field is any pojo class with a single constructor and no matching accessors.

The fix I've proposed here is not an elegant one, but it does seem to work; the basic approach is just to forbid TransformProductToProductRule from applying where From <:< To