### PR TITLE
add ignore prefix names comparison

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -49,6 +49,19 @@ object TransformedNamesComparison {
     def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
   }
 
+  /** Matches Strings ignoring given prefix.
+    *
+    * usage: case object FooNamesComparison extends IgnorePrefixNamesComparison("Foo")
+    *
+    * motivation: https://buf.build/blog/totw-3-enum-names-need-prefixes
+    */
+  sealed abstract class IgnorePrefix(prefix: String) extends TransformedNamesComparison {
+    this: Singleton =>
+
+    def namesMatch(fromName: String, toName: String): Boolean =
+      fromName == prefix + toName
+  }
+
   type FieldDefault = BeanAware.type
   val FieldDefault: FieldDefault = BeanAware
 


### PR DESCRIPTION
Adds a new `IgnorePrefix` name matching strategy to `TransformedNamesComparison`, letting users match source names to target names by stripping a shared prefix from the source side.

## Motivation

Protobuf-generated enums (and similar code-generated types) commonly prefix every variant with the enum name to avoid collisions at the package level — e.g. `FooBar`, `FooBaz` for an enum `Foo`. See [Buf's "enum names need prefixes" post](https://buf.build/blog/totw-3-enum-names-need-prefixes) for the rationale.

When transforming such generated types into domain ADTs whose cases are written without the redundant prefix (`Bar`, `Baz`), neither `StrictEquality` nor `CaseInsensitiveEquality` matches. Users currently have to write a custom `TransformedNamesComparison` for every such enum.

## Changes

- New `sealed abstract class IgnorePrefix(prefix: String) extends TransformedNamesComparison`
  in `TransformedNamesComparison.scala`.

## Usage

```
case object FooNamesComparison extends IgnorePrefix("Foo")
```