### PR TITLE
Fix #772 ComputedPartialFailFast

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -193,7 +193,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputedPartialFailFast[T, U](
       selector: To => T,
@@ -259,7 +259,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputedPartialFromFailFast[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
@@ -437,7 +437,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withSealedSubtypeHandledPartialFailFast[Subtype](
       f: (Subtype, Boolean) => partial.Result[To]
@@ -447,7 +447,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withEnumCaseHandledPartialFailFast[Subtype](
       f: (Subtype, Boolean) => partial.Result[To]
@@ -688,7 +688,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withConstructorPartialFailFast[Ctor](
       f: Ctor
@@ -720,7 +720,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withConstructorPartialToFailFast[T, Ctor](selector: To => T)(
       f: Ctor

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -172,6 +172,35 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
 
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputedPartialFailFast[T, U](
+      selector: To => T,
+      f: (From, Boolean) => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withFieldComputedPartialFailFastImpl[From, To, Overrides, Flags]
+
   /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
     * with `selectorFrom` as an input.
     *
@@ -203,6 +232,40 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       f: S => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
+
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputedPartialFromFailFast[S, T, U](selectorFrom: From => S)(
+      selectorTo: To => T,
+      f: (S, Boolean) => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withFieldComputedPartialFromFailFastImpl[From, To, Overrides, Flags]
 
   /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
@@ -347,6 +410,50 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       f: Subtype => partial.Result[To]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialImpl[From, To, Overrides, Flags, Subtype]
+
+  /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    *
+    * For convenience/readability [[withEnumCaseHandledPartialFailFast]] alias can be used (e.g. for Scala 3 enums or
+    * Java enums).
+    *
+    * It differs from `withFieldComputedPartialFailFast(_.matching[Subtype], (src, failFast) => ...)`, since
+    * `withSealedSubtypeHandledPartialFailFast` matches on a `From` subtype, while `.matching[Subtype]` matches on a
+    * `To` value's piece.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
+    *   for more details
+    *
+    * @tparam Subtype
+    *   type of sealed/enum instance
+    * @param f
+    *   function to calculate values of components that cannot be mapped automatically
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  def withSealedSubtypeHandledPartialFailFast[Subtype](
+      f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros
+      .withSealedSubtypeHandledPartialFailFastImpl[From, To, Overrides, Flags, Subtype]
+
+  /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
+    *
+    * @since 1.7.0
+    */
+  def withEnumCaseHandledPartialFailFast[Subtype](
+      f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros
+      .withSealedSubtypeHandledPartialFailFastImpl[From, To, Overrides, Flags, Subtype]
 
   /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
@@ -561,6 +668,66 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       ev: IsFunction.Of[Ctor, partial.Result[T]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerDefinitionMacros.withConstructorPartialToImpl[From, To, Overrides, Flags]
+
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[To]`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[To]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  def withConstructorPartialFailFast[Ctor](
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, Boolean => partial.Result[To]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withConstructorPartialFailFastImpl[From, To, Overrides, Flags]
+
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  def withConstructorPartialToFailFast[T, Ctor](selector: To => T)(
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, Boolean => partial.Result[T]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionMacros.withConstructorPartialToFailFastImpl[From, To, Overrides, Flags]
 
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -177,6 +177,35 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags]
 
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputedPartialFailFast[T, U](
+      selector: To => T,
+      f: (From, Boolean) => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withFieldComputedPartialFailFastImpl[From, To, Overrides, Flags]
+
   /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
     * with `selectorFrom` as an input.
     *
@@ -208,6 +237,40 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       f: S => partial.Result[U]
   )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withFieldComputedPartialFromImpl[From, To, Overrides, Flags]
+
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputedPartialFromFailFast[S, T, U](selectorFrom: From => S)(
+      selectorTo: To => T,
+      f: (S, Boolean) => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withFieldComputedPartialFromFailFastImpl[From, To, Overrides, Flags]
 
   /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
@@ -350,6 +413,50 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       f: Subtype => partial.Result[To]
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withSealedSubtypeHandledPartialImpl[From, To, Overrides, Flags, Subtype]
+
+  /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    *
+    * For convenience/readability [[withEnumCaseHandledPartialFailFast]] alias can be used (e.g. for Scala 3 enums or
+    * Java enums).
+    *
+    * It differs from `withFieldComputedPartialFailFast(_.matching[Subtype], (src, failFast) => ...)`, since
+    * `withSealedSubtypeHandledPartialFailFast` matches on a `From` subtype, while `.matching[Subtype]` matches on a
+    * `To` value's piece.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
+    *   for more details
+    *
+    * @tparam Subtype
+    *   type of sealed/enum instance
+    * @param f
+    *   function to calculate values of components that cannot be mapped automatically
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  def withSealedSubtypeHandledPartialFailFast[Subtype](
+      f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros
+      .withSealedSubtypeHandledPartialFailFastImpl[From, To, Overrides, Flags, Subtype]
+
+  /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
+    *
+    * @since 1.7.0
+    */
+  def withEnumCaseHandledPartialFailFast[Subtype](
+      f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros
+      .withSealedSubtypeHandledPartialFailFastImpl[From, To, Overrides, Flags, Subtype]
 
   /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
@@ -563,6 +670,66 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       ev: IsFunction.Of[Ctor, partial.Result[T]]
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     macro PartialTransformerIntoMacros.withConstructorPartialToImpl[From, To, Overrides, Flags]
+
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[To]`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[To]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  def withConstructorPartialFailFast[Ctor](
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, Boolean => partial.Result[To]]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withConstructorPartialFailFastImpl[From, To, Overrides, Flags]
+
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  def withConstructorPartialToFailFast[T, Ctor](selector: To => T)(
+      f: Ctor
+  )(implicit
+      ev: IsFunction.Of[Ctor, Boolean => partial.Result[T]]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoMacros.withConstructorPartialToFailFastImpl[From, To, Overrides, Flags]
 
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -198,7 +198,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputedPartialFailFast[T, U](
       selector: To => T,
@@ -264,7 +264,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputedPartialFromFailFast[S, T, U](selectorFrom: From => S)(
       selectorTo: To => T,
@@ -440,7 +440,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withSealedSubtypeHandledPartialFailFast[Subtype](
       f: (Subtype, Boolean) => partial.Result[To]
@@ -450,7 +450,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withEnumCaseHandledPartialFailFast[Subtype](
       f: (Subtype, Boolean) => partial.Result[To]
@@ -690,7 +690,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withConstructorPartialFailFast[Ctor](
       f: Ctor
@@ -722,7 +722,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withConstructorPartialToFailFast[T, Ctor](selector: To => T)(
       f: Ctor

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -231,6 +231,31 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             )
           }
       }
+      object ComputedPartialFailFast extends ComputedPartialFailFastModule {
+        def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
+            : Type[runtime.TransformerOverrides.ComputedPartialFailFast[ToPath, Tail]] =
+          weakTypeTag[runtime.TransformerOverrides.ComputedPartialFailFast[ToPath, Tail]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.ComputedPartialFailFast[?, ?]].map { A0 =>
+            fixJavaEnums(A0.param_<[runtime.Path](0)) -> A0.param_<[runtime.TransformerOverrides](1)
+          }
+      }
+      object ComputedPartialFromFailFast extends ComputedPartialFromFailFastModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ComputedPartialFromFailFast[FromPath, ToPath, Tail]] =
+          weakTypeTag[runtime.TransformerOverrides.ComputedPartialFromFailFast[FromPath, ToPath, Tail]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.ComputedPartialFromFailFast[?, ?, ?]].map { A0 =>
+            (
+              fixJavaEnums(A0.param_<[runtime.Path](0)),
+              fixJavaEnums(A0.param_<[runtime.Path](1)),
+              A0.param_<[runtime.TransformerOverrides](2)
+            )
+          }
+      }
       object CaseComputed extends CaseComputedModule {
         def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
             : Type[runtime.TransformerOverrides.CaseComputed[ToPath, Tail]] =
@@ -246,6 +271,15 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           weakTypeTag[runtime.TransformerOverrides.CaseComputedPartial[ToPath, Tail]]
         def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
           A.asCtor[runtime.TransformerOverrides.CaseComputedPartial[?, ?]].map { A0 =>
+            fixJavaEnums(A0.param_<[runtime.Path](0)) -> A0.param_<[runtime.TransformerOverrides](1)
+          }
+      }
+      object CaseComputedPartialFailFast extends CaseComputedPartialFailFastModule {
+        def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
+            : Type[runtime.TransformerOverrides.CaseComputedPartialFailFast[ToPath, Tail]] =
+          weakTypeTag[runtime.TransformerOverrides.CaseComputedPartialFailFast[ToPath, Tail]]
+        def unapply[A](A: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.CaseComputedPartialFailFast[?, ?]].map { A0 =>
             fixJavaEnums(A0.param_<[runtime.Path](0)) -> A0.param_<[runtime.TransformerOverrides](1)
           }
       }
@@ -294,6 +328,24 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             A: Type[A]
         ): Option[(?<[runtime.ArgumentLists], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
           A.asCtor[runtime.TransformerOverrides.ConstructorPartial[?, ?, ?]].map { A0 =>
+            (
+              A0.param_<[runtime.ArgumentLists](0),
+              fixJavaEnums(A0.param_<[runtime.Path](1)),
+              A0.param_<[runtime.TransformerOverrides](2)
+            )
+          }
+      }
+      object ConstructorPartialFailFast extends ConstructorPartialFailFastModule {
+        def apply[
+            Args <: runtime.ArgumentLists: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ConstructorPartialFailFast[Args, ToPath, Tail]] =
+          weakTypeTag[runtime.TransformerOverrides.ConstructorPartialFailFast[Args, ToPath, Tail]]
+        def unapply[A](
+            A: Type[A]
+        ): Option[(?<[runtime.ArgumentLists], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.ConstructorPartialFailFast[?, ?, ?]].map { A0 =>
             (
               A0.param_<[runtime.ArgumentLists](0),
               fixJavaEnums(A0.param_<[runtime.Path](1)),

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -95,6 +95,47 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       }.applyFromSelectors(selectorFrom, selectorTo)
     )
 
+  def withFieldComputedPartialFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = {
+    val FromTpe = weakTypeOf[From]
+    val curriedF = q"{ val fn = $f; (from: $FromTpe) => (failFast: _root_.scala.Boolean) => fn(from, failFast) }"
+    c.prefix.tree
+      .addOverride(curriedF)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerDefinition[From, To, ComputedPartialFailFast[ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }
+
+  def withFieldComputedPartialFromFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = {
+    val sTpe = f.tpe.dealias.typeArgs.head
+    val curriedF = q"{ val fn = $f; (s: $sTpe) => (failFast: _root_.scala.Boolean) => fn(s, failFast) }"
+    c.prefix.tree
+      .addOverride(curriedF)
+      .asInstanceOfExpr(
+        new ApplyFieldNameTypes {
+          def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerDefinition[
+              From,
+              To,
+              ComputedPartialFromFailFast[FromPath, ToPath, Overrides],
+              Flags
+            ]]
+        }.applyFromSelectors(selectorFrom, selectorTo)
+      )
+  }
+
   def withFieldRenamedImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -154,6 +195,27 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
+
+  def withSealedSubtypeHandledPartialFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      Subtype: WeakTypeTag
+  ](f: Tree): Tree = {
+    val SubtypeTpe = weakTypeOf[Subtype]
+    val curriedF = q"{ val fn = $f; (subtype: $SubtypeTpe) => (failFast: _root_.scala.Boolean) => fn(subtype, failFast) }"
+    new ApplyFixedCoproductType {
+      def apply[FixedSubtype: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(curriedF)
+        .asInstanceOfExpr[PartialTransformerDefinition[
+          From,
+          To,
+          CaseComputedPartialFailFast[Path.SourceMatching[Path.Root, FixedSubtype], Overrides],
+          Flags
+        ]]
+    }.applyJavaEnumFixFromClosureSignature[Subtype](f)
+  }
 
   def withSealedSubtypeRenamedImpl[
       From: WeakTypeTag,
@@ -258,6 +320,43 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
         new ApplyFieldNameType {
           def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
             weakTypeTag[PartialTransformerDefinition[From, To, ConstructorPartial[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }.applyFromBody(f)
+
+  def withConstructorPartialFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerDefinition[
+        From,
+        To,
+        ConstructorPartialFailFast[Args, Path.Root, Overrides],
+        Flags
+      ]]
+  }.applyFromBody(f)
+
+  def withConstructorPartialToFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerDefinition[
+              From,
+              To,
+              ConstructorPartialFailFast[Args, ToPath, Overrides],
+              Flags
+            ]]
         }.applyFromSelector(selector)
       )
   }.applyFromBody(f)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -204,7 +204,8 @@ class PartialTransformerDefinitionMacros(val c: whitebox.Context) extends utils.
       Subtype: WeakTypeTag
   ](f: Tree): Tree = {
     val SubtypeTpe = weakTypeOf[Subtype]
-    val curriedF = q"{ val fn = $f; (subtype: $SubtypeTpe) => (failFast: _root_.scala.Boolean) => fn(subtype, failFast) }"
+    val curriedF =
+      q"{ val fn = $f; (subtype: $SubtypeTpe) => (failFast: _root_.scala.Boolean) => fn(subtype, failFast) }"
     new ApplyFixedCoproductType {
       def apply[FixedSubtype: WeakTypeTag]: Tree = c.prefix.tree
         .addOverride(curriedF)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -95,6 +95,47 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       }.applyFromSelectors(selectorFrom, selectorTo)
     )
 
+  def withFieldComputedPartialFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = {
+    val FromTpe = weakTypeOf[From]
+    val curriedF = q"{ val fn = $f; (from: $FromTpe) => (failFast: _root_.scala.Boolean) => fn(from, failFast) }"
+    c.prefix.tree
+      .addOverride(curriedF)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerInto[From, To, ComputedPartialFailFast[ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }
+
+  def withFieldComputedPartialFromFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selectorFrom: Tree)(selectorTo: Tree, f: Tree)(@unused ev: Tree): Tree = {
+    val sTpe = f.tpe.dealias.typeArgs.head
+    val curriedF = q"{ val fn = $f; (s: $sTpe) => (failFast: _root_.scala.Boolean) => fn(s, failFast) }"
+    c.prefix.tree
+      .addOverride(curriedF)
+      .asInstanceOfExpr(
+        new ApplyFieldNameTypes {
+          def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerInto[
+              From,
+              To,
+              ComputedPartialFromFailFast[FromPath, ToPath, Overrides],
+              Flags
+            ]]
+        }.applyFromSelectors(selectorFrom, selectorTo)
+      )
+  }
+
   def withFieldRenamedImpl[
       From: WeakTypeTag,
       To: WeakTypeTag,
@@ -154,6 +195,27 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
         Flags
       ]]
   }.applyJavaEnumFixFromClosureSignature[Subtype](f)
+
+  def withSealedSubtypeHandledPartialFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      Subtype: WeakTypeTag
+  ](f: Tree): Tree = {
+    val SubtypeTpe = weakTypeOf[Subtype]
+    val curriedF = q"{ val fn = $f; (subtype: $SubtypeTpe) => (failFast: _root_.scala.Boolean) => fn(subtype, failFast) }"
+    new ApplyFixedCoproductType {
+      def apply[FixedSubtype: WeakTypeTag]: Tree = c.prefix.tree
+        .addOverride(curriedF)
+        .asInstanceOfExpr[PartialTransformerInto[
+          From,
+          To,
+          CaseComputedPartialFailFast[Path.SourceMatching[Path.Root, FixedSubtype], Overrides],
+          Flags
+        ]]
+    }.applyJavaEnumFixFromClosureSignature[Subtype](f)
+  }
 
   def withSealedSubtypeRenamedImpl[
       From: WeakTypeTag,
@@ -258,6 +320,33 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
         new ApplyFieldNameType {
           def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
             weakTypeTag[PartialTransformerInto[From, To, ConstructorPartial[Args, ToPath, Overrides], Flags]]
+        }.applyFromSelector(selector)
+      )
+  }.applyFromBody(f)
+
+  def withConstructorPartialFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr[PartialTransformerInto[From, To, ConstructorPartialFailFast[Args, Path.Root, Overrides], Flags]]
+  }.applyFromBody(f)
+
+  def withConstructorPartialToFailFastImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag
+  ](selector: Tree)(f: Tree)(@unused ev: Tree): Tree = new ApplyConstructorType {
+    def apply[Args <: ArgumentLists: WeakTypeTag]: Tree = c.prefix.tree
+      .addOverride(f)
+      .asInstanceOfExpr(
+        new ApplyFieldNameType {
+          def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+            weakTypeTag[PartialTransformerInto[From, To, ConstructorPartialFailFast[Args, ToPath, Overrides], Flags]]
         }.applyFromSelector(selector)
       )
   }.applyFromBody(f)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -204,7 +204,8 @@ class PartialTransformerIntoMacros(val c: whitebox.Context) extends utils.DslMac
       Subtype: WeakTypeTag
   ](f: Tree): Tree = {
     val SubtypeTpe = weakTypeOf[Subtype]
-    val curriedF = q"{ val fn = $f; (subtype: $SubtypeTpe) => (failFast: _root_.scala.Boolean) => fn(subtype, failFast) }"
+    val curriedF =
+      q"{ val fn = $f; (subtype: $SubtypeTpe) => (failFast: _root_.scala.Boolean) => fn(subtype, failFast) }"
     new ApplyFixedCoproductType {
       def apply[FixedSubtype: WeakTypeTag]: Tree = c.prefix.tree
         .addOverride(curriedF)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -196,7 +196,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputedPartialFailFast[T, U](
       inline selector: To => T,
@@ -262,7 +262,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputedPartialFromFailFast[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
@@ -447,7 +447,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withSealedSubtypeHandledPartialFailFast[Subtype](
       inline f: (Subtype, Boolean) => partial.Result[To]
@@ -456,7 +456,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
 
   /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withEnumCaseHandledPartialFailFast[Subtype](
       inline f: (Subtype, Boolean) => partial.Result[To]
@@ -710,7 +710,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withConstructorPartialFailFast[Ctor](
       inline f: Ctor
@@ -742,7 +742,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: To => T)(
       inline f: Ctor

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -175,6 +175,35 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
 
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputedPartialFailFast[T, U](
+      inline selector: To => T,
+      inline f: (From, Boolean) => partial.Result[U]
+  )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withFieldComputedPartialFailFastImpl('this, 'selector, 'f) }
+
   /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
     * with `selectorFrom` as an input.
     *
@@ -206,6 +235,47 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
+
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputedPartialFromFailFast[S, T, U](inline selectorFrom: From => S)(
+      inline selectorTo: To => T,
+      inline f: (S, Boolean) => partial.Result[U]
+  )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${
+      PartialTransformerDefinitionMacros.withFieldComputedPartialFromFailFastImpl(
+        'this,
+        'selectorFrom,
+        'selectorTo,
+        'f
+      )
+    }
 
   /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
@@ -350,6 +420,48 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       inline f: Subtype => partial.Result[To]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialImpl('this, 'f) }
+
+  /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    *
+    * For convenience/readability [[withEnumCaseHandledPartialFailFast]] alias can be used (e.g. for Scala 3 enums or
+    * Java enums).
+    *
+    * It differs from `withFieldComputedPartialFailFast(_.matching[Subtype], (src, failFast) => ...)`, since
+    * `withSealedSubtypeHandledPartialFailFast` matches on a `From` subtype, while `.matching[Subtype]` matches on a
+    * `To` value's piece.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
+    *   for more details
+    *
+    * @tparam Subtype
+    *   type of sealed/enum instance
+    * @param f
+    *   function to calculate values of components that cannot be mapped automatically
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withSealedSubtypeHandledPartialFailFast[Subtype](
+      inline f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialFailFastImpl('this, 'f) }
+
+  /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withEnumCaseHandledPartialFailFast[Subtype](
+      inline f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withSealedSubtypeHandledPartialFailFastImpl('this, 'f) }
 
   /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
@@ -578,6 +690,66 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
       IsFunction.Of[Ctor, partial.Result[T]]
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorPartialToImpl('this, 'selector, 'f) }
+
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[To]`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[To]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withConstructorPartialFailFast[Ctor](
+      inline f: Ctor
+  )(using
+      IsFunction.Of[Ctor, Boolean => partial.Result[To]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withConstructorPartialFailFastImpl('this, 'f) }
+
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerDefinition]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: To => T)(
+      inline f: Ctor
+  )(using
+      IsFunction.Of[Ctor, Boolean => partial.Result[T]]
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionMacros.withConstructorPartialToFailFastImpl('this, 'selector, 'f) }
 
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -200,7 +200,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputedPartialFailFast[T, U](
       inline selector: To => T,
@@ -266,7 +266,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputedPartialFromFailFast[S, T, U](inline selectorFrom: From => S)(
       inline selectorTo: To => T,
@@ -444,7 +444,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withSealedSubtypeHandledPartialFailFast[Subtype](
       inline f: (Subtype, Boolean) => partial.Result[To]
@@ -453,7 +453,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withEnumCaseHandledPartialFailFast[Subtype](
       inline f: (Subtype, Boolean) => partial.Result[To]
@@ -695,7 +695,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withConstructorPartialFailFast[Ctor](
       inline f: Ctor
@@ -727,7 +727,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @return
     *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: To => T)(
       inline f: Ctor

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -179,6 +179,35 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
 
+  /** Use the function `f` to compute a partial result for the field picked using the `selector`.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputedPartialFailFast[T, U](
+      inline selector: To => T,
+      inline f: (From, Boolean) => partial.Result[U]
+  )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withFieldComputedPartialFailFastImpl('this, 'selector, 'f) }
+
   /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
     * with `selectorFrom` as an input.
     *
@@ -210,6 +239,40 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
+
+  /** Use the function `f` to compute a partial result of the field picked using the `selectorTo` from a value extracted
+    * with `selectorFrom` as an input.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if `From` is missing a field and it's not provided with some `selector`, the compilation fails.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#wiring-the-constructors-parameter-to-computed-value]]
+    *   for more details
+    *
+    * @tparam S
+    *   * type of source field
+    * @tparam T
+    *   type of target field
+    * @tparam U
+    *   type of computed value
+    * @param selectorFrom
+    *   source field in `From`, defined like `_.name`
+    * @param selectorTo
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   function used to compute value of the target field
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputedPartialFromFailFast[S, T, U](inline selectorFrom: From => S)(
+      inline selectorTo: To => T,
+      inline f: (S, Boolean) => partial.Result[U]
+  )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withFieldComputedPartialFromFailFastImpl('this, 'selectorFrom, 'selectorTo, 'f) }
 
   /** Use the `selectorFrom` field in `From` to obtain the value of the `selectorTo` field in `To`.
     *
@@ -354,6 +417,48 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       inline f: Subtype => partial.Result[To]
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withSealedSubtypeHandledPartialImpl('this, 'f) }
+
+  /** Use `f` to calculate the unmatched subtype's partial.Result when mapping one sealed/enum into another.
+    *
+    * The function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * By default, if mapping one coproduct in `From` into another coproduct in `To` derivation expects that coproducts
+    * to have matching names of its components, and for every component in `To` field's type there is matching component
+    * in `From` type. If some component is missing it fails compilation unless provided replacement with this operation.
+    *
+    * For convenience/readability [[withEnumCaseHandledPartialFailFast]] alias can be used (e.g. for Scala 3 enums or
+    * Java enums).
+    *
+    * It differs from `withFieldComputedPartialFailFast(_.matching[Subtype], (src, failFast) => ...)`, since
+    * `withSealedSubtypeHandledPartialFailFast` matches on a `From` subtype, while `.matching[Subtype]` matches on a
+    * `To` value's piece.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#handling-a-specific-sealed-subtype-with-a-computed-value]]
+    *   for more details
+    *
+    * @tparam Subtype
+    *   type of sealed/enum instance
+    * @param f
+    *   function to calculate values of components that cannot be mapped automatically
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withSealedSubtypeHandledPartialFailFast[Subtype](
+      inline f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withSealedSubtypeHandledPartialFailFastImpl('this, 'f) }
+
+  /** Alias to [[withSealedSubtypeHandledPartialFailFast]].
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withEnumCaseHandledPartialFailFast[Subtype](
+      inline f: (Subtype, Boolean) => partial.Result[To]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withSealedSubtypeHandledPartialFailFastImpl('this, 'f) }
 
   /** Use the `FromSubtype` in `From` as a source for the `ToSubtype` in `To`.
     *
@@ -570,6 +675,66 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
       inline f: Ctor
   )(using IsFunction.Of[Ctor, partial.Result[T]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorPartialToImpl('this, 'selector, 'f) }
+
+  /** Use `f` instead of the primary constructor to parse into `partial.Result[To]` value.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[To]`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[To]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withConstructorPartialFailFast[Ctor](
+      inline f: Ctor
+  )(using
+      IsFunction.Of[Ctor, Boolean => partial.Result[To]]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withConstructorPartialFailFastImpl('this, 'f) }
+
+  /** Use `f` instead of the primary constructor to parse into the value extracted from `To` using the `selector`.
+    *
+    * The resulting function receives a `Boolean` flag indicating whether the transformation is in fail-fast mode.
+    *
+    * Macro will read the names of Eta-expanded method's/lambda's parameters and try to match them with `From` getters.
+    *
+    * Values for each parameter can be provided the same way as if they were normal constructor's arguments.
+    *
+    * @see
+    *   [[https://chimney.readthedocs.io/supported-transformations/#types-with-manually-provided-constructors]] for more
+    *   details
+    *
+    * @tparam T
+    *   type of the value which would be constructed with a custom constructor
+    * @tparam Ctor
+    *   type of the Eta-expanded method/lambda which should return `Boolean => partial.Result[T]`
+    * @param selector
+    *   target field in `To`, defined like `_.name`
+    * @param f
+    *   method name or lambda which constructs `Boolean => partial.Result[T]`
+    * @return
+    *   [[io.scalaland.chimney.dsl.PartialTransformerInto]]
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: To => T)(
+      inline f: Ctor
+  )(using
+      IsFunction.Of[Ctor, Boolean => partial.Result[T]]
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoMacros.withConstructorPartialToFailFastImpl('this, 'selector, 'f) }
 
   /** Use `f` instead of the primary constructor to parse into `Either[String, To]` value.
     *

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -195,6 +195,37 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             case _ => scala.None
           }
       }
+      object ComputedPartialFailFast extends ComputedPartialFailFastModule {
+        def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
+            : Type[runtime.TransformerOverrides.ComputedPartialFailFast[ToPath, Tail]] =
+          quoted.Type.of[runtime.TransformerOverrides.ComputedPartialFailFast[ToPath, Tail]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          tpe match {
+            case '[runtime.TransformerOverrides.ComputedPartialFailFast[toPath, cfg]] =>
+              Some((Type[toPath].as_?<[runtime.Path], Type[cfg].as_?<[runtime.TransformerOverrides]))
+            case _ => scala.None
+          }
+      }
+      object ComputedPartialFromFailFast extends ComputedPartialFromFailFastModule {
+        def apply[
+            FromPath <: runtime.Path: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ComputedPartialFromFailFast[FromPath, ToPath, Tail]] =
+          quoted.Type.of[runtime.TransformerOverrides.ComputedPartialFromFailFast[FromPath, ToPath, Tail]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] =
+          tpe match {
+            case '[runtime.TransformerOverrides.ComputedPartialFromFailFast[fromPath, toPath, cfg]] =>
+              Some(
+                (
+                  Type[fromPath].as_?<[runtime.Path],
+                  Type[toPath].as_?<[runtime.Path],
+                  Type[cfg].as_?<[runtime.TransformerOverrides]
+                )
+              )
+            case _ => scala.None
+          }
+      }
       object CaseComputed extends CaseComputedModule {
         def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
             : Type[runtime.TransformerOverrides.CaseComputed[ToPath, Tail]] =
@@ -211,6 +242,16 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
           quoted.Type.of[runtime.TransformerOverrides.CaseComputedPartial[ToPath, Tail]]
         def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] = tpe match {
           case '[runtime.TransformerOverrides.CaseComputedPartial[toPath, cfg]] =>
+            Some((Type[toPath].as_?<[runtime.Path], Type[cfg].as_?<[runtime.TransformerOverrides]))
+          case _ => scala.None
+        }
+      }
+      object CaseComputedPartialFailFast extends CaseComputedPartialFailFastModule {
+        def apply[ToPath <: runtime.Path: Type, Tail <: runtime.TransformerOverrides: Type]
+            : Type[runtime.TransformerOverrides.CaseComputedPartialFailFast[ToPath, Tail]] =
+          quoted.Type.of[runtime.TransformerOverrides.CaseComputedPartialFailFast[ToPath, Tail]]
+        def unapply[A](tpe: Type[A]): Option[(?<[runtime.Path], ?<[runtime.TransformerOverrides])] = tpe match {
+          case '[runtime.TransformerOverrides.CaseComputedPartialFailFast[toPath, cfg]] =>
             Some((Type[toPath].as_?<[runtime.Path], Type[cfg].as_?<[runtime.TransformerOverrides]))
           case _ => scala.None
         }
@@ -266,6 +307,27 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             tpe: Type[A]
         ): Option[(?<[runtime.ArgumentLists], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] = tpe match {
           case '[runtime.TransformerOverrides.ConstructorPartial[args, toPath, cfg]] =>
+            Some(
+              (
+                Type[args].as_?<[runtime.ArgumentLists],
+                Type[toPath].as_?<[runtime.Path],
+                Type[cfg].as_?<[runtime.TransformerOverrides]
+              )
+            )
+          case _ => scala.None
+        }
+      }
+      object ConstructorPartialFailFast extends ConstructorPartialFailFastModule {
+        def apply[
+            Args <: runtime.ArgumentLists: Type,
+            ToPath <: runtime.Path: Type,
+            Tail <: runtime.TransformerOverrides: Type
+        ]: Type[runtime.TransformerOverrides.ConstructorPartialFailFast[Args, ToPath, Tail]] =
+          quoted.Type.of[runtime.TransformerOverrides.ConstructorPartialFailFast[Args, ToPath, Tail]]
+        def unapply[A](
+            tpe: Type[A]
+        ): Option[(?<[runtime.ArgumentLists], ?<[runtime.Path], ?<[runtime.TransformerOverrides])] = tpe match {
+          case '[runtime.TransformerOverrides.ConstructorPartialFailFast[args, toPath, cfg]] =>
             Some(
               (
                 Type[args].as_?<[runtime.ArgumentLists],

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -160,6 +160,61 @@ object PartialTransformerDefinitionMacros {
         }
     }(selectorFrom, selectorTo)
 
+  def withFieldComputedPartialFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
+      selector: Expr[To => T],
+      f: Expr[(From, Boolean) => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        val fn = $f
+        WithRuntimeDataStore
+          .update($td, (from: From) => (failFast: Boolean) => fn(from, failFast))
+          .asInstanceOf[PartialTransformerDefinition[
+            From,
+            To,
+            ComputedPartialFailFast[toPath, Overrides],
+            Flags
+          ]]
+      }
+    }(selector)
+
+  def withFieldComputedPartialFromFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      S: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
+      selectorFrom: Expr[From => S],
+      selectorTo: Expr[To => T],
+      f: Expr[(S, Boolean) => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
+        '{
+          val fn = $f
+          WithRuntimeDataStore
+            .update($td, (s: S) => (failFast: Boolean) => fn(s, failFast))
+            .asInstanceOf[PartialTransformerDefinition[
+              From,
+              To,
+              ComputedPartialFromFailFast[fromPath, toPath, Overrides],
+              Flags
+            ]]
+        }
+    }(selectorFrom, selectorTo)
+
   def withFieldRenamedImpl[
       From: Type,
       To: Type,
@@ -235,6 +290,28 @@ object PartialTransformerDefinitionMacros {
           From,
           To,
           CaseComputedPartial[Path.SourceMatching[Path.Root, Subtype], Overrides],
+          Flags
+        ]]
+    }
+
+  def withSealedSubtypeHandledPartialFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Subtype: Type
+  ](
+      td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
+      f: Expr[(Subtype, Boolean) => partial.Result[To]]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    '{
+      val fn = $f
+      WithRuntimeDataStore
+        .update($td, (subtype: Subtype) => (failFast: Boolean) => fn(subtype, failFast))
+        .asInstanceOf[PartialTransformerDefinition[
+          From,
+          To,
+          CaseComputedPartialFailFast[Path.SourceMatching[Path.Root, Subtype], Overrides],
           Flags
         ]]
     }
@@ -400,6 +477,56 @@ object PartialTransformerDefinitionMacros {
               From,
               To,
               ConstructorPartial[args, toPath, Overrides],
+              Flags
+            ]]
+        }
+      }(selector)
+    }(f)
+
+  def withConstructorPartialFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType { [args <: ArgumentLists] => (_: Type[args]) ?=>
+      '{
+        WithRuntimeDataStore
+          .update($td, $f)
+          .asInstanceOf[PartialTransformerDefinition[
+            From,
+            To,
+            ConstructorPartialFailFast[args, Path.Root, Overrides],
+            Flags
+          ]]
+      }
+    }(f)
+
+  def withConstructorPartialToFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      Ctor: Type
+  ](
+      td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
+      selector: Expr[To => T],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType { [args <: ArgumentLists] => (_: Type[args]) ?=>
+      DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+        '{
+          WithRuntimeDataStore
+            .update($td, $f)
+            .asInstanceOf[PartialTransformerDefinition[
+              From,
+              To,
+              ConstructorPartialFailFast[args, toPath, Overrides],
               Flags
             ]]
         }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -145,6 +145,56 @@ object PartialTransformerIntoMacros {
         }
     }(selectorFrom, selectorTo)
 
+  def withFieldComputedPartialFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selector: Expr[To => T],
+      f: Expr[(From, Boolean) => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        val fn = $f
+        WithRuntimeDataStore
+          .update($ti, (from: From) => (failFast: Boolean) => fn(from, failFast))
+          .asInstanceOf[PartialTransformerInto[From, To, ComputedPartialFailFast[toPath, Overrides], Flags]]
+      }
+    }(selector)
+
+  def withFieldComputedPartialFromFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      S: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selectorFrom: Expr[From => S],
+      selectorTo: Expr[To => T],
+      f: Expr[(S, Boolean) => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
+        '{
+          val fn = $f
+          WithRuntimeDataStore
+            .update($ti, (s: S) => (failFast: Boolean) => fn(s, failFast))
+            .asInstanceOf[PartialTransformerInto[
+              From,
+              To,
+              ComputedPartialFromFailFast[fromPath, toPath, Overrides],
+              Flags
+            ]]
+        }
+    }(selectorFrom, selectorTo)
+
   def withFieldRenamedImpl[
       From: Type,
       To: Type,
@@ -220,6 +270,28 @@ object PartialTransformerIntoMacros {
           From,
           To,
           CaseComputedPartial[Path.SourceMatching[Path.Root, Subtype], Overrides],
+          Flags
+        ]]
+    }
+
+  def withSealedSubtypeHandledPartialFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Subtype: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      f: Expr[(Subtype, Boolean) => partial.Result[To]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    '{
+      val fn = $f
+      WithRuntimeDataStore
+        .update($ti, (subtype: Subtype) => (failFast: Boolean) => fn(subtype, failFast))
+        .asInstanceOf[PartialTransformerInto[
+          From,
+          To,
+          CaseComputedPartialFailFast[Path.SourceMatching[Path.Root, Subtype], Overrides],
           Flags
         ]]
     }
@@ -379,6 +451,55 @@ object PartialTransformerIntoMacros {
               From,
               To,
               ConstructorPartial[args, toPath, Overrides],
+              Flags
+            ]]
+        }
+      }(selector)
+    }(f)
+
+  def withConstructorPartialFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType { [args <: ArgumentLists] => (_: Type[args]) ?=>
+      '{
+        WithRuntimeDataStore
+          .update($ti, $f)
+          .asInstanceOf[PartialTransformerInto[
+            From,
+            To,
+            ConstructorPartialFailFast[args, Path.Root, Overrides],
+            Flags
+          ]]
+      }
+    }(f)
+
+  def withConstructorPartialToFailFastImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      Ctor: Type
+  ](
+      ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
+      selector: Expr[To => Ctor],
+      f: Expr[Ctor]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyConstructorType { [args <: ArgumentLists] => (_: Type[args]) ?=>
+      DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+        '{
+          WithRuntimeDataStore
+            .update($ti, $f)
+            .asInstanceOf[PartialTransformerInto[
+              From,
+              To,
+              ConstructorPartialFailFast[args, toPath, Overrides],
               Flags
             ]]
         }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -146,6 +146,23 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerOverrides.ComputedPartialFrom
           ] { this: ComputedPartialFrom.type => }
 
+      val ComputedPartialFailFast: ComputedPartialFailFastModule
+      trait ComputedPartialFailFastModule
+          extends Type.Ctor2UpperBounded[
+            runtime.Path,
+            runtime.TransformerOverrides,
+            runtime.TransformerOverrides.ComputedPartialFailFast
+          ] { this: ComputedPartialFailFast.type => }
+
+      val ComputedPartialFromFailFast: ComputedPartialFromFailFastModule
+      trait ComputedPartialFromFailFastModule
+          extends Type.Ctor3UpperBounded[
+            runtime.Path,
+            runtime.Path,
+            runtime.TransformerOverrides,
+            runtime.TransformerOverrides.ComputedPartialFromFailFast
+          ] { this: ComputedPartialFromFailFast.type => }
+
       val CaseComputed: CaseComputedModule
       trait CaseComputedModule
           extends Type.Ctor2UpperBounded[
@@ -161,6 +178,14 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerOverrides,
             runtime.TransformerOverrides.CaseComputedPartial
           ] { this: CaseComputedPartial.type => }
+
+      val CaseComputedPartialFailFast: CaseComputedPartialFailFastModule
+      trait CaseComputedPartialFailFastModule
+          extends Type.Ctor2UpperBounded[
+            runtime.Path,
+            runtime.TransformerOverrides,
+            runtime.TransformerOverrides.CaseComputedPartialFailFast
+          ] { this: CaseComputedPartialFailFast.type => }
 
       val Fallback: FallbackModule
       trait FallbackModule
@@ -188,6 +213,15 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerOverrides,
             runtime.TransformerOverrides.ConstructorPartial
           ] { this: ConstructorPartial.type => }
+
+      val ConstructorPartialFailFast: ConstructorPartialFailFastModule
+      trait ConstructorPartialFailFastModule
+          extends Type.Ctor3UpperBounded[
+            runtime.ArgumentLists,
+            runtime.Path,
+            runtime.TransformerOverrides,
+            runtime.TransformerOverrides.ConstructorPartialFailFast
+          ] { this: ConstructorPartialFailFast.type => }
 
       val RenamedFrom: RenamedFromModule
       trait RenamedFromModule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -386,11 +386,15 @@ private[compiletime] trait Configurations { this: Derivation =>
         with ForSubtype {
       override def toString: String = s"Computed($sourcePath, $targetPath, ${ExistentialExpr.prettyPrint(runtimeData)})"
     }
-    final case class ComputedPartial(sourcePath: Path, targetPath: Path, runtimeData: ExistentialExpr)
-        extends ForField
+    final case class ComputedPartial(
+        sourcePath: Path,
+        targetPath: Path,
+        runtimeData: ExistentialExpr,
+        failFastAware: Boolean = false
+    ) extends ForField
         with ForSubtype {
       override def toString: String =
-        s"ComputedPartial($sourcePath, $targetPath, ${ExistentialExpr.prettyPrint(runtimeData)})"
+        s"ComputedPartial($sourcePath, $targetPath, ${ExistentialExpr.prettyPrint(runtimeData)}, failFastAware=$failFastAware)"
     }
 
     final case class Fallback(runtimeData: ExistentialExpr) extends ForFallback {
@@ -402,9 +406,10 @@ private[compiletime] trait Configurations { this: Derivation =>
     final case class Constructor(args: Args, runtimeData: ExistentialExpr) extends ForConstructor {
       override def toString: String = s"Constructor(${printArgs(args)}, ${ExistentialExpr.prettyPrint(runtimeData)})"
     }
-    final case class ConstructorPartial(args: Args, runtimeData: ExistentialExpr) extends ForConstructor {
+    final case class ConstructorPartial(args: Args, runtimeData: ExistentialExpr, failFastAware: Boolean = false)
+        extends ForConstructor {
       override def toString: String =
-        s"ConstructorPartial(${printArgs(args)}, ${ExistentialExpr.prettyPrint(runtimeData)})"
+        s"ConstructorPartial(${printArgs(args)}, ${ExistentialExpr.prettyPrint(runtimeData)}, failFastAware=$failFastAware)"
     }
 
     final case class Renamed(sourcePath: Path, targetPath: Path) extends ForField with ForSubtype
@@ -556,9 +561,9 @@ private[compiletime] trait Configurations { this: Derivation =>
     def sourceFieldsUsedByOverrides(currentSrc: Path)(implicit ctx: TransformationContext[?, ?]): List[String] =
       originalRuntimeOverrides.view
         .collect {
-          case (_, TransformerOverride.Computed(sourcePath, _, _))        => sourcePath.drop(currentSrc)
-          case (_, TransformerOverride.ComputedPartial(sourcePath, _, _)) => sourcePath.drop(currentSrc)
-          case (_, TransformerOverride.Renamed(sourcePath, _))            => sourcePath.drop(currentSrc)
+          case (_, TransformerOverride.Computed(sourcePath, _, _))           => sourcePath.drop(currentSrc)
+          case (_, TransformerOverride.ComputedPartial(sourcePath, _, _, _)) => sourcePath.drop(currentSrc)
+          case (_, TransformerOverride.Renamed(sourcePath, _))               => sourcePath.drop(currentSrc)
         }
         .collect { case Some(Path.AtField(fromName, _)) => fromName }
         .toList
@@ -568,9 +573,9 @@ private[compiletime] trait Configurations { this: Derivation =>
     )(implicit ctx: TransformationContext[?, ?]): List[ExistentialType] =
       originalRuntimeOverrides.view
         .collect {
-          case (_, TransformerOverride.Computed(_, targetPath, _))        => targetPath.drop(currentTgt)
-          case (_, TransformerOverride.ComputedPartial(_, targetPath, _)) => targetPath.drop(currentTgt)
-          case (_, TransformerOverride.Renamed(_, targetPath))            => targetPath.drop(currentTgt)
+          case (_, TransformerOverride.Computed(_, targetPath, _))           => targetPath.drop(currentTgt)
+          case (_, TransformerOverride.ComputedPartial(_, targetPath, _, _)) => targetPath.drop(currentTgt)
+          case (_, TransformerOverride.Renamed(_, targetPath))               => targetPath.drop(currentTgt)
         }
         .collect { case Some(Path.AtSubtype(toSubtype, _)) => toSubtype }
         .toList
@@ -887,6 +892,32 @@ private[compiletime] trait Configurations { this: Derivation =>
           SourcePath(sourcePath),
           TransformerOverride.ComputedPartial(sourcePath, Path.Root, runtimeDataStore(runtimeDataIdx).as_??)
         )
+      case ChimneyType.TransformerOverrides.ComputedPartialFailFast(toPath, cfg) =>
+        import toPath.Underlying as ToPath, cfg.Underlying as Tail2
+        val targetPath = extractPath[ToPath]
+        extractTransformerConfig[Tail2](1 + runtimeDataIdx, runtimeDataStore).addTransformerOverride(
+          TargetPath(targetPath),
+          TransformerOverride
+            .ComputedPartial(Path.Root, targetPath, runtimeDataStore(runtimeDataIdx).as_??, failFastAware = true)
+        )
+      case ChimneyType.TransformerOverrides.ComputedPartialFromFailFast(fromPath, toPath, cfg) =>
+        import fromPath.Underlying as FromPath, toPath.Underlying as ToPath, cfg.Underlying as Tail2
+        val sourcePath = extractPath[FromPath]
+        val targetPath = extractPath[ToPath]
+        extractTransformerConfig[Tail2](1 + runtimeDataIdx, runtimeDataStore).addTransformerOverride(
+          sourcePath,
+          targetPath,
+          TransformerOverride
+            .ComputedPartial(sourcePath, targetPath, runtimeDataStore(runtimeDataIdx).as_??, failFastAware = true)
+        )
+      case ChimneyType.TransformerOverrides.CaseComputedPartialFailFast(fromPath, cfg) =>
+        import fromPath.Underlying as FromPath, cfg.Underlying as Tail2
+        val sourcePath = extractPath[FromPath]
+        extractTransformerConfig[Tail2](1 + runtimeDataIdx, runtimeDataStore).addTransformerOverride(
+          SourcePath(sourcePath),
+          TransformerOverride
+            .ComputedPartial(sourcePath, Path.Root, runtimeDataStore(runtimeDataIdx).as_??, failFastAware = true)
+        )
       case ChimneyType.TransformerOverrides.Fallback(fallbackType, fromPath, cfg) =>
         import fallbackType.Underlying as FallbackType, fromPath.Underlying as FromPath, cfg.Underlying as Tail2
         extractTransformerConfig[Tail2](1 + runtimeDataIdx, runtimeDataStore).addTransformerOverride(
@@ -904,6 +935,16 @@ private[compiletime] trait Configurations { this: Derivation =>
         extractTransformerConfig[Tail2](1 + runtimeDataIdx, runtimeDataStore).addTransformerOverride(
           TargetPath(extractPath[ToPath]),
           TransformerOverride.ConstructorPartial(extractArgumentLists[Args], runtimeDataStore(runtimeDataIdx).as_??)
+        )
+      case ChimneyType.TransformerOverrides.ConstructorPartialFailFast(args, toPath, cfg) =>
+        import args.Underlying as Args, toPath.Underlying as ToPath, cfg.Underlying as Tail2
+        extractTransformerConfig[Tail2](1 + runtimeDataIdx, runtimeDataStore).addTransformerOverride(
+          TargetPath(extractPath[ToPath]),
+          TransformerOverride.ConstructorPartial(
+            extractArgumentLists[Args],
+            runtimeDataStore(runtimeDataIdx).as_??,
+            failFastAware = true
+          )
         )
       case ChimneyType.TransformerOverrides.RenamedFrom(fromPath, toPath, cfg) =>
         import fromPath.Underlying as FromPath, toPath.Underlying as ToPath, cfg.Underlying as Tail2

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -48,7 +48,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
         case TransformerOverride.Constructor(args, runtimeData) =>
           val Product.Constructor(parameters, constructor) = mkCtor[To](args)(runtimeData)
           mapOverridesAndExtractorsToConstructorArguments[From, To, To](fromExtractors, parameters, constructor)
-        case TransformerOverride.ConstructorPartial(args, runtimeData) =>
+        case TransformerOverride.ConstructorPartial(args, runtimeData, failFastAware) if !failFastAware =>
           val Product.Constructor(params, ctor) = mkCtor[partial.Result[To]](args)(runtimeData)
           mapOverridesAndExtractorsToConstructorArguments[From, To, partial.Result[To]](fromExtractors, params, ctor)
             .map {
@@ -61,6 +61,32 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                 Rule.ExpansionResult.Expanded(flattenTransformationExpr)
               case Rule.ExpansionResult.AttemptNextRule(reason) => Rule.ExpansionResult.AttemptNextRule(reason)
             }
+        case TransformerOverride.ConstructorPartial(args, runtimeData, _ /* failFastAware = true */ ) =>
+          val Product.Constructor(params, ctor) =
+            mkCtor[Boolean => partial.Result[To]](args)(runtimeData)
+          mapOverridesAndExtractorsToConstructorArguments[From, To, Boolean => partial.Result[To]](
+            fromExtractors,
+            params,
+            ctor
+          ).map {
+            case Rule.ExpansionResult.Expanded(transformationExpr) =>
+              val failFastExpr = ctx match {
+                case TransformationContext.ForPartial(_, failFast) => failFast
+                case _                                             => Expr.Boolean(false)
+              }
+              // no idea why it doesn't figure that out on its own in Scala 2 (GADT skolem)
+              val appliedExpr =
+                transformationExpr.asInstanceOf[TransformationExpr[Boolean => partial.Result[To]]] match {
+                  case TransformationExpr.TotalExpr(expr) =>
+                    TransformationExpr.PartialExpr(expr.apply(failFastExpr))
+                  case TransformationExpr.PartialExpr(expr) =>
+                    TransformationExpr.PartialExpr(expr.map(Expr.Function1.instance { (fn: Expr[Boolean => partial.Result[To]]) =>
+                      fn.apply(failFastExpr)
+                    }).flatten)
+                }
+              Rule.ExpansionResult.Expanded(appliedExpr)
+            case Rule.ExpansionResult.AttemptNextRule(reason) => Rule.ExpansionResult.AttemptNextRule(reason)
+          }
       }
     }
 
@@ -178,7 +204,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                           s".withFieldConstPartial(_.$anotherToName, ...)"
                         case TransformerOverride.Computed(_, _, _) =>
                           s".withFieldComputed(_.$anotherToName, ...)"
-                        case TransformerOverride.ComputedPartial(_, _, _) =>
+                        case TransformerOverride.ComputedPartial(_, _, _, _) =>
                           s".withFieldComputedPartial(_.$anotherToName, ...)"
                         case TransformerOverride.Renamed(sourcePath, _) =>
                           s".withFieldRenamed($sourcePath, _.$anotherToName})"
@@ -403,23 +429,25 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               )
           }
         }
-      case TransformerOverride.ComputedPartial(sourcePath, _, runtimeData) =>
+      case TransformerOverride.ComputedPartial(sourcePath, _, runtimeData, failFastAware) =>
         extractSrcByPath(FromOperation.ComputedPartial, sourcePath, toName).map { extractedSrc =>
           import extractedSrc.Underlying as ExtractedSrc, extractedSrc.value as extractedSrcExpr
-          // We're constructing:
-          // '{
-          //   ${ runtimeDataStore }(idx)
-          //     .asInstanceOf[$ExtractedSrc => partial.Result[$CtorParam]](${ extractedSrcExpr })
-          //     // prepend sourcePath
-          //     .prependErrorPath(PathElement.Computed("_.toName"))
-          // }
+          val partialResult = if (failFastAware) {
+            val failFastExpr = ctx match {
+              case TransformationContext.ForPartial(_, failFast) => failFast
+              case _                                             => Expr.Boolean(false)
+            }
+            runtimeData
+              .asInstanceOfExpr[ExtractedSrc => Boolean => partial.Result[CtorParam]]
+              .apply(extractedSrcExpr)
+              .apply(failFastExpr)
+          } else {
+            runtimeData
+              .asInstanceOfExpr[ExtractedSrc => partial.Result[CtorParam]]
+              .apply(extractedSrcExpr)
+          }
           TransformationExpr.fromPartial(
-            prependWholeErrorPath(
-              runtimeData
-                .asInstanceOfExpr[ExtractedSrc => partial.Result[CtorParam]]
-                .apply(extractedSrcExpr),
-              sourcePath
-            )
+            prependWholeErrorPath(partialResult, sourcePath)
               .prependErrorPath(
                 ChimneyExpr.PathElement
                   .Computed(Expr.String(s"${ctx.currentTgt}.$toName"))

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -80,9 +80,13 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                   case TransformationExpr.TotalExpr(expr) =>
                     TransformationExpr.PartialExpr(expr.apply(failFastExpr))
                   case TransformationExpr.PartialExpr(expr) =>
-                    TransformationExpr.PartialExpr(expr.map(Expr.Function1.instance { (fn: Expr[Boolean => partial.Result[To]]) =>
-                      fn.apply(failFastExpr)
-                    }).flatten)
+                    TransformationExpr.PartialExpr(
+                      expr
+                        .map(Expr.Function1.instance { (fn: Expr[Boolean => partial.Result[To]]) =>
+                          fn.apply(failFastExpr)
+                        })
+                        .flatten
+                    )
                 }
               Rule.ExpansionResult.Expanded(appliedExpr)
             case Rule.ExpansionResult.AttemptNextRule(reason) => Rule.ExpansionResult.AttemptNextRule(reason)
@@ -432,6 +436,14 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
       case TransformerOverride.ComputedPartial(sourcePath, _, runtimeData, failFastAware) =>
         extractSrcByPath(FromOperation.ComputedPartial, sourcePath, toName).map { extractedSrc =>
           import extractedSrc.Underlying as ExtractedSrc, extractedSrc.value as extractedSrcExpr
+          // We're constructing:
+          // '{
+          //   ${ runtimeDataStore }(idx)
+          //     .asInstanceOf[$ExtractedSrc => partial.Result[$CtorParam]](${ extractedSrcExpr })
+          //     // prepend sourcePath
+          //     .prependErrorPath(PathElement.Computed("_.toName"))
+          // }
+          // (or the failFastAware variant with an extra Boolean => ... curried call)
           val partialResult = if (failFastAware) {
             val failFastExpr = ctx match {
               case TransformationContext.ForPartial(_, failFast) => failFast

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -74,10 +74,10 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
           Type[SomeFrom] <:< Type[From]
         }
         .filter {
-          case (_, TransformerOverride.Unused)                            => true
-          case (_, TransformerOverride.Computed(_, targetPath, _))        => targetPath == ctx.currentTgt
+          case (_, TransformerOverride.Unused)                               => true
+          case (_, TransformerOverride.Computed(_, targetPath, _))           => targetPath == ctx.currentTgt
           case (_, TransformerOverride.ComputedPartial(_, targetPath, _, _)) => targetPath == ctx.currentTgt
-          case (_, TransformerOverride.Renamed(_, targetPath))            =>
+          case (_, TransformerOverride.Renamed(_, targetPath))               =>
             targetPath.drop(ctx.currentTgt) match {
               case Some(Path.AtSubtype(someTo, Path.Root)) => someTo.Underlying <:< Type[To]
               case _                                       => false

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformSealedHierarchyToSealedHierarchyRuleModule.scala
@@ -76,7 +76,7 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
         .filter {
           case (_, TransformerOverride.Unused)                            => true
           case (_, TransformerOverride.Computed(_, targetPath, _))        => targetPath == ctx.currentTgt
-          case (_, TransformerOverride.ComputedPartial(_, targetPath, _)) => targetPath == ctx.currentTgt
+          case (_, TransformerOverride.ComputedPartial(_, targetPath, _, _)) => targetPath == ctx.currentTgt
           case (_, TransformerOverride.Renamed(_, targetPath))            =>
             targetPath.drop(ctx.currentTgt) match {
               case Some(Path.AtSubtype(someTo, Path.Root)) => someTo.Underlying <:< Type[To]
@@ -116,12 +116,22 @@ private[compiletime] trait TransformSealedHierarchyToSealedHierarchyRuleModule {
                   TransformationExpr.fromTotal(
                     runtimeData.asInstanceOfExpr[From => To].apply(fromExpr)
                   )
-                case TransformerOverride.ComputedPartial(_, _, runtimeData) =>
+                case TransformerOverride.ComputedPartial(_, _, runtimeData, failFastAware) =>
                   // We're constructing:
                   // case someFromExpr: $someFrom => runtimeDataStore(${ idx }).asInstanceOf[$someFrom => partial.Result[$To]](someFromExpr)
-                  TransformationExpr.fromPartial(
+                  val partialResult = if (failFastAware) {
+                    val failFastExpr = ctx match {
+                      case TransformationContext.ForPartial(_, failFast) => failFast
+                      case _                                             => Expr.Boolean(false)
+                    }
+                    runtimeData
+                      .asInstanceOfExpr[From => Boolean => partial.Result[To]]
+                      .apply(fromExpr)
+                      .apply(failFastExpr)
+                  } else {
                     runtimeData.asInstanceOfExpr[From => partial.Result[To]].apply(fromExpr)
-                  )
+                  }
+                  TransformationExpr.fromPartial(partialResult)
                 case TransformerOverride.Renamed(_, targetPath) =>
                   val Some(Path.AtSubtype(someTo, _)) = targetPath.drop(ctx.currentTgt): @unchecked
                   // We're constructing:

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
@@ -32,8 +32,7 @@ object TransformerOverrides {
   final class Constructor[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
   final class ConstructorPartial[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
   // Computes a partial value after all constructor arguments have been matched, with failFast flag
-  final class ConstructorPartialFailFast[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides]
-      extends Overrides
+  final class ConstructorPartialFailFast[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
   // FIXME (2.0.0 cleanup) - try merging RenameFrom with RenameTo
   // Computes a value using manually pointed value from (src: From)
   final class RenamedFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
@@ -22,9 +22,18 @@ object TransformerOverrides {
   // Computes a value from an already extracted (e.g. matched) piece of (src: From)
   final class CaseComputed[ToPath <: Path, Tail <: Overrides] extends Overrides
   final class CaseComputedPartial[ToPath <: Path, Tail <: Overrides] extends Overrides
+  // Computes a partial value from a whole (src: From) with failFast flag
+  final class ComputedPartialFailFast[ToPath <: Path, Tail <: Overrides] extends Overrides
+  // Computes a partial value from an expr with failFast flag
+  final class ComputedPartialFromFailFast[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
+  // Computes a partial value from an already extracted (e.g. matched) piece of (src: From) with failFast flag
+  final class CaseComputedPartialFailFast[ToPath <: Path, Tail <: Overrides] extends Overrides
   // Computes a value after all constructor arguments have been matched
   final class Constructor[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
   final class ConstructorPartial[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides] extends Overrides
+  // Computes a partial value after all constructor arguments have been matched, with failFast flag
+  final class ConstructorPartialFailFast[Args <: ArgumentLists, ToPath <: Path, Tail <: Overrides]
+      extends Overrides
   // FIXME (2.0.0 cleanup) - try merging RenameFrom with RenameTo
   // Computes a value using manually pointed value from (src: From)
   final class RenamedFrom[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerProductSpec.scala
@@ -1298,6 +1298,90 @@ class PartialTransformerProductSpec extends ChimneySpec {
     }
   }
 
+  group("setting .withFieldComputedPartialFailFast(_.field, (source, failFast) => value)") {
+
+    test("should pass failFast=true when using transformFailFast") {
+      import products.{Foo, Bar}
+
+      var receivedFailFast: Option[Boolean] = None
+
+      val result = Bar(3, (3.14, 3.14))
+        .intoPartial[Foo]
+        .withFieldComputedPartialFailFast(
+          _.y,
+          (bar, failFast) => {
+            receivedFailFast = Some(failFast)
+            partial.Result.fromValue(bar.x.toString)
+          }
+        )
+        .transformFailFast
+      result.asOption ==> Some(Foo(3, "3", (3.14, 3.14)))
+      receivedFailFast ==> Some(true)
+    }
+
+    test("should pass failFast=false when using transform") {
+      import products.{Foo, Bar}
+
+      var receivedFailFast: Option[Boolean] = None
+
+      val result = Bar(3, (3.14, 3.14))
+        .intoPartial[Foo]
+        .withFieldComputedPartialFailFast(
+          _.y,
+          (bar, failFast) => {
+            receivedFailFast = Some(failFast)
+            partial.Result.fromValue(bar.x.toString)
+          }
+        )
+        .transform
+      result.asOption ==> Some(Foo(3, "3", (3.14, 3.14)))
+      receivedFailFast ==> Some(false)
+    }
+
+    test("should work with PartialTransformer.define") {
+      import products.{Foo, Bar}
+
+      var receivedFailFast: Option[Boolean] = None
+
+      val transformer = PartialTransformer
+        .define[Bar, Foo]
+        .withFieldComputedPartialFailFast(
+          _.y,
+          (bar, failFast) => {
+            receivedFailFast = Some(failFast)
+            partial.Result.fromValue(bar.x.toString)
+          }
+        )
+        .buildTransformer
+
+      val result = transformer.transform(Bar(3, (3.14, 3.14)), failFast = true)
+      result.asOption ==> Some(Foo(3, "3", (3.14, 3.14)))
+      receivedFailFast ==> Some(true)
+    }
+  }
+
+  group("setting .withFieldComputedPartialFromFailFast(_.from)(_.to, (source, failFast) => value)") {
+
+    test("should pass failFast correctly") {
+      import products.{Foo, Bar}
+
+      var receivedFailFast: Option[Boolean] = None
+
+      val result = Bar(3, (3.14, 3.14))
+        .intoPartial[Foo]
+        .withFieldComputedPartialFromFailFast(_.x)(
+          _.y,
+          (x, failFast) => {
+            receivedFailFast = Some(failFast)
+            partial.Result.fromValue(x.toString)
+          }
+        )
+        .transformFailFast
+      result.asOption ==> Some(Foo(3, "3", (3.14, 3.14)))
+      receivedFailFast ==> Some(true)
+    }
+  }
+
   group("""setting .withFieldRenamed(_.from, _.to)""") {
 
     test("should not be enabled by default") {

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSealedHierarchySpec.scala
@@ -655,6 +655,41 @@ class PartialTransformerSealedHierarchySpec extends ChimneySpec {
     }
   }
 
+  group("setting .withSealedSubtypeHandledPartialFailFast[Subtype]((mapping, failFast))") {
+
+    test("should pass failFast=true when using transformFailFast") {
+      var receivedFailFast: Option[Boolean] = None
+
+      def blackIsFail(b: colors2.Black.type, failFast: Boolean): partial.Result[colors1.Color] = {
+        receivedFailFast = Some(failFast)
+        partial.Result.fromEmpty
+      }
+
+      (colors2.Black: colors2.Color)
+        .intoPartial[colors1.Color]
+        .withSealedSubtypeHandledPartialFailFast(blackIsFail)
+        .transformFailFast
+        .asOption ==> None
+      receivedFailFast ==> Some(true)
+    }
+
+    test("should pass failFast=false when using transform") {
+      var receivedFailFast: Option[Boolean] = None
+
+      def blackIsFail(b: colors2.Black.type, failFast: Boolean): partial.Result[colors1.Color] = {
+        receivedFailFast = Some(failFast)
+        partial.Result.fromEmpty
+      }
+
+      (colors2.Black: colors2.Color)
+        .intoPartial[colors1.Color]
+        .withSealedSubtypeHandledPartialFailFast(blackIsFail)
+        .transform
+        .asOption ==> None
+      receivedFailFast ==> Some(false)
+    }
+  }
+
   group("setting .withSealedSubtypeRenamed[FromSubtype, ToSubtype]") {
 
     import fixtures.renames.Subtypes.*

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -2394,6 +2394,67 @@ We are also able to compute values in nested structure:
     // Right(value = NestedBar(bar = Bar(a = "value", b = 1248, c = 2496L)))
     ```
 
+#### Fail-fast-aware partial computations
+
+When using `.withFieldComputedPartial`, the provided function does not know whether the caller used `.transform` (which
+collects all errors) or `.transformFailFast` (which stops at the first error). In some cases the computation itself could
+benefit from this knowledge - for example, to skip expensive validations when fail-fast mode is already active, or to
+eagerly accumulate additional diagnostics when all errors are collected.
+
+`.withFieldComputedPartialFailFast` passes the `failFast` flag as an additional `Boolean` parameter to the function. The
+flag is `true` when `.transformFailFast` is used and `false` when `.transform` is used.
+`.withFieldComputedPartialFromFailFast` provides the same capability for computations that extract a value from the
+source first.
+
+!!! example
+
+    ```scala
+    //> using scala {{ scala.3 }}
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
+    import io.scalaland.chimney.dsl._
+    import io.scalaland.chimney.partial
+
+    case class Foo(a: String, b: Int)
+    case class Bar(a: String, b: Int, c: Long)
+
+    // With transformFailFast, failFast is true:
+    pprint.pprintln(
+      Foo("value", 10)
+        .intoPartial[Bar]
+        .withFieldComputedPartialFailFast(_.c, (foo, failFast) =>
+          if (failFast) partial.Result.fromValue(foo.b.toLong) // skip extra work in fail-fast mode
+          else partial.Result.fromValue(foo.b.toLong * 2)      // do full computation otherwise
+        )
+        .transformFailFast
+        .asEither
+        .left
+        .map(_.asErrorPathMessages)
+    )
+    // expected output:
+    // Right(value = Bar(a = "value", b = 10, c = 10L))
+
+    // With transform, failFast is false:
+    pprint.pprintln(
+      Foo("value", 10)
+        .intoPartial[Bar]
+        .withFieldComputedPartialFailFast(_.c, (foo, failFast) =>
+          if (failFast) partial.Result.fromValue(foo.b.toLong)
+          else partial.Result.fromValue(foo.b.toLong * 2)
+        )
+        .transform
+        .asEither
+        .left
+        .map(_.asErrorPathMessages)
+    )
+    // expected output:
+    // Right(value = Bar(a = "value", b = 10, c = 20L))
+    ```
+
+Similarly, `.withSealedSubtypeHandledPartialFailFast` passes the `failFast` flag when handling sealed subtypes, and
+`.withConstructorPartialFailFast` passes it when wiring an entire constructor (as a curried `Boolean => partial.Result[To]`
+argument).
+
 ### Customizing field name matching
 
 Be default names are matched in a Java-Bean-aware way - `fieldName` would be considered a match for another `fieldName`


### PR DESCRIPTION
## Summary

Closes #772.

Adds fail-fast-aware variants of partial transformer DSL methods. These accept functions that receive a `failFast: Boolean` parameter, allowing users to optimize partial computations based on whether `.transform` (collects all errors, `failFast = false`) or `.transformFailFast` (stops at first error, `failFast = true`) was used.

### New methods

Added to both `PartialTransformerInto` and `PartialTransformerDefinition` (Scala 2.12, 2.13, and 3):

| Method | Function signature |
|---|---|
| `withFieldComputedPartialFailFast` | `(From, Boolean) => partial.Result[U]` |
| `withFieldComputedPartialFromFailFast` | `(S, Boolean) => partial.Result[U]` |
| `withSealedSubtypeHandledPartialFailFast` | `(Subtype, Boolean) => partial.Result[To]` |
| `withEnumCaseHandledPartialFailFast` | alias for the above |
| `withConstructorPartialFailFast` | curried: `(a, b, ...) => (failFast: Boolean) => partial.Result[To]` |
| `withConstructorPartialToFailFast` | curried, with target selector |

### Example

```scala
Foo("value", 10)
  .intoPartial[Bar]
  .withFieldComputedPartialFailFast(_.c, (foo, failFast) =>
    if (failFast) partial.Result.fromValue(foo.b.toLong)      // skip expensive work
    else partial.Result.fromValue(foo.b.toLong * 2)           // full computation
  )
  .transformFailFast // failFast = true
```

### Implementation details

- **Type-level entries**: `ComputedPartialFailFast`, `ComputedPartialFromFailFast`, `CaseComputedPartialFailFast`, `ConstructorPartialFailFast` added to `TransformerOverrides`
- **Internal representation**: `failFastAware: Boolean` flag on `TransformerOverride.ComputedPartial` and `ConstructorPartial`
- **Curried storage**: Functions are stored curried (`A => Boolean => Result[B]`) since `chimney-macro-commons` only supports `Expr.apply` for `Function1`
- **Rule modules**: `TransformProductToProductRuleModule` and `TransformSealedHierarchyToSealedHierarchyRuleModule` updated to thread `ctx.failFast` when `failFastAware = true`

### Tests

- `withFieldComputedPartialFailFast` passes correct `failFast` via `transform` and `transformFailFast`
- `withFieldComputedPartialFromFailFast` variant
- `withSealedSubtypeHandledPartialFailFast` for sealed hierarchies
- `PartialTransformer.define` builder variant

### Documentation

- New "Fail-fast-aware partial computations" subsection in `supported-transformations.md`
- Runnable Scala CLI snippet demonstrating `failFast` flag behavior
