### PR TITLE
Fix #832: add IsCollection evidence for OuterTransformer's From+Inner…

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/IsCollection.scala
@@ -31,6 +31,10 @@ private[runtime] trait IsCollectionImplicits0 extends IsCollectionImplicits1 { t
   implicit def totalOuterTransformerIsCollection[To, InnerTo](implicit
       @unused ev: TotalOuterTransformer[?, To, ?, InnerTo]
   ): IsCollection.Of[To, InnerTo] = Impl.asInstanceOf[IsCollection.Of[To, InnerTo]]
+
+  implicit def totalOuterTransformerIsCollectionFrom[From, InnerFrom](implicit
+      @unused ev: TotalOuterTransformer[From, ?, InnerFrom, ?]
+  ): IsCollection.Of[From, InnerFrom] = Impl.asInstanceOf[IsCollection.Of[From, InnerFrom]]
 }
 private[runtime] trait IsCollectionImplicits1 extends IsCollectionImplicits2 { this: IsCollection.type =>
 
@@ -38,6 +42,10 @@ private[runtime] trait IsCollectionImplicits1 extends IsCollectionImplicits2 { t
   implicit def partialOuterTransformerIsCollection[To, InnerTo](implicit
       @unused ev: PartialOuterTransformer[?, To, ?, InnerTo]
   ): IsCollection.Of[To, InnerTo] = Impl.asInstanceOf[IsCollection.Of[To, InnerTo]]
+
+  implicit def partialOuterTransformerIsCollectionFrom[From, InnerFrom](implicit
+      @unused ev: PartialOuterTransformer[From, ?, InnerFrom, ?]
+  ): IsCollection.Of[From, InnerFrom] = Impl.asInstanceOf[IsCollection.Of[From, InnerFrom]]
 }
 private[runtime] trait IsCollectionImplicits2 extends IsCollectionImplicits3 { this: IsCollection.type =>
 

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerIntegrationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerIntegrationsSpec.scala
@@ -86,6 +86,20 @@ class PartialTransformerIntegrationsSpec extends ChimneySpec {
     result2.asErrorPathMessageStrings ==> Iterable.empty
   }
 
+  test("transform using PartialOuterTransformer with .everyItem on source path (issue #832)") {
+    import OuterTransformers.partialNonEmptyToSorted
+    import fixtures.products.Renames.*
+
+    implicit val userPlStdOrdering: Ordering[UserPLStd] = Ordering[Int].on[UserPLStd](_.id)
+
+    val result = NonEmptyWrapper(User(1, "Kuba", Some(28)), User(2, "Artur", None))
+      .intoPartial[SortedWrapper[UserPLStd]]
+      .withFieldRenamed(_.everyItem.name, _.everyItem.imie)
+      .withFieldRenamed(_.everyItem.age, _.everyItem.wiek)
+      .transform
+    result.asOption ==> Some(SortedWrapper(UserPLStd(1, "Kuba", Some(28)), UserPLStd(2, "Artur", None)))
+  }
+
   test("transform using PartialOuterTransformer resolving total-partial-conflict") {
     import OuterTransformers.*
 

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerIntegrationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerIntegrationsSpec.scala
@@ -36,6 +36,19 @@ class TotalTransformerIntegrationsSpec extends ChimneySpec {
       .transform ==> SortedWrapper(Bar("c"))
   }
 
+  test("transform using TotalOuterTransformer with .everyItem on source path (issue #832)") {
+    import OuterTransformers.totalNonEmptyToSorted
+    import fixtures.products.Renames.*
+
+    implicit val userPlStdOrdering: Ordering[UserPLStd] = Ordering[Int].on[UserPLStd](_.id)
+
+    NonEmptyWrapper(User(1, "Kuba", Some(28)), User(2, "Artur", None))
+      .into[SortedWrapper[UserPLStd]]
+      .withFieldRenamed(_.everyItem.name, _.everyItem.imie)
+      .withFieldRenamed(_.everyItem.age, _.everyItem.wiek)
+      .transform ==> SortedWrapper(UserPLStd(1, "Kuba", Some(28)), UserPLStd(2, "Artur", None))
+  }
+
   test("transform from OptionalValue into OptionalValue") {
     Possible(Foo("a")).transformInto[Possible[Bar]] ==> Possible(Bar("a"))
     (Possible.Present(Foo("a")): Possible[Foo]).transformInto[Possible[Bar]] ==> Possible(Bar("a"))


### PR DESCRIPTION
…From

Previously, IsCollection only provided implicit evidence for the To+InnerTo side of TotalOuterTransformer/PartialOuterTransformer. This meant .everyItem could not be used on source-side fields whose collection nature comes from an OuterTransformer.

Add totalOuterTransformerIsCollectionFrom and
partialOuterTransformerIsCollectionFrom implicits at the same priority levels as the existing To-side ones.