### PR TITLE
Cache utilities results

### DIFF
--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -17,10 +17,13 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
       sym.isClass && sym.asClass.isSealed
     }
 
-    def parse[A: Type]: Option[Enum[A]] =
+    private type Cached[A] = Option[Enum[A]]
+    private val enumCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Enum[A]] = enumCache(Type[A]) {
       if (isJavaEnum[A]) Some(symbolsToEnum(extractJavaEnumInstances[A]))
       else if (isSealed[A]) Some(symbolsToEnum(extractSealedSubtypes[A]))
       else None
+    }
 
     private def extractJavaEnumInstances[A: Type]: List[(String, ?<[A])] =
       Type[A].tpe.companion.decls

--- a/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-2/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -11,7 +11,9 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
 
   protected object WrapperClassType extends WrapperClassTypeModule {
 
-    def parse[A: Type]: Option[Existential[WrapperClass[A, *]]] = {
+    private type Cached[A] = Option[Existential[WrapperClass[A, *]]]
+    private val wrapperClassCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Existential[WrapperClass[A, *]]] = wrapperClassCache(Type[A]) {
       val A = Type[A].tpe
       forceTypeSymbolInitialization[A]
 

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ExprsPlatform.scala
@@ -152,7 +152,9 @@ private[compiletime] trait ExprsPlatform extends Exprs { this: DefinitionsPlatfo
     def block[A: Type](statements: List[Expr[Unit]], expr: Expr[A]): Expr[A] =
       Block(statements.map(_.asTerm), expr.asTerm).asExprOf[A]
 
-    def summonImplicit[A: Type]: Option[Expr[A]] = scala.quoted.Expr.summon[A]
+    private type OptionExpr[A] = Option[Expr[A]]
+    private val implicitCache = new Type.Cache[OptionExpr]
+    def summonImplicit[A: Type]: Option[Expr[A]] = implicitCache(Type[A])(scala.quoted.Expr.summon[A])
 
     def nowarn[A: Type](warnings: Option[String])(expr: Expr[A]): Expr[A] = {
       val annotationSymbol: Symbol = TypeRepr.of[scala.annotation.nowarn].typeSymbol

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchiesPlatform.scala
@@ -17,10 +17,13 @@ trait SealedHierarchiesPlatform extends SealedHierarchies { this: DefinitionsPla
       flags.is(Flags.Sealed) // do NOT use flags.is(Flags.Enum) since it will also match enums cases!
     }
 
-    def parse[A: Type]: Option[Enum[A]] =
+    private type Cached[A] = Option[Enum[A]]
+    private val enumCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Enum[A]] = enumCache(Type[A]) {
       // no need for separate java.lang.Enum handling contrary to Scala 2
       if isSealed[A] then Some(symbolsToEnum(extractSealedSubtypes[A]))
       else None
+    }
 
     implicit private val order: Ordering[Symbol] = Ordering
       .Option(Ordering.fromLessThan[Position] { (a, b) =>

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ValueClassesPlatform.scala
@@ -9,7 +9,9 @@ trait ValueClassesPlatform extends ValueClasses { this: DefinitionsPlatform =>
 
   protected object WrapperClassType extends WrapperClassTypeModule {
 
-    def parse[A: Type]: Option[Existential[WrapperClass[A, *]]] = {
+    private type Cached[A] = Option[Existential[WrapperClass[A, *]]]
+    private val wrapperClassCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Existential[WrapperClass[A, *]]] = wrapperClassCache(Type[A]) {
       val A: TypeRepr = TypeRepr.of[A]
       val sym: Symbol = A.typeSymbol
 

--- a/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ValueClasses.scala
+++ b/chimney-macro-commons/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ValueClasses.scala
@@ -35,7 +35,9 @@ trait ValueClasses { this: Definitions =>
   }
 
   protected object ValueClassType {
-    def parse[A: Type]: Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]] =
+    private type Cached[A] = Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]]
+    private val valueClassCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]] = valueClassCache(Type[A]) {
       if (Type[A].isAnyVal)
         WrapperClassType.parse[A].map {
           _.asInstanceOf[Existential.UpperBounded[AnyVal, WrapperClass[A, *]]].mapK[ValueClass[A, *]] { _ =>
@@ -45,6 +47,7 @@ trait ValueClasses { this: Definitions =>
           }
         }
       else None
+    }
     def unapply[A](tpe: Type[A]): Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]] = parse(tpe)
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/OptionalValues.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/OptionalValues.scala
@@ -25,8 +25,10 @@ trait OptionalValues { this: Derivation =>
   }
   protected object OptionalValue {
 
+    private type Cached[A] = Option[Existential[OptionalValue[A, *]]]
+    private val optionalCache = new Type.Cache[Cached]
     def unapply[Optional](implicit Optional: Type[Optional]): Option[Existential[OptionalValue[Optional, *]]] =
-      providedSupport[Optional].orElse(buildInOptionSupport[Optional])
+      optionalCache(Optional)(providedSupport[Optional].orElse(buildInOptionSupport[Optional]))
 
     private def providedSupport[Optional: Type]: Option[Existential[OptionalValue[Optional, *]]] =
       summonOptionalValue[Optional].map { optionalValue =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartialOuterTransformers.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartialOuterTransformers.scala
@@ -6,6 +6,8 @@ import io.scalaland.chimney.partial
 
 trait PartialOuterTransformers { this: Derivation =>
 
+  import ChimneyType.Implicits.*
+
   abstract protected class PartialOuterTransformer[From: Type, To: Type] {
     type InnerFrom
     implicit val InnerFrom: Type[InnerFrom]
@@ -30,7 +32,11 @@ trait PartialOuterTransformers { this: Derivation =>
   }
   protected object PartialOuterTransformer {
 
+    private val implicitCache = new Type.Cache[Option]
     def unapply[From, To](implicit from: Type[From], to: Type[To]): Option[PartialOuterTransformer[From, To]] =
-      summonPartialOuterTransformer[From, To]
+      implicitCache(
+        Type[integrations.PartialOuterTransformer[From, To, From, To]]
+          .asInstanceOf[Type[PartialOuterTransformer[From, To]]]
+      )(summonPartialOuterTransformer[From, To])
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartiallyBuildIterables.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartiallyBuildIterables.scala
@@ -34,8 +34,10 @@ trait PartiallyBuildIterables { this: Derivation =>
   }
   protected object PartiallyBuildIterable {
 
+    private type Cached[M] = Option[Existential[PartiallyBuildIterable[M, *]]]
+    private val partiallyBulidIterableCache = new Type.Cache[Cached]
     def unapply[M](implicit M: Type[M]): Option[Existential[PartiallyBuildIterable[M, *]]] =
-      providedSupport[M]
+      partiallyBulidIterableCache(M)(providedSupport[M])
 
     private def providedSupport[Collection: Type]: Option[Existential[PartiallyBuildIterable[Collection, *]]] =
       summonPartiallyBuildIterable[Collection].map { partiallyBuildIterable =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
@@ -6,6 +6,8 @@ import io.scalaland.chimney.partial
 
 trait TotalOuterTransformers { this: Derivation =>
 
+  import ChimneyType.Implicits.*
+
   abstract protected class TotalOuterTransformer[From: Type, To: Type] {
     type InnerFrom
     implicit val InnerFrom: Type[InnerFrom]
@@ -28,7 +30,10 @@ trait TotalOuterTransformers { this: Derivation =>
   }
   protected object TotalOuterTransformer {
 
+    private val implicitCache = new Type.Cache[Option]
     def unapply[From, To](implicit from: Type[From], to: Type[To]): Option[TotalOuterTransformer[From, To]] =
-      summonTotalOuterTransformer[From, To]
+      implicitCache(
+        Type[integrations.TotalOuterTransformer[From, To, From, To]].asInstanceOf[Type[TotalOuterTransformer[From, To]]]
+      )(summonTotalOuterTransformer[From, To])
   }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyBuildIterables.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyBuildIterables.scala
@@ -35,8 +35,10 @@ trait TotallyBuildIterables { this: Derivation =>
   }
   protected object TotallyBuildIterable {
 
+    private type Cached[M] = Option[Existential[TotallyBuildIterable[M, *]]]
+    private val totallyBulidIterableCache = new Type.Cache[Cached]
     def unapply[M](implicit M: Type[M]): Option[Existential[TotallyBuildIterable[M, *]]] =
-      providedSupport[M].orElse(buildInSupport[M])
+      totallyBulidIterableCache(M)(providedSupport[M].orElse(buildInSupport[M]))
 
     private def providedSupport[Collection: Type]: Option[Existential[TotallyBuildIterable[Collection, *]]] =
       summonTotallyBuildIterable[Collection].map { totallyBuildIterable =>


### PR DESCRIPTION
Caching inside a macro:
 - summoning `Transformer`s/`PartialTransformer`s/`OuterTransformer`s
 - resolving `IterableOrArray`/`ProductType`/`SealedHierchies`/`ValueTypes`
 - resolving `OptionalValue`/`TotallyBuildIterable`/`PartiallyBuildIterable`

The change is not tremendous but we can try it and ask for feedback - I cannot see _regression_ in compile time, so it should be safe (at least not harmful).