### PR TITLE
Fix #857: resolve path-dependent types in inline def reuse for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -234,7 +234,10 @@ val settings = Seq(
     )
   ),
   Test / compile / scalacOptions ++= versions.fold(scalaVersion.value)(
-    for3 = Seq("-Wconf:msg=unused local definition:s"), // silence warn that appears since 3.3.7
+    for3 = Seq(
+      "-Wconf:msg=unused local definition:s", // silence warn that appears since 3.3.7
+      "-Wconf:msg=with as a type operator has been deprecated:s" // silence deprecation of `with` in Scala 3.4+
+    ),
     for2_13 = Seq.empty,
     for2_12 = Seq.empty
   ),

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -100,8 +100,16 @@ object TransformerMacros {
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]]
-  )(using quotes: Quotes): Expr[Transformer[From, To]] =
-    new TransformerMacros(quotes).deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags](td)
+  )(using quotes: Quotes): Expr[Transformer[From, To]] = {
+    val (overridesType, flagsType) = resolveOverridesAndFlagsTypes(td)
+    (overridesType, flagsType) match {
+      case ('[o], '[f]) =>
+        new TransformerMacros(quotes)
+          .deriveTotalTransformerWithConfig[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags, ImplicitScopeFlags](
+            td.asInstanceOf[Expr[TransformerDefinition[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags]]]
+          )
+    }
+  }
 
   final def deriveTotalTransformerResultWithConfig[
       From: Type,
@@ -109,11 +117,17 @@ object TransformerMacros {
       Overrides <: runtime.TransformerOverrides: Type,
       Flags <: runtime.TransformerFlags: Type,
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
-  ](source: Expr[From], td: Expr[TransformerDefinition[From, To, Overrides, Flags]])(using quotes: Quotes): Expr[To] =
-    new TransformerMacros(quotes).deriveTotalTransformationResult[From, To, Overrides, Flags, ImplicitScopeFlags](
-      source,
-      '{ $td.runtimeData }
-    )
+  ](source: Expr[From], td: Expr[TransformerDefinition[From, To, Overrides, Flags]])(using quotes: Quotes): Expr[To] = {
+    val (overridesType, flagsType) = resolveOverridesAndFlagsTypes(td)
+    (overridesType, flagsType) match {
+      case ('[o], '[f]) =>
+        val typedTd = td.asInstanceOf[Expr[TransformerDefinition[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags]]]
+        new TransformerMacros(quotes).deriveTotalTransformationResult[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags, ImplicitScopeFlags](
+          source,
+          '{ $typedTd.runtimeData }
+        )
+    }
+  }
 
   final def derivePartialTransformerWithDefaults[
       From: Type,
@@ -129,8 +143,16 @@ object TransformerMacros {
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]]
-  )(using quotes: Quotes): Expr[PartialTransformer[From, To]] =
-    new TransformerMacros(quotes).derivePartialTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags](td)
+  )(using quotes: Quotes): Expr[PartialTransformer[From, To]] = {
+    val (overridesType, flagsType) = resolveOverridesAndFlagsTypes(td)
+    (overridesType, flagsType) match {
+      case ('[o], '[f]) =>
+        new TransformerMacros(quotes)
+          .derivePartialTransformerWithConfig[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags, ImplicitScopeFlags](
+            td.asInstanceOf[Expr[PartialTransformerDefinition[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags]]]
+          )
+    }
+  }
 
   final def derivePartialTransformerResultWithConfig[
       From: Type,
@@ -140,10 +162,95 @@ object TransformerMacros {
       ImplicitScopeFlags <: runtime.TransformerFlags: Type
   ](source: Expr[From], td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]], failFast: Boolean)(using
       quotes: Quotes
-  ): Expr[partial.Result[To]] =
-    new TransformerMacros(quotes).derivePartialTransformationResult[From, To, Overrides, Flags, ImplicitScopeFlags](
-      source,
-      Expr(failFast),
-      '{ $td.runtimeData }
-    )
+  ): Expr[partial.Result[To]] = {
+    val (overridesType, flagsType) = resolveOverridesAndFlagsTypes(td)
+    (overridesType, flagsType) match {
+      case ('[o], '[f]) =>
+        val typedTd = td.asInstanceOf[Expr[PartialTransformerDefinition[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags]]]
+        new TransformerMacros(quotes).derivePartialTransformationResult[From, To, o & runtime.TransformerOverrides, f & runtime.TransformerFlags, ImplicitScopeFlags](
+          source,
+          Expr(failFast),
+          '{ $typedTd.runtimeData }
+        )
+    }
+  }
+
+  // When inline def methods are chained (e.g. .withFieldConst(...).enableDefaultValues.buildTransformer)
+  // inside another inline def, the Scala 3 compiler may represent Overrides/Flags as path-dependent types
+  // (e.g. TransformerDefinition_this.Overrides) rather than resolving them to their concrete forms.
+  // We resolve these by extracting actual type arguments from the 'this' expression's widened type. (see #857)
+  private def resolveOverridesAndFlagsTypes(td: Expr[?])(using quotes: Quotes): (Type[?], Type[?]) = {
+    import quotes.reflect.*
+
+    def extractAllArgs(tpe: TypeRepr): Option[(Type[?], Type[?])] = {
+      val args = tpe.dealias.typeArgs
+      if (args.length >= 4) {
+        // Both Overrides (index 2) and Flags (index 3) must be concrete (not TypeBounds/wildcards)
+        (args(2), args(3)) match {
+          case (_: TypeBounds, _) | (_, _: TypeBounds) => None
+          case _                                       => Some((args(2).asType, args(3).asType))
+        }
+      } else None
+    }
+
+    val term = td.asTerm
+    val widened = term.tpe.widen
+
+    // Try direct type args first (common case when types are concrete)
+    extractAllArgs(widened)
+      .orElse {
+        // For inline def reuse (#857), the widened type may have wildcards for Overrides
+        // (e.g. TransformerDefinition[..., ? <: TransformerOverrides, ...].UpdateFlag[...]).
+        // Strategy: extract Flags from the base type (it's concrete even when Overrides isn't),
+        // and extract Overrides by inspecting the val definition's RHS tree.
+        val tdClassSym = TypeRepr.of[TransformerDefinition[?, ?, ?, ?]].typeSymbol
+        val ptdClassSym = TypeRepr.of[PartialTransformerDefinition[?, ?, ?, ?]].typeSymbol
+
+        // Get Flags from base type (args(3) is usually concrete)
+        val flagsFromBaseType: Option[Type[?]] = widened.baseClasses.iterator
+          .filter(cls => cls == tdClassSym || cls == ptdClassSym)
+          .map(cls => widened.baseType(cls).typeArgs)
+          .collectFirst { case args if args.length >= 4 && !args(3).match { case TypeBounds(_, _) => true; case _ => false } =>
+            args(3).asType
+          }
+
+        // Get Overrides from the val definition's RHS tree
+        val overridesFromTree: Option[Type[?]] = {
+          val inner = term match { case Inlined(_, _, i) => i; case t => t }
+          val sym = inner.symbol
+          if (sym.isValDef) {
+            sym.tree match {
+              case ValDef(_, _, Some(rhs)) =>
+                def findOverrides(t: Tree): Option[Type[?]] = t match {
+                  case Select(qualifier, _) =>
+                    val qTpe = qualifier.asInstanceOf[Term].tpe.widen.dealias
+                    val args = qTpe.typeArgs
+                    if (args.length >= 4 && !args(2).match { case TypeBounds(_, _) => true; case _ => false }) Some(args(2).asType)
+                    else findOverrides(qualifier)
+                  case Inlined(_, _, inner) => findOverrides(inner)
+                  case Block(_, expr)       => findOverrides(expr)
+                  case TypeApply(inner, _) =>
+                    val tTpe = t.asInstanceOf[Term].tpe.widen.dealias
+                    val args = tTpe.typeArgs
+                    if (args.length >= 4 && !args(2).match { case TypeBounds(_, _) => true; case _ => false }) Some(args(2).asType)
+                    else findOverrides(inner)
+                  case _ => None
+                }
+                findOverrides(rhs)
+              case _ => None
+            }
+          } else None
+        }
+
+        for {
+          overrides <- overridesFromTree
+          flags <- flagsFromBaseType
+        } yield (overrides, flags)
+      }
+      .getOrElse {
+        report.errorAndAbort(
+          s"Could not resolve Overrides and Flags type arguments from: ${term.tpe.show}"
+        )
+      }
+  }
 }

--- a/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala
@@ -58,6 +58,23 @@ class IssuesScala3Spec extends ChimneySpec {
     Request("abc", true).transformInto[(String, Boolean)] ==> ("abc", true)
   }
 
+  group("fix issue #857 (inline def reuse with enableDefaultValues)") {
+
+    test("generic inline transformer with enableDefaultValues should work") {
+      import io.scalaland.chimney.fixtures.Issue857.*
+
+      val userHydrator: EntityHydrator[CreateUser, User] = EntityHydrator.make[CreateUser, User]
+      userHydrator.touch(CreateUser("joe shmoe")) ==> User(13, "joe shmoe")
+    }
+
+    test("generic inline transformer with enableDefaultValues and default values should work") {
+      import io.scalaland.chimney.fixtures.Issue857.*
+
+      val messageHydrator: EntityHydrator[CreateMessage, Message] = EntityHydrator.make[CreateMessage, Message]
+      messageHydrator.touch(CreateMessage("awesome message")) ==> Message(13, "awesome message", None)
+    }
+  }
+
   group("fix issue #835 (enableInheritedAccessors for scala 3)") {
 
     test("val") {

--- a/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/Issue.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/Issue.scala
@@ -1,5 +1,40 @@
 package io.scalaland.chimney.fixtures
 
+import io.scalaland.chimney.Transformer
+import io.scalaland.chimney.dsl.*
+
+object Issue857 {
+
+  trait Entity {
+    val id: Int
+  }
+
+  case class User(override val id: Int, name: String) extends Entity
+  case class CreateUser(name: String)
+
+  case class Message(override val id: Int, message: String, replyTo: Option[String] = None) extends Entity
+  case class CreateMessage(message: String)
+
+  trait EntityHydrator[C, E <: Entity] {
+    def touch(c: C): E
+  }
+
+  object EntityHydrator {
+    class EntityHydratorImpl[C, E <: Entity](t: Transformer[C, E]) extends EntityHydrator[C, E] {
+      override def touch(c: C): E = t.transform(c)
+    }
+
+    inline def make[C, E <: Entity]: EntityHydrator[C, E] = {
+      val transformer = Transformer
+        .define[C, E]
+        .withFieldConst(_.id, 13)
+        .enableDefaultValues
+        .buildTransformer
+      new EntityHydratorImpl[C, E](transformer)
+    }
+  }
+}
+
 object Issue835 {
   abstract class StatusEntity(val status: String)
 


### PR DESCRIPTION
When chimney DSL methods are chained inside an inline def (e.g. .withFieldConst(...).enableDefaultValues.buildTransformer), the Scala 3 compiler represents Overrides/Flags type parameters as path-dependent types (TransformerDefinition_this.Overrides) instead of resolving them to concrete forms. The macro's type pattern matching could not see through these.

The fix extracts actual type arguments from the 'this' expression's type at the macro entry point, falling back to inspecting the ValDef RHS tree when the widened type has wildcards.