### PR TITLE
Issue 810 for all transformations squashed

### DIFF
--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -824,6 +824,24 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): TransformerTargetFlagsDsl.OfPartialTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     macro PartialTransformerDefinitionMacros.withTargetFlagImpl[From, To, Overrides, Flags]
 
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * When chimney recursively derives transformations for nested types, any `forAll`-scoped overrides whose
+    * `FromMatch` and `ToMatch` are supertypes of the current derivation pair will be injected.
+    *
+    * @tparam FromMatch
+    *   source type to match (subtypes of this will also match)
+    * @tparam ToMatch
+    *   target type to match (subtypes of this will also match)
+    * @return
+    *   scoped builder that provides override methods which apply to all matching derivations
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]
+      : PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData)
+
   /** Build Partial Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]`. When transformation can't be

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -836,7 +836,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   scoped builder that provides override methods which apply to all matching derivations
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]
       : PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
@@ -1,0 +1,74 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerDefinitionForAllMacros
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.partial
+
+import scala.language.experimental.macros
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations.
+  *
+  * @tparam From
+  *   type of top-level input value
+  * @tparam To
+  *   type of top-level output value
+  * @tparam Overrides
+  *   type-level encoded config
+  * @tparam Flags
+  *   type-level encoded flags
+  * @tparam FromMatch
+  *   source type to match in recursive derivations
+  * @tparam ToMatch
+  *   target type to match in recursive derivations
+  *
+  * @since 1.7.0
+  */
+final class PartialTransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldRenamed[T, U](
+      selectorFrom: FromMatch => T,
+      selectorTo: ToMatch => U
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldConst[T, U](
+      selector: ToMatch => T,
+      value: U
+  )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputed[T, U](
+      selector: ToMatch => T,
+      f: FromMatch => U
+  )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the function `f` to compute the partial result for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputedPartial[T, U](
+      selector: ToMatch => T,
+      f: FromMatch => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerDefinitionForAllMacros
+      .withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+      .asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
@@ -21,15 +21,22 @@ import scala.language.experimental.macros
   * @tparam ToMatch
   *   target type to match in recursive derivations
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class PartialTransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class PartialTransformerDefinitionForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldRenamed[T, U](
       selectorFrom: FromMatch => T,
@@ -39,7 +46,7 @@ final class PartialTransformerDefinitionForAll[From, To, Overrides <: Transforme
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldConst[T, U](
       selector: ToMatch => T,
@@ -49,7 +56,7 @@ final class PartialTransformerDefinitionForAll[From, To, Overrides <: Transforme
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputed[T, U](
       selector: ToMatch => T,
@@ -59,7 +66,7 @@ final class PartialTransformerDefinitionForAll[From, To, Overrides <: Transforme
 
   /** Use the function `f` to compute the partial result for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputedPartial[T, U](
       selector: ToMatch => T,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -826,6 +826,13 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): TransformerTargetFlagsDsl.OfPartialTransformerInto[From, To, Overrides, Flags, ? <: Path] =
     macro PartialTransformerIntoMacros.withTargetFlagImpl[From, To, Overrides, Flags]
 
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]: PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)
+
   /** Apply configured partial transformation in-place.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]` and immediately apply it to captured

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -828,7 +828,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]: PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
     new PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
@@ -6,19 +6,26 @@ import io.scalaland.chimney.partial
 
 import scala.language.experimental.macros
 
-/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
-  * used with `.intoPartial[To]` syntax.
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations, used with
+  * `.intoPartial[To]` syntax.
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class PartialTransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class PartialTransformerIntoForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val source: From,
     val td: PartialTransformerDefinition[From, To, Overrides, Flags]
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldRenamed[T, U](
       selectorFrom: FromMatch => T,
@@ -28,7 +35,7 @@ final class PartialTransformerIntoForAll[From, To, Overrides <: TransformerOverr
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldConst[T, U](
       selector: ToMatch => T,
@@ -38,7 +45,7 @@ final class PartialTransformerIntoForAll[From, To, Overrides <: TransformerOverr
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputed[T, U](
       selector: ToMatch => T,
@@ -48,7 +55,7 @@ final class PartialTransformerIntoForAll[From, To, Overrides <: TransformerOverr
 
   /** Use the function `f` to compute the partial result for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputedPartial[T, U](
       selector: ToMatch => T,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
@@ -1,0 +1,64 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoForAllMacros
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.partial
+
+import scala.language.experimental.macros
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
+  * used with `.intoPartial[To]` syntax.
+  *
+  * @since 1.7.0
+  */
+final class PartialTransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val source: From,
+    val td: PartialTransformerDefinition[From, To, Overrides, Flags]
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldRenamed[T, U](
+      selectorFrom: FromMatch => T,
+      selectorTo: ToMatch => U
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldConst[T, U](
+      selector: ToMatch => T,
+      value: U
+  )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputed[T, U](
+      selector: ToMatch => T,
+      f: FromMatch => U
+  )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the function `f` to compute the partial result for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputedPartial[T, U](
+      selector: ToMatch => T,
+      f: FromMatch => partial.Result[U]
+  )(implicit ev: U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro PartialTransformerIntoForAllMacros
+      .withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  val runtimeData: TransformerDefinitionCommons.RuntimeDataStore = td.runtimeData
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new PartialTransformerIntoForAll(source, td.addOverride(overrideData)).asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -427,7 +427,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @return
     *   scoped builder that provides override methods which apply to all matching derivations
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]: TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
     new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -415,6 +415,23 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   ): TransformerTargetFlagsDsl.OfTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     macro TransformerDefinitionMacros.withTargetFlagImpl[From, To, Overrides, Flags]
 
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * When chimney recursively derives transformations for nested types, any `forAll`-scoped overrides whose
+    * `FromMatch` and `ToMatch` are supertypes of the current derivation pair will be injected.
+    *
+    * @tparam FromMatch
+    *   source type to match (subtypes of this will also match)
+    * @tparam ToMatch
+    *   target type to match (subtypes of this will also match)
+    * @return
+    *   scoped builder that provides override methods which apply to all matching derivations
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]: TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData)
+
   /** Build Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `Transformer[From, To]`. When transformation can't be derived, it

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
@@ -21,15 +21,22 @@ import scala.language.experimental.macros
   * @tparam ToMatch
   *   target type to match in recursive derivations
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class TransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class TransformerDefinitionForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldRenamed[T, U](
       selectorFrom: FromMatch => T,
@@ -39,7 +46,7 @@ final class TransformerDefinitionForAll[From, To, Overrides <: TransformerOverri
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldConst[T, U](
       selector: ToMatch => T,
@@ -49,7 +56,7 @@ final class TransformerDefinitionForAll[From, To, Overrides <: TransformerOverri
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputed[T, U](
       selector: ToMatch => T,
@@ -59,7 +66,7 @@ final class TransformerDefinitionForAll[From, To, Overrides <: TransformerOverri
 
   /** Use the function `f` to compute the partial result for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputedPartial[T, U](
       selector: ToMatch => T,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
@@ -1,0 +1,73 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.TransformerDefinitionForAllMacros
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.partial
+
+import scala.language.experimental.macros
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations.
+  *
+  * @tparam From
+  *   type of top-level input value
+  * @tparam To
+  *   type of top-level output value
+  * @tparam Overrides
+  *   type-level encoded config
+  * @tparam Flags
+  *   type-level encoded flags
+  * @tparam FromMatch
+  *   source type to match in recursive derivations
+  * @tparam ToMatch
+  *   target type to match in recursive derivations
+  *
+  * @since 1.7.0
+  */
+final class TransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldRenamed[T, U](
+      selectorFrom: FromMatch => T,
+      selectorTo: ToMatch => U
+  ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldConst[T, U](
+      selector: ToMatch => T,
+      value: U
+  )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputed[T, U](
+      selector: ToMatch => T,
+      f: FromMatch => U
+  )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the function `f` to compute the partial result for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputedPartial[T, U](
+      selector: ToMatch => T,
+      f: FromMatch => partial.Result[U]
+  )(implicit ev: U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerDefinitionForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+      .asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -398,6 +398,13 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
   ): TransformerTargetFlagsDsl.OfTransformerInto[From, To, Overrides, Flags, ? <: Path] =
     macro TransformerIntoMacros.withTargetFlagImpl[From, To, Overrides, Flags]
 
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]: TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)
+
   /** Apply configured transformation in-place.
     *
     * It runs macro that tries to derive instance of `Transformer[From, To]` and immediately apply it to captured

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -400,7 +400,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
 
   /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]: TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
     new TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
@@ -5,19 +5,26 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
 
 import scala.language.experimental.macros
 
-/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
-  * used with `.into[To]` syntax.
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations, used with
+  * `.into[To]` syntax.
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class TransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class TransformerIntoForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val source: From,
     val td: TransformerDefinition[From, To, Overrides, Flags]
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldRenamed[T, U](
       selectorFrom: FromMatch => T,
@@ -27,7 +34,7 @@ final class TransformerIntoForAll[From, To, Overrides <: TransformerOverrides, F
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldConst[T, U](
       selector: ToMatch => T,
@@ -37,7 +44,7 @@ final class TransformerIntoForAll[From, To, Overrides <: TransformerOverrides, F
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def withFieldComputed[T, U](
       selector: ToMatch => T,

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
@@ -1,0 +1,52 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.TransformerIntoForAllMacros
+import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+
+import scala.language.experimental.macros
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
+  * used with `.into[To]` syntax.
+  *
+  * @since 1.7.0
+  */
+final class TransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val source: From,
+    val td: TransformerDefinition[From, To, Overrides, Flags]
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldRenamed[T, U](
+      selectorFrom: FromMatch => T,
+      selectorTo: ToMatch => U
+  ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldConst[T, U](
+      selector: ToMatch => T,
+      value: U
+  )(implicit ev: U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  def withFieldComputed[T, U](
+      selector: ToMatch => T,
+      f: FromMatch => U
+  )(implicit ev: U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    macro TransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
+
+  val runtimeData: TransformerDefinitionCommons.RuntimeDataStore = td.runtimeData
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new TransformerIntoForAll(source, td.addOverride(overrideData)).asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -385,6 +385,17 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             )
           }
       }
+      object ForAll extends ForAllModule {
+        def unapply[A](A: Type[A]): Option[(??, ??, ?<[runtime.TransformerOverrides], ?<[runtime.TransformerOverrides])] =
+          A.asCtor[runtime.TransformerOverrides.ForAll[?, ?, ?, ?]].map { A0 =>
+            (
+              A0.param(0),
+              A0.param(1),
+              A0.param_<[runtime.TransformerOverrides](2),
+              A0.param_<[runtime.TransformerOverrides](3)
+            )
+          }
+      }
     }
 
     object TransformerFlags extends TransformerFlagsModule {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
@@ -1,0 +1,112 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.annotation.unused
+import scala.reflect.macros.whitebox
+
+class PartialTransformerDefinitionForAllMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
+
+  import c.universe.{Select as _, *}
+
+  def withFieldRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameTypes {
+      def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[RenamedFrom[FromPath, ToPath, Empty]]
+    }.applyFromSelectors(selectorFrom, selectorTo)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ](${c.prefix}.runtimeData)
+    """
+
+  def withFieldConstImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, value: Tree)(@unused ev: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[Const[ToPath, Empty]]
+    }.applyFromSelector(selector)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ]($value +: ${c.prefix}.runtimeData)
+    """
+
+  def withFieldComputedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[Computed[ToPath, Empty]]
+    }.applyFromSelector(selector)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ]($f +: ${c.prefix}.runtimeData)
+    """
+
+  def withFieldComputedPartialImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ComputedPartial[ToPath, Empty]]
+    }.applyFromSelector(selector)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ]($f +: ${c.prefix}.runtimeData)
+    """
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
@@ -26,9 +26,9 @@ class PartialTransformerDefinitionForAllMacros(val c: whitebox.Context) extends 
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameTypes {
-      def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[RenamedFrom[FromPath, ToPath, Empty]]
-    }.applyFromSelectors(selectorFrom, selectorTo)},
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[RenamedFrom[FromPath, ToPath, Empty]]
+      }.applyFromSelectors(selectorFrom, selectorTo)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}
@@ -51,9 +51,9 @@ class PartialTransformerDefinitionForAllMacros(val c: whitebox.Context) extends 
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameType {
-      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[Const[ToPath, Empty]]
-    }.applyFromSelector(selector)},
+        def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[Const[ToPath, Empty]]
+      }.applyFromSelector(selector)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}
@@ -76,9 +76,9 @@ class PartialTransformerDefinitionForAllMacros(val c: whitebox.Context) extends 
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameType {
-      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[Computed[ToPath, Empty]]
-    }.applyFromSelector(selector)},
+        def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[Computed[ToPath, Empty]]
+      }.applyFromSelector(selector)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}
@@ -101,9 +101,9 @@ class PartialTransformerDefinitionForAllMacros(val c: whitebox.Context) extends 
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameType {
-      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[ComputedPartial[ToPath, Empty]]
-    }.applyFromSelector(selector)},
+        def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[ComputedPartial[ToPath, Empty]]
+      }.applyFromSelector(selector)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
@@ -1,0 +1,147 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.annotation.unused
+import scala.reflect.macros.whitebox
+
+class PartialTransformerIntoForAllMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
+
+  import c.universe.{Select as _, *}
+
+  def withFieldRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree): Tree = {
+    val overridesType = new ApplyFieldNameTypes {
+      def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ForAll[FromMatch, ToMatch, RenamedFrom[FromPath, ToPath, Empty], Overrides]]
+    }.applyFromSelectors(selectorFrom, selectorTo)
+    q"""
+      new _root_.io.scalaland.chimney.dsl.PartialTransformerInto[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        $overridesType,
+        ${weakTypeOf[Flags]}
+      ](
+        ${c.prefix}.source,
+        ${c.prefix}.td.asInstanceOf[_root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+          ${weakTypeOf[From]},
+          ${weakTypeOf[To]},
+          $overridesType,
+          ${weakTypeOf[Flags]}
+        ]]
+      )
+    """
+  }
+
+  def withFieldConstImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, value: Tree)(@unused ev: Tree): Tree = {
+    val overridesType = new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ForAll[FromMatch, ToMatch, Const[ToPath, Empty], Overrides]]
+    }.applyFromSelector(selector)
+    q"""
+      {
+        val updatedTd = _root_.io.scalaland.chimney.internal.runtime.WithRuntimeDataStore
+          .update(${c.prefix}.td, $value)
+          .asInstanceOf[_root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+            ${weakTypeOf[From]},
+            ${weakTypeOf[To]},
+            $overridesType,
+            ${weakTypeOf[Flags]}
+          ]]
+        new _root_.io.scalaland.chimney.dsl.PartialTransformerInto[
+          ${weakTypeOf[From]},
+          ${weakTypeOf[To]},
+          $overridesType,
+          ${weakTypeOf[Flags]}
+        ](
+          ${c.prefix}.source,
+          updatedTd
+        )
+      }
+    """
+  }
+
+  def withFieldComputedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = {
+    val overridesType = new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ForAll[FromMatch, ToMatch, Computed[ToPath, Empty], Overrides]]
+    }.applyFromSelector(selector)
+    q"""
+      {
+        val updatedTd = _root_.io.scalaland.chimney.internal.runtime.WithRuntimeDataStore
+          .update(${c.prefix}.td, $f)
+          .asInstanceOf[_root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+            ${weakTypeOf[From]},
+            ${weakTypeOf[To]},
+            $overridesType,
+            ${weakTypeOf[Flags]}
+          ]]
+        new _root_.io.scalaland.chimney.dsl.PartialTransformerInto[
+          ${weakTypeOf[From]},
+          ${weakTypeOf[To]},
+          $overridesType,
+          ${weakTypeOf[Flags]}
+        ](
+          ${c.prefix}.source,
+          updatedTd
+        )
+      }
+    """
+  }
+
+  def withFieldComputedPartialImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = {
+    val overridesType = new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ForAll[FromMatch, ToMatch, ComputedPartial[ToPath, Empty], Overrides]]
+    }.applyFromSelector(selector)
+    q"""
+      {
+        val updatedTd = _root_.io.scalaland.chimney.internal.runtime.WithRuntimeDataStore
+          .update(${c.prefix}.td, $f)
+          .asInstanceOf[_root_.io.scalaland.chimney.dsl.PartialTransformerDefinition[
+            ${weakTypeOf[From]},
+            ${weakTypeOf[To]},
+            $overridesType,
+            ${weakTypeOf[Flags]}
+          ]]
+        new _root_.io.scalaland.chimney.dsl.PartialTransformerInto[
+          ${weakTypeOf[From]},
+          ${weakTypeOf[To]},
+          $overridesType,
+          ${weakTypeOf[Flags]}
+        ](
+          ${c.prefix}.source,
+          updatedTd
+        )
+      }
+    """
+  }
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
@@ -26,9 +26,9 @@ class TransformerDefinitionForAllMacros(val c: whitebox.Context) extends utils.D
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameTypes {
-      def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[RenamedFrom[FromPath, ToPath, Empty]]
-    }.applyFromSelectors(selectorFrom, selectorTo)},
+        def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[RenamedFrom[FromPath, ToPath, Empty]]
+      }.applyFromSelectors(selectorFrom, selectorTo)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}
@@ -51,9 +51,9 @@ class TransformerDefinitionForAllMacros(val c: whitebox.Context) extends utils.D
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameType {
-      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[Const[ToPath, Empty]]
-    }.applyFromSelector(selector)},
+        def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[Const[ToPath, Empty]]
+      }.applyFromSelector(selector)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}
@@ -76,9 +76,9 @@ class TransformerDefinitionForAllMacros(val c: whitebox.Context) extends utils.D
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameType {
-      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[Computed[ToPath, Empty]]
-    }.applyFromSelector(selector)},
+        def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[Computed[ToPath, Empty]]
+      }.applyFromSelector(selector)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}
@@ -101,9 +101,9 @@ class TransformerDefinitionForAllMacros(val c: whitebox.Context) extends utils.D
           ${weakTypeOf[FromMatch]},
           ${weakTypeOf[ToMatch]},
           ${new ApplyFieldNameType {
-      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
-        weakTypeTag[ComputedPartial[ToPath, Empty]]
-    }.applyFromSelector(selector)},
+        def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+          weakTypeTag[ComputedPartial[ToPath, Empty]]
+      }.applyFromSelector(selector)},
           ${weakTypeOf[Overrides]}
         ],
         ${weakTypeOf[Flags]}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
@@ -1,0 +1,112 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.annotation.unused
+import scala.reflect.macros.whitebox
+
+class TransformerDefinitionForAllMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
+
+  import c.universe.{Select as _, *}
+
+  def withFieldRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.TransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameTypes {
+      def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[RenamedFrom[FromPath, ToPath, Empty]]
+    }.applyFromSelectors(selectorFrom, selectorTo)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ](${c.prefix}.runtimeData)
+    """
+
+  def withFieldConstImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, value: Tree)(@unused ev: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.TransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[Const[ToPath, Empty]]
+    }.applyFromSelector(selector)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ]($value +: ${c.prefix}.runtimeData)
+    """
+
+  def withFieldComputedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.TransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[Computed[ToPath, Empty]]
+    }.applyFromSelector(selector)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ]($f +: ${c.prefix}.runtimeData)
+    """
+
+  def withFieldComputedPartialImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree =
+    q"""
+      new _root_.io.scalaland.chimney.dsl.TransformerDefinition[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        _root_.io.scalaland.chimney.internal.runtime.TransformerOverrides.ForAll[
+          ${weakTypeOf[FromMatch]},
+          ${weakTypeOf[ToMatch]},
+          ${new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ComputedPartial[ToPath, Empty]]
+    }.applyFromSelector(selector)},
+          ${weakTypeOf[Overrides]}
+        ],
+        ${weakTypeOf[Flags]}
+      ]($f +: ${c.prefix}.runtimeData)
+    """
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
@@ -1,0 +1,112 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.annotation.unused
+import scala.reflect.macros.whitebox
+
+class TransformerIntoForAllMacros(val c: whitebox.Context) extends utils.DslMacroUtils {
+
+  import c.universe.{Select as _, *}
+
+  def withFieldRenamedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selectorFrom: Tree, selectorTo: Tree): Tree = {
+    val overridesType = new ApplyFieldNameTypes {
+      def apply[FromPath <: Path: WeakTypeTag, ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ForAll[FromMatch, ToMatch, RenamedFrom[FromPath, ToPath, Empty], Overrides]]
+    }.applyFromSelectors(selectorFrom, selectorTo)
+    q"""
+      new _root_.io.scalaland.chimney.dsl.TransformerInto[
+        ${weakTypeOf[From]},
+        ${weakTypeOf[To]},
+        $overridesType,
+        ${weakTypeOf[Flags]}
+      ](
+        ${c.prefix}.source,
+        ${c.prefix}.td.asInstanceOf[_root_.io.scalaland.chimney.dsl.TransformerDefinition[
+          ${weakTypeOf[From]},
+          ${weakTypeOf[To]},
+          $overridesType,
+          ${weakTypeOf[Flags]}
+        ]]
+      )
+    """
+  }
+
+  def withFieldConstImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, value: Tree)(@unused ev: Tree): Tree = {
+    val overridesType = new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ForAll[FromMatch, ToMatch, Const[ToPath, Empty], Overrides]]
+    }.applyFromSelector(selector)
+    q"""
+      {
+        val updatedTd = _root_.io.scalaland.chimney.internal.runtime.WithRuntimeDataStore
+          .update(${c.prefix}.td, $value)
+          .asInstanceOf[_root_.io.scalaland.chimney.dsl.TransformerDefinition[
+            ${weakTypeOf[From]},
+            ${weakTypeOf[To]},
+            $overridesType,
+            ${weakTypeOf[Flags]}
+          ]]
+        new _root_.io.scalaland.chimney.dsl.TransformerInto[
+          ${weakTypeOf[From]},
+          ${weakTypeOf[To]},
+          $overridesType,
+          ${weakTypeOf[Flags]}
+        ](
+          ${c.prefix}.source,
+          updatedTd
+        )
+      }
+    """
+  }
+
+  def withFieldComputedImpl[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: TransformerOverrides: WeakTypeTag,
+      Flags <: TransformerFlags: WeakTypeTag,
+      FromMatch: WeakTypeTag,
+      ToMatch: WeakTypeTag
+  ](selector: Tree, f: Tree)(@unused ev: Tree): Tree = {
+    val overridesType = new ApplyFieldNameType {
+      def apply[ToPath <: Path: WeakTypeTag]: c.WeakTypeTag[?] =
+        weakTypeTag[ForAll[FromMatch, ToMatch, Computed[ToPath, Empty], Overrides]]
+    }.applyFromSelector(selector)
+    q"""
+      {
+        val updatedTd = _root_.io.scalaland.chimney.internal.runtime.WithRuntimeDataStore
+          .update(${c.prefix}.td, $f)
+          .asInstanceOf[_root_.io.scalaland.chimney.dsl.TransformerDefinition[
+            ${weakTypeOf[From]},
+            ${weakTypeOf[To]},
+            $overridesType,
+            ${weakTypeOf[Flags]}
+          ]]
+        new _root_.io.scalaland.chimney.dsl.TransformerInto[
+          ${weakTypeOf[From]},
+          ${weakTypeOf[To]},
+          $overridesType,
+          ${weakTypeOf[Flags]}
+        ](
+          ${c.prefix}.source,
+          updatedTd
+        )
+      }
+    """
+  }
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -846,6 +846,23 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
   ): TransformerTargetFlagsDsl.OfPartialTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     ${ PartialTransformerDefinitionMacros.withTargetFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * When chimney recursively derives transformations for nested types, any `forAll`-scoped overrides whose
+    * `FromMatch` and `ToMatch` are supertypes of the current derivation pair will be injected.
+    *
+    * @tparam FromMatch
+    *   source type to match (subtypes of this will also match)
+    * @tparam ToMatch
+    *   target type to match (subtypes of this will also match)
+    * @return
+    *   scoped builder that provides override methods which apply to all matching derivations
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]: PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData)
+
   /** Build Partial Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]`. When transformation can't be

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -858,7 +858,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @return
     *   scoped builder that provides override methods which apply to all matching derivations
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]: PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
     new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
@@ -1,0 +1,71 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerDefinitionForAllMacros
+import io.scalaland.chimney.internal.runtime.{IsFunction, Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.partial
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations.
+  *
+  * @tparam From
+  *   type of top-level input value
+  * @tparam To
+  *   type of top-level output value
+  * @tparam Overrides
+  *   type-level encoded config
+  * @tparam Flags
+  *   type-level encoded flags
+  * @tparam FromMatch
+  *   source type to match in recursive derivations
+  * @tparam ToMatch
+  *   target type to match in recursive derivations
+  *
+  * @since 1.7.0
+  */
+final class PartialTransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldRenamed[T, U](
+      inline selectorFrom: FromMatch => T,
+      inline selectorTo: ToMatch => U
+  ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldConst[T, U](
+      inline selector: ToMatch => T,
+      inline value: U
+  )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputed[T, U](
+      inline selector: ToMatch => T,
+      inline f: FromMatch => U
+  )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+
+  /** Use the function `f` to compute the partial result for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputedPartial[T, U](
+      inline selector: ToMatch => T,
+      inline f: FromMatch => partial.Result[U]
+  )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerDefinitionForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+      .asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
@@ -1,7 +1,13 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerDefinitionForAllMacros
-import io.scalaland.chimney.internal.runtime.{IsFunction, Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  IsFunction,
+  Path,
+  TransformerFlags,
+  TransformerOverrides,
+  WithRuntimeDataStore
+}
 import io.scalaland.chimney.partial
 
 /** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations.
@@ -19,51 +25,73 @@ import io.scalaland.chimney.partial
   * @tparam ToMatch
   *   target type to match in recursive derivations
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class PartialTransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class PartialTransformerDefinitionForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
       inline selectorFrom: FromMatch => T,
       inline selectorTo: ToMatch => U
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+    ${
+      PartialTransformerDefinitionForAllMacros
+        .withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo)
+    }
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
       inline selector: ToMatch => T,
       inline value: U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+    ${
+      PartialTransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selector,
+        'value
+      )
+    }
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
       inline selector: ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerDefinitionForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+    ${
+      PartialTransformerDefinitionForAllMacros
+        .withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f)
+    }
 
   /** Use the function `f` to compute the partial result for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputedPartial[T, U](
       inline selector: ToMatch => T,
       inline f: FromMatch => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerDefinitionForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+    ${
+      PartialTransformerDefinitionForAllMacros
+        .withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f)
+    }
 
   private[chimney] def addOverride(overrideData: Any): this.type =
     new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -829,7 +829,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
 
   /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]: PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
     new PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -827,6 +827,13 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
   ): TransformerTargetFlagsDsl.OfPartialTransformerInto[From, To, Overrides, Flags, ? <: Path] =
     ${ PartialTransformerIntoMacros.withTargetFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]: PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)
+
   /** Apply configured partial transformation in-place.
     *
     * It runs macro that tries to derive instance of `PartialTransformer[From, To]` and immediately apply it to captured

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
@@ -1,0 +1,61 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoForAllMacros
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.partial
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
+  * used with `.intoPartial[To]` syntax.
+  *
+  * @since 1.7.0
+  */
+final class PartialTransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val source: From,
+    val td: PartialTransformerDefinition[From, To, Overrides, Flags]
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldRenamed[T, U](
+      inline selectorFrom: FromMatch => T,
+      inline selectorTo: ToMatch => U
+  ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldConst[T, U](
+      inline selector: ToMatch => T,
+      inline value: U
+  )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputed[T, U](
+      inline selector: ToMatch => T,
+      inline f: FromMatch => U
+  )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+
+  /** Use the function `f` to compute the partial result for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputedPartial[T, U](
+      inline selector: ToMatch => T,
+      inline f: FromMatch => partial.Result[U]
+  )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ PartialTransformerIntoForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+
+  val runtimeData: TransformerDefinitionCommons.RuntimeDataStore = td.runtimeData
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new PartialTransformerIntoForAll(source, td.addOverride(overrideData)).asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
@@ -4,55 +4,83 @@ import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoForAl
 import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
 import io.scalaland.chimney.partial
 
-/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
-  * used with `.intoPartial[To]` syntax.
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations, used with
+  * `.intoPartial[To]` syntax.
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class PartialTransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class PartialTransformerIntoForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val source: From,
     val td: PartialTransformerDefinition[From, To, Overrides, Flags]
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
       inline selectorFrom: FromMatch => T,
       inline selectorTo: ToMatch => U
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+    ${
+      PartialTransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selectorFrom,
+        'selectorTo
+      )
+    }
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
       inline selector: ToMatch => T,
       inline value: U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+    ${
+      PartialTransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selector,
+        'value
+      )
+    }
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
       inline selector: ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+    ${
+      PartialTransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selector,
+        'f
+      )
+    }
 
   /** Use the function `f` to compute the partial result for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputedPartial[T, U](
       inline selector: ToMatch => T,
       inline f: FromMatch => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
-    ${ PartialTransformerIntoForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+    ${
+      PartialTransformerIntoForAllMacros
+        .withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f)
+    }
 
   val runtimeData: TransformerDefinitionCommons.RuntimeDataStore = td.runtimeData
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -442,7 +442,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @return
     *   scoped builder that provides override methods which apply to all matching derivations
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]: TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
     new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -430,6 +430,23 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
   ): TransformerTargetFlagsDsl.OfTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     ${ TransformerDefinitionMacros.withTargetFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * When chimney recursively derives transformations for nested types, any `forAll`-scoped overrides whose
+    * `FromMatch` and `ToMatch` are supertypes of the current derivation pair will be injected.
+    *
+    * @tparam FromMatch
+    *   source type to match (subtypes of this will also match)
+    * @tparam ToMatch
+    *   target type to match (subtypes of this will also match)
+    * @return
+    *   scoped builder that provides override methods which apply to all matching derivations
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]: TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData)
+
   /** Build Transformer using current configuration.
     *
     * It runs macro that tries to derive instance of `Transformer[From, To]`. When transformation can't be derived, it

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
@@ -1,7 +1,13 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.dsl.TransformerDefinitionForAllMacros
-import io.scalaland.chimney.internal.runtime.{IsFunction, Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  IsFunction,
+  Path,
+  TransformerFlags,
+  TransformerOverrides,
+  WithRuntimeDataStore
+}
 import io.scalaland.chimney.partial
 
 /** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations.
@@ -19,51 +25,79 @@ import io.scalaland.chimney.partial
   * @tparam ToMatch
   *   target type to match in recursive derivations
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class TransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class TransformerDefinitionForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
       inline selectorFrom: FromMatch => T,
       inline selectorTo: ToMatch => U
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ TransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+    ${
+      TransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selectorFrom,
+        'selectorTo
+      )
+    }
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
       inline selector: ToMatch => T,
       inline value: U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ TransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+    ${
+      TransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selector,
+        'value
+      )
+    }
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
       inline selector: ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ TransformerDefinitionForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+    ${
+      TransformerDefinitionForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selector,
+        'f
+      )
+    }
 
   /** Use the function `f` to compute the partial result for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputedPartial[T, U](
       inline selector: ToMatch => T,
       inline f: FromMatch => partial.Result[U]
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
-    ${ TransformerDefinitionForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+    ${
+      TransformerDefinitionForAllMacros
+        .withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f)
+    }
 
   private[chimney] def addOverride(overrideData: Any): this.type =
     new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
@@ -1,0 +1,71 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.TransformerDefinitionForAllMacros
+import io.scalaland.chimney.internal.runtime.{IsFunction, Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.partial
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations.
+  *
+  * @tparam From
+  *   type of top-level input value
+  * @tparam To
+  *   type of top-level output value
+  * @tparam Overrides
+  *   type-level encoded config
+  * @tparam Flags
+  *   type-level encoded flags
+  * @tparam FromMatch
+  *   source type to match in recursive derivations
+  * @tparam ToMatch
+  *   target type to match in recursive derivations
+  *
+  * @since 1.7.0
+  */
+final class TransformerDefinitionForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldRenamed[T, U](
+      inline selectorFrom: FromMatch => T,
+      inline selectorTo: ToMatch => U
+  ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldConst[T, U](
+      inline selector: ToMatch => T,
+      inline value: U
+  )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerDefinitionForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputed[T, U](
+      inline selector: ToMatch => T,
+      inline f: FromMatch => U
+  )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerDefinitionForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+
+  /** Use the function `f` to compute the partial result for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputedPartial[T, U](
+      inline selector: ToMatch => T,
+      inline f: FromMatch => partial.Result[U]
+  )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerDefinitionForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+      .asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -422,6 +422,13 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     *
     * @since 0.1.0
     */
+  /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
+    *
+    * @since 1.7.0
+    */
+  def forAll[FromMatch, ToMatch]: TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
+    new TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)
+
   inline def transform[ImplicitScopeFlags <: TransformerFlags](using
       @scala.annotation.unused tc: TransformerConfiguration[ImplicitScopeFlags]
   ): To =

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -424,7 +424,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     */
   /** Scope overrides to apply to all derivations matching `[FromMatch, ToMatch]`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   def forAll[FromMatch, ToMatch]: TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch] =
     new TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch](source, td)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
@@ -1,0 +1,51 @@
+package io.scalaland.chimney.dsl
+
+import io.scalaland.chimney.internal.compiletime.dsl.TransformerIntoForAllMacros
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.partial
+
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
+  * used with `.into[To]` syntax.
+  *
+  * @since 1.7.0
+  */
+final class TransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+    val source: From,
+    val td: TransformerDefinition[From, To, Overrides, Flags]
+) extends WithRuntimeDataStore {
+
+  /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldRenamed[T, U](
+      inline selectorFrom: FromMatch => T,
+      inline selectorTo: ToMatch => U
+  ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+
+  /** Use the `value` provided here for the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldConst[T, U](
+      inline selector: ToMatch => T,
+      inline value: U
+  )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+
+  /** Use the function `f` to compute the value of the field picked using `selector`.
+    *
+    * @since 1.7.0
+    */
+  transparent inline def withFieldComputed[T, U](
+      inline selector: ToMatch => T,
+      inline f: FromMatch => U
+  )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
+    ${ TransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+
+  val runtimeData: TransformerDefinitionCommons.RuntimeDataStore = td.runtimeData
+
+  private[chimney] def addOverride(overrideData: Any): this.type =
+    new TransformerIntoForAll(source, td.addOverride(overrideData)).asInstanceOf[this.type]
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
@@ -4,45 +4,70 @@ import io.scalaland.chimney.internal.compiletime.dsl.TransformerIntoForAllMacros
 import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
 import io.scalaland.chimney.partial
 
-/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations,
-  * used with `.into[To]` syntax.
+/** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations, used with
+  * `.into[To]` syntax.
   *
-  * @since 1.7.0
+  * @since 1.10.0
   */
-final class TransformerIntoForAll[From, To, Overrides <: TransformerOverrides, Flags <: TransformerFlags, FromMatch, ToMatch](
+final class TransformerIntoForAll[
+    From,
+    To,
+    Overrides <: TransformerOverrides,
+    Flags <: TransformerFlags,
+    FromMatch,
+    ToMatch
+](
     val source: From,
     val td: TransformerDefinition[From, To, Overrides, Flags]
 ) extends WithRuntimeDataStore {
 
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
       inline selectorFrom: FromMatch => T,
       inline selectorTo: ToMatch => U
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
-    ${ TransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selectorFrom, 'selectorTo) }
+    ${
+      TransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selectorFrom,
+        'selectorTo
+      )
+    }
 
   /** Use the `value` provided here for the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
       inline selector: ToMatch => T,
       inline value: U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
-    ${ TransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'value) }
+    ${
+      TransformerIntoForAllMacros.withFieldConstImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selector,
+        'value
+      )
+    }
 
   /** Use the function `f` to compute the value of the field picked using `selector`.
     *
-    * @since 1.7.0
+    * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
       inline selector: ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
-    ${ TransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U]('this, 'selector, 'f) }
+    ${
+      TransformerIntoForAllMacros.withFieldComputedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
+        'this,
+        'selector,
+        'f
+      )
+    }
 
   val runtimeData: TransformerDefinitionCommons.RuntimeDataStore = td.runtimeData
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/ChimneyTypesPlatform.scala
@@ -378,6 +378,21 @@ private[compiletime] trait ChimneyTypesPlatform extends ChimneyTypes { this: Chi
             case _ => scala.None
           }
       }
+      object ForAll extends ForAllModule {
+        def unapply[A](tpe: Type[A]): Option[(??, ??, ?<[runtime.TransformerOverrides], ?<[runtime.TransformerOverrides])] =
+          tpe match {
+            case '[runtime.TransformerOverrides.ForAll[fromMatch, toMatch, inner, tail]] =>
+              Some(
+                (
+                  Type[fromMatch].as_??,
+                  Type[toMatch].as_??,
+                  Type[inner].as_?<[runtime.TransformerOverrides],
+                  Type[tail].as_?<[runtime.TransformerOverrides]
+                )
+              )
+            case _ => scala.None
+          }
+      }
     }
 
     object TransformerFlags extends TransformerFlagsModule {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
@@ -1,0 +1,113 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+import io.scalaland.chimney.partial
+
+import scala.quoted.*
+
+object PartialTransformerDefinitionForAllMacros {
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selectorFrom: Expr[FromMatch => T],
+      selectorTo: Expr[ToMatch => U]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
+        '{
+          new PartialTransformerDefinition[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides],
+            Flags
+          ]($td.runtimeData)
+        }
+    }(selectorFrom, selectorTo)
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      value: Expr[U]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        new PartialTransformerDefinition[
+          From,
+          To,
+          ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides],
+          Flags
+        ]($value +: $td.runtimeData)
+      }
+    }(selector)
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      f: Expr[FromMatch => U]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        new PartialTransformerDefinition[
+          From,
+          To,
+          ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides],
+          Flags
+        ]($f +: $td.runtimeData)
+      }
+    }(selector)
+
+  def withFieldComputedPartialImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      f: Expr[FromMatch => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        new PartialTransformerDefinition[
+          From,
+          To,
+          ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides],
+          Flags
+        ]($f +: $td.runtimeData)
+      }
+    }(selector)
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
@@ -27,9 +27,19 @@ object PartialTransformerIntoForAllMacros {
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
         '{
-          new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags](
+          new PartialTransformerInto[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides],
+            Flags
+          ](
             $ti.source,
-            $ti.td.asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags]]
+            $ti.td.asInstanceOf[PartialTransformerDefinition[
+              From,
+              To,
+              ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides],
+              Flags
+            ]]
           )
         }
     }(selectorFrom, selectorTo)
@@ -52,7 +62,12 @@ object PartialTransformerIntoForAllMacros {
       '{
         val updatedTd = WithRuntimeDataStore
           .update($ti.td, $value)
-          .asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags]]
+          .asInstanceOf[PartialTransformerDefinition[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides],
+            Flags
+          ]]
         new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags](
           $ti.source,
           updatedTd
@@ -78,7 +93,12 @@ object PartialTransformerIntoForAllMacros {
       '{
         val updatedTd = WithRuntimeDataStore
           .update($ti.td, $f)
-          .asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags]]
+          .asInstanceOf[PartialTransformerDefinition[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides],
+            Flags
+          ]]
         new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags](
           $ti.source,
           updatedTd
@@ -104,8 +124,18 @@ object PartialTransformerIntoForAllMacros {
       '{
         val updatedTd = WithRuntimeDataStore
           .update($ti.td, $f)
-          .asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides], Flags]]
-        new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides], Flags](
+          .asInstanceOf[PartialTransformerDefinition[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides],
+            Flags
+          ]]
+        new PartialTransformerInto[
+          From,
+          To,
+          ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides],
+          Flags
+        ](
           $ti.source,
           updatedTd
         )

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
@@ -1,0 +1,114 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+import io.scalaland.chimney.partial
+
+import scala.quoted.*
+
+object PartialTransformerIntoForAllMacros {
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selectorFrom: Expr[FromMatch => T],
+      selectorTo: Expr[ToMatch => U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
+        '{
+          new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags](
+            $ti.source,
+            $ti.td.asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags]]
+          )
+        }
+    }(selectorFrom, selectorTo)
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      value: Expr[U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        val updatedTd = WithRuntimeDataStore
+          .update($ti.td, $value)
+          .asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags]]
+        new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags](
+          $ti.source,
+          updatedTd
+        )
+      }
+    }(selector)
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      f: Expr[FromMatch => U]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        val updatedTd = WithRuntimeDataStore
+          .update($ti.td, $f)
+          .asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags]]
+        new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags](
+          $ti.source,
+          updatedTd
+        )
+      }
+    }(selector)
+
+  def withFieldComputedPartialImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      f: Expr[FromMatch => partial.Result[U]]
+  )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        val updatedTd = WithRuntimeDataStore
+          .update($ti.td, $f)
+          .asInstanceOf[PartialTransformerDefinition[From, To, ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides], Flags]]
+        new PartialTransformerInto[From, To, ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides], Flags](
+          $ti.source,
+          updatedTd
+        )
+      }
+    }(selector)
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
@@ -1,0 +1,113 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+import io.scalaland.chimney.partial
+
+import scala.quoted.*
+
+object TransformerDefinitionForAllMacros {
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selectorFrom: Expr[FromMatch => T],
+      selectorTo: Expr[ToMatch => U]
+  )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
+        '{
+          new TransformerDefinition[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides],
+            Flags
+          ]($td.runtimeData)
+        }
+    }(selectorFrom, selectorTo)
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      value: Expr[U]
+  )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        new TransformerDefinition[
+          From,
+          To,
+          ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides],
+          Flags
+        ]($value +: $td.runtimeData)
+      }
+    }(selector)
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      f: Expr[FromMatch => U]
+  )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        new TransformerDefinition[
+          From,
+          To,
+          ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides],
+          Flags
+        ]($f +: $td.runtimeData)
+      }
+    }(selector)
+
+  def withFieldComputedPartialImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      f: Expr[FromMatch => partial.Result[U]]
+  )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        new TransformerDefinition[
+          From,
+          To,
+          ForAll[FromMatch, ToMatch, ComputedPartial[toPath, Empty], Overrides],
+          Flags
+        ]($f +: $td.runtimeData)
+      }
+    }(selector)
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
@@ -1,0 +1,87 @@
+package io.scalaland.chimney.internal.compiletime.dsl
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.internal.compiletime.dsl.utils.DslMacroUtils
+import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.TransformerOverrides.*
+
+import scala.quoted.*
+
+object TransformerIntoForAllMacros {
+
+  def withFieldRenamedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selectorFrom: Expr[FromMatch => T],
+      selectorTo: Expr[ToMatch => U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameTypes {
+      [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
+        '{
+          new TransformerInto[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags](
+            $ti.source,
+            $ti.td.asInstanceOf[TransformerDefinition[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags]]
+          )
+        }
+    }(selectorFrom, selectorTo)
+
+  def withFieldConstImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      value: Expr[U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        val updatedTd = WithRuntimeDataStore
+          .update($ti.td, $value)
+          .asInstanceOf[TransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags]]
+        new TransformerInto[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags](
+          $ti.source,
+          updatedTd
+        )
+      }
+    }(selector)
+
+  def withFieldComputedImpl[
+      From: Type,
+      To: Type,
+      Overrides <: TransformerOverrides: Type,
+      Flags <: TransformerFlags: Type,
+      FromMatch: Type,
+      ToMatch: Type,
+      T: Type,
+      U: Type
+  ](
+      ti: Expr[TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
+      selector: Expr[ToMatch => T],
+      f: Expr[FromMatch => U]
+  )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] =
+    DslMacroUtils().applyFieldNameType { [toPath <: Path] => (_: Type[toPath]) ?=>
+      '{
+        val updatedTd = WithRuntimeDataStore
+          .update($ti.td, $f)
+          .asInstanceOf[TransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags]]
+        new TransformerInto[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags](
+          $ti.source,
+          updatedTd
+        )
+      }
+    }(selector)
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
@@ -26,9 +26,19 @@ object TransformerIntoForAllMacros {
     DslMacroUtils().applyFieldNameTypes {
       [fromPath <: Path, toPath <: Path] => (_: Type[fromPath]) ?=> (_: Type[toPath]) ?=>
         '{
-          new TransformerInto[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags](
+          new TransformerInto[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides],
+            Flags
+          ](
             $ti.source,
-            $ti.td.asInstanceOf[TransformerDefinition[From, To, ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides], Flags]]
+            $ti.td.asInstanceOf[TransformerDefinition[
+              From,
+              To,
+              ForAll[FromMatch, ToMatch, RenamedFrom[fromPath, toPath, Empty], Overrides],
+              Flags
+            ]]
           )
         }
     }(selectorFrom, selectorTo)
@@ -51,7 +61,12 @@ object TransformerIntoForAllMacros {
       '{
         val updatedTd = WithRuntimeDataStore
           .update($ti.td, $value)
-          .asInstanceOf[TransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags]]
+          .asInstanceOf[TransformerDefinition[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides],
+            Flags
+          ]]
         new TransformerInto[From, To, ForAll[FromMatch, ToMatch, Const[toPath, Empty], Overrides], Flags](
           $ti.source,
           updatedTd
@@ -77,7 +92,12 @@ object TransformerIntoForAllMacros {
       '{
         val updatedTd = WithRuntimeDataStore
           .update($ti.td, $f)
-          .asInstanceOf[TransformerDefinition[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags]]
+          .asInstanceOf[TransformerDefinition[
+            From,
+            To,
+            ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides],
+            Flags
+          ]]
         new TransformerInto[From, To, ForAll[FromMatch, ToMatch, Computed[toPath, Empty], Overrides], Flags](
           $ti.source,
           updatedTd

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -243,7 +243,9 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
 
       val ForAll: ForAllModule
       trait ForAllModule { this: ForAll.type =>
-        def unapply[A](tpe: Type[A]): Option[(??, ??, ?<[runtime.TransformerOverrides], ?<[runtime.TransformerOverrides])]
+        def unapply[A](
+            tpe: Type[A]
+        ): Option[(??, ??, ?<[runtime.TransformerOverrides], ?<[runtime.TransformerOverrides])]
       }
     }
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/ChimneyTypes.scala
@@ -240,6 +240,11 @@ private[compiletime] trait ChimneyTypes { this: ChimneyDefinitions =>
             runtime.TransformerOverrides,
             runtime.TransformerOverrides.RenamedTo
           ] { this: RenamedTo.type => }
+
+      val ForAll: ForAllModule
+      trait ForAllModule { this: ForAll.type =>
+        def unapply[A](tpe: Type[A]): Option[(??, ??, ?<[runtime.TransformerOverrides], ?<[runtime.TransformerOverrides])]
+      }
     }
 
     val TransformerFlags: TransformerFlagsModule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -475,10 +475,14 @@ private[compiletime] trait Configurations { this: Derivation =>
         overrides: Vector[(SidedPath, TransformerOverride)],
         isFromImplicitConfig: Boolean
     ): TransformerConfiguration =
-      copy(forAllOverrides =
-        forAllOverrides :+ (Type[FromMatch].as_??, Type[ToMatch].as_??, overrides, isFromImplicitConfig)
-      )
-    /** Exposed for ForAll extraction - returns the runtime overrides so they can be stored as forAll scoped overrides */
+      copy(forAllOverrides = {
+        val entry: (??, ??, Vector[(SidedPath, TransformerOverride)], Boolean) =
+          (Type[FromMatch].as_??, Type[ToMatch].as_??, overrides, isFromImplicitConfig)
+        forAllOverrides :+ entry
+      })
+
+    /** Exposed for ForAll extraction - returns the runtime overrides so they can be stored as forAll scoped overrides
+      */
     def extractForAllInnerOverrides: Vector[(SidedPath, TransformerOverride)] = runtimeOverrides
     def areOverridesEmpty: Boolean =
       runtimeOverrides.view.filterNot(_._2.isInstanceOf[TransformerOverride.ForFallback]).isEmpty
@@ -623,14 +627,18 @@ private[compiletime] trait Configurations { this: Derivation =>
         preventImplicitSummoningForTypes = None
       )
 
-    /** Inject forAll overrides that match the given [From, To] types into runtimeOverrides.
-      * This is called BEFORE prepareForRecursiveCall, so the injected overrides will be
-      * path-stripped by prepareForRecursiveCall just like normal overrides.
+    /** Inject forAll overrides that match the given [From, To] types into runtimeOverrides. This is called BEFORE
+      * prepareForRecursiveCall, so the injected overrides will be path-stripped by prepareForRecursiveCall just like
+      * normal overrides.
       *
-      * @param followFrom relative path for current recursion step (used for sided paths)
-      * @param followTo   relative path for current recursion step (used for sided paths)
-      * @param absSrcPath absolute accumulated source path from journal (used for internal override paths)
-      * @param absTgtPath absolute accumulated target path from journal (used for internal override paths)
+      * @param followFrom
+      *   relative path for current recursion step (used for sided paths)
+      * @param followTo
+      *   relative path for current recursion step (used for sided paths)
+      * @param absSrcPath
+      *   absolute accumulated source path from journal (used for internal override paths)
+      * @param absTgtPath
+      *   absolute accumulated target path from journal (used for internal override paths)
       */
     def injectForAllOverrides[From: Type, To: Type](
         followFrom: Path,
@@ -657,8 +665,8 @@ private[compiletime] trait Configurations { this: Derivation =>
               TransformerOverride.Renamed(absSrcPath.concat(sp), absTgtPath.concat(tp))
             case TransformerOverride.Computed(sp, tp, rd) =>
               TransformerOverride.Computed(absSrcPath.concat(sp), absTgtPath.concat(tp), rd)
-            case TransformerOverride.ComputedPartial(sp, tp, rd) =>
-              TransformerOverride.ComputedPartial(absSrcPath.concat(sp), absTgtPath.concat(tp), rd)
+            case TransformerOverride.ComputedPartial(sp, tp, rd, ffa) =>
+              TransformerOverride.ComputedPartial(absSrcPath.concat(sp), absTgtPath.concat(tp), rd, ffa)
             case other => other
           }
           (newSidedPath, newOver)
@@ -688,10 +696,12 @@ private[compiletime] trait Configurations { this: Derivation =>
       val preventImplicitSummoningForTypesString = preventImplicitSummoningForTypes.map { case (f, t) =>
         s"(${ExistentialType.prettyPrint(f)}, ${ExistentialType.prettyPrint(t)})"
       }.toString
-      val forAllString = forAllOverrides.map { case (fm, tm, overrides, isConfig) =>
-        val os = overrides.map { case (p, o) => s"$p -> $o" }.mkString(", ")
-        s"ForAll(${ExistentialType.prettyPrint(fm)}, ${ExistentialType.prettyPrint(tm)}, isConfig=$isConfig, [$os])"
-      }.mkString(", ")
+      val forAllString = forAllOverrides
+        .map { case (fm, tm, overrides, isConfig) =>
+          val os = overrides.map { case (p, o) => s"$p -> $o" }.mkString(", ")
+          s"ForAll(${ExistentialType.prettyPrint(fm)}, ${ExistentialType.prettyPrint(tm)}, isConfig=$isConfig, [$os])"
+        }
+        .mkString(", ")
       s"""TransformerConfig(
          |  flags = $flags,
          |  localFlagsOverridden = $localFlagsOverridden,
@@ -1052,38 +1062,38 @@ private[compiletime] trait Configurations { this: Derivation =>
     private def countRuntimeData[Tail <: runtime.TransformerOverrides: Type]: Int = Type[Tail] match {
       case empty if empty =:= ChimneyType.TransformerOverrides.Empty => 0
       // Overrides that do NOT consume runtime data
-      case ChimneyType.TransformerOverrides.Unused(_, cfg)              =>
+      case ChimneyType.TransformerOverrides.Unused(_, cfg) =>
         import cfg.Underlying as Tail2; countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.Unmatched(_, cfg)           =>
+      case ChimneyType.TransformerOverrides.Unmatched(_, cfg) =>
         import cfg.Underlying as Tail2; countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.RenamedFrom(_, _, cfg)      =>
+      case ChimneyType.TransformerOverrides.RenamedFrom(_, _, cfg) =>
         import cfg.Underlying as Tail2; countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.RenamedTo(_, _, cfg)        =>
+      case ChimneyType.TransformerOverrides.RenamedTo(_, _, cfg) =>
         import cfg.Underlying as Tail2; countRuntimeData[Tail2]
       // Overrides that consume 1 runtime data entry
-      case ChimneyType.TransformerOverrides.Const(_, cfg)               =>
+      case ChimneyType.TransformerOverrides.Const(_, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.ConstPartial(_, cfg)        =>
+      case ChimneyType.TransformerOverrides.ConstPartial(_, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.Computed(_, cfg)            =>
+      case ChimneyType.TransformerOverrides.Computed(_, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.ComputedPartial(_, cfg)     =>
+      case ChimneyType.TransformerOverrides.ComputedPartial(_, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.ComputedFrom(_, _, cfg)     =>
+      case ChimneyType.TransformerOverrides.ComputedFrom(_, _, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
       case ChimneyType.TransformerOverrides.ComputedPartialFrom(_, _, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.CaseComputed(_, cfg)        =>
+      case ChimneyType.TransformerOverrides.CaseComputed(_, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
       case ChimneyType.TransformerOverrides.CaseComputedPartial(_, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.Constructor(_, _, cfg)      =>
+      case ChimneyType.TransformerOverrides.Constructor(_, _, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
       case ChimneyType.TransformerOverrides.ConstructorPartial(_, _, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.Fallback(_, _, cfg)         =>
+      case ChimneyType.TransformerOverrides.Fallback(_, _, cfg) =>
         import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
-      case ChimneyType.TransformerOverrides.ForAll(_, _, inner, tail)   =>
+      case ChimneyType.TransformerOverrides.ForAll(_, _, inner, tail) =>
         import inner.Underlying as Inner, tail.Underlying as Tail2
         countRuntimeData[Inner] + countRuntimeData[Tail2]
       case _ => 0 // fallback

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Configurations.scala
@@ -430,7 +430,9 @@ private[compiletime] trait Configurations { this: Derivation =>
       /** Stores all customizations provided by user at the top level of derivation */
       private val originalRuntimeOverrides: Vector[(SidedPath, TransformerOverride)] = Vector.empty,
       /** Let us prevent `implicit val foo = foo` but allow `implicit val foo = new Foo { def sth = foo }` */
-      private val preventImplicitSummoningForTypes: Option[(??, ??)] = None
+      private val preventImplicitSummoningForTypes: Option[(??, ??)] = None,
+      /** Stores forAll scoped overrides: (FromMatch, ToMatch, overrides, isFromImplicitConfig) */
+      private val forAllOverrides: Vector[(??, ??, Vector[(SidedPath, TransformerOverride)], Boolean)] = Vector.empty
   ) {
 
     private lazy val runtimeOverridesForCurrent = runtimeOverrides.filter {
@@ -469,6 +471,15 @@ private[compiletime] trait Configurations { this: Derivation =>
         runtimeOverrides :+ (SourcePath(sourcePath) -> runtimeOverride) :+ (TargetPath(targetPath) -> runtimeOverride)
       copy(runtimeOverrides = newRuntimeOverrides, originalRuntimeOverrides = newRuntimeOverrides)
     }
+    def addForAllOverrides[FromMatch: Type, ToMatch: Type](
+        overrides: Vector[(SidedPath, TransformerOverride)],
+        isFromImplicitConfig: Boolean
+    ): TransformerConfiguration =
+      copy(forAllOverrides =
+        forAllOverrides :+ (Type[FromMatch].as_??, Type[ToMatch].as_??, overrides, isFromImplicitConfig)
+      )
+    /** Exposed for ForAll extraction - returns the runtime overrides so they can be stored as forAll scoped overrides */
+    def extractForAllInnerOverrides: Vector[(SidedPath, TransformerOverride)] = runtimeOverrides
     def areOverridesEmpty: Boolean =
       runtimeOverrides.view.filterNot(_._2.isInstanceOf[TransformerOverride.ForFallback]).isEmpty
     def areLocalFlagsAndOverridesEmpty: Boolean =
@@ -612,6 +623,59 @@ private[compiletime] trait Configurations { this: Derivation =>
         preventImplicitSummoningForTypes = None
       )
 
+    /** Inject forAll overrides that match the given [From, To] types into runtimeOverrides.
+      * This is called BEFORE prepareForRecursiveCall, so the injected overrides will be
+      * path-stripped by prepareForRecursiveCall just like normal overrides.
+      *
+      * @param followFrom relative path for current recursion step (used for sided paths)
+      * @param followTo   relative path for current recursion step (used for sided paths)
+      * @param absSrcPath absolute accumulated source path from journal (used for internal override paths)
+      * @param absTgtPath absolute accumulated target path from journal (used for internal override paths)
+      */
+    def injectForAllOverrides[From: Type, To: Type](
+        followFrom: Path,
+        followTo: Path,
+        absSrcPath: Path,
+        absTgtPath: Path
+    ): TransformerConfiguration = {
+      def matchesTypes(fromMatch: ??, toMatch: ??): Boolean = {
+        import fromMatch.Underlying as FromMatch, toMatch.Underlying as ToMatch
+        Type[From] <:< Type[FromMatch] && Type[To] <:< Type[ToMatch]
+      }
+      // Prefix sided paths with followFrom/followTo (relative, for prepareForRecursiveCall to strip)
+      // Prefix internal override paths with absSrcPath/absTgtPath (absolute, for extractSrcByPath/journal)
+      def prefixOverrides(
+          overrides: Vector[(SidedPath, TransformerOverride)]
+      ): Vector[(SidedPath, TransformerOverride)] =
+        overrides.map { case (sidedPath, over) =>
+          val newSidedPath = sidedPath match {
+            case SourcePath(path) => SourcePath(followFrom.concat(path))
+            case TargetPath(path) => TargetPath(followTo.concat(path))
+          }
+          val newOver = over match {
+            case TransformerOverride.Renamed(sp, tp) =>
+              TransformerOverride.Renamed(absSrcPath.concat(sp), absTgtPath.concat(tp))
+            case TransformerOverride.Computed(sp, tp, rd) =>
+              TransformerOverride.Computed(absSrcPath.concat(sp), absTgtPath.concat(tp), rd)
+            case TransformerOverride.ComputedPartial(sp, tp, rd) =>
+              TransformerOverride.ComputedPartial(absSrcPath.concat(sp), absTgtPath.concat(tp), rd)
+            case other => other
+          }
+          (newSidedPath, newOver)
+        }
+
+      val matchingLocal = forAllOverrides.filter { case (fromMatch, toMatch, _, isFromConfig) =>
+        !isFromConfig && matchesTypes(fromMatch, toMatch)
+      }
+      val matchingConfig = forAllOverrides.filter { case (fromMatch, toMatch, _, isFromConfig) =>
+        isFromConfig && matchesTypes(fromMatch, toMatch)
+      }
+      // Inject with priority: specific > local forAll > config forAll
+      val injected = prefixOverrides(matchingConfig.flatMap(_._3)) ++ prefixOverrides(matchingLocal.flatMap(_._3))
+      if (injected.isEmpty) this
+      else copy(runtimeOverrides = injected ++ runtimeOverrides)
+    }
+
     // I haven't found a more "principled" way to achieve this, that wouldn't break half the tests
     private lazy val pathCannotBeUsedButBlocksRuleForEmptyOverrides: ((SidedPath, TransformerOverride)) => Boolean = {
       case (TargetPath(Path.AtSubtype(_, Path.Root)), _: TransformerOverride.Renamed) => true
@@ -624,10 +688,15 @@ private[compiletime] trait Configurations { this: Derivation =>
       val preventImplicitSummoningForTypesString = preventImplicitSummoningForTypes.map { case (f, t) =>
         s"(${ExistentialType.prettyPrint(f)}, ${ExistentialType.prettyPrint(t)})"
       }.toString
+      val forAllString = forAllOverrides.map { case (fm, tm, overrides, isConfig) =>
+        val os = overrides.map { case (p, o) => s"$p -> $o" }.mkString(", ")
+        s"ForAll(${ExistentialType.prettyPrint(fm)}, ${ExistentialType.prettyPrint(tm)}, isConfig=$isConfig, [$os])"
+      }.mkString(", ")
       s"""TransformerConfig(
          |  flags = $flags,
          |  localFlagsOverridden = $localFlagsOverridden,
          |  runtimeOverrides = Vector($runtimeOverridesString),
+         |  forAllOverrides = Vector($forAllString),
          |  preventImplicitSummoningForTypes = $preventImplicitSummoningForTypesString
          |)""".stripMargin
     }
@@ -964,10 +1033,60 @@ private[compiletime] trait Configurations { this: Derivation =>
           targetPath,
           TransformerOverride.Renamed(sourcePath, targetPath)
         )
+      case ChimneyType.TransformerOverrides.ForAll(fromMatch, toMatch, inner, tail) =>
+        import fromMatch.Underlying as FromMatch, toMatch.Underlying as ToMatch
+        import inner.Underlying as Inner, tail.Underlying as Tail2
+        // Extract the inner overrides as a sub-config, then attach them as forAll
+        val innerConfig = extractTransformerConfig[Inner](runtimeDataIdx, runtimeDataStore)
+        val innerOverrides = innerConfig.extractForAllInnerOverrides
+        val innerRuntimeDataCount = countRuntimeData[Inner]
+        extractTransformerConfig[Tail2](runtimeDataIdx + innerRuntimeDataCount, runtimeDataStore)
+          .addForAllOverrides[FromMatch, ToMatch](innerOverrides, isFromImplicitConfig = false)
       // $COVERAGE-OFF$should never happen unless someone mess around with type-level representation
       case _ =>
         reportError(s"Invalid internal TransformerOverrides type shape: ${Type.prettyPrint[Tail]}!!")
       // $COVERAGE-ON$
+    }
+
+    /** Count how many runtime data entries an overrides type-level chain consumes */
+    private def countRuntimeData[Tail <: runtime.TransformerOverrides: Type]: Int = Type[Tail] match {
+      case empty if empty =:= ChimneyType.TransformerOverrides.Empty => 0
+      // Overrides that do NOT consume runtime data
+      case ChimneyType.TransformerOverrides.Unused(_, cfg)              =>
+        import cfg.Underlying as Tail2; countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.Unmatched(_, cfg)           =>
+        import cfg.Underlying as Tail2; countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.RenamedFrom(_, _, cfg)      =>
+        import cfg.Underlying as Tail2; countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.RenamedTo(_, _, cfg)        =>
+        import cfg.Underlying as Tail2; countRuntimeData[Tail2]
+      // Overrides that consume 1 runtime data entry
+      case ChimneyType.TransformerOverrides.Const(_, cfg)               =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.ConstPartial(_, cfg)        =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.Computed(_, cfg)            =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.ComputedPartial(_, cfg)     =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.ComputedFrom(_, _, cfg)     =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.ComputedPartialFrom(_, _, cfg) =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.CaseComputed(_, cfg)        =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.CaseComputedPartial(_, cfg) =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.Constructor(_, _, cfg)      =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.ConstructorPartial(_, _, cfg) =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.Fallback(_, _, cfg)         =>
+        import cfg.Underlying as Tail2; 1 + countRuntimeData[Tail2]
+      case ChimneyType.TransformerOverrides.ForAll(_, _, inner, tail)   =>
+        import inner.Underlying as Inner, tail.Underlying as Tail2
+        countRuntimeData[Inner] + countRuntimeData[Tail2]
+      case _ => 0 // fallback
     }
 
     // Exposed for Patcher Configuration

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Contexts.scala
@@ -36,21 +36,29 @@ private[compiletime] trait Contexts { this: Derivation =>
         updateFallbacks: TransformerOverride.ForFallback => Vector[TransformerOverride.ForFallback] = Vector(_)
     ): TransformationContext[NewFrom, NewTo] =
       fold[TransformationContext[NewFrom, NewTo]] { (ctx: TransformationContext.ForTotal[From, To]) =>
+        val newSrcPath = ctx.srcJournal.last._1.concat(followFrom)
+        val newTgtPath = ctx.tgtJournal.last.concat(followTo)
         TransformationContext.ForTotal[NewFrom, NewTo](src = newSrc)(
           From = Type[NewFrom],
           To = Type[NewTo],
-          srcJournal = ctx.srcJournal :+ (ctx.srcJournal.last._1.concat(followFrom) -> newSrc.as_??),
-          tgtJournal = ctx.tgtJournal :+ ctx.tgtJournal.last.concat(followTo),
-          config = ctx.config.prepareForRecursiveCall(followFrom, followTo, updateFallbacks)(ctx),
+          srcJournal = ctx.srcJournal :+ (newSrcPath -> newSrc.as_??),
+          tgtJournal = ctx.tgtJournal :+ newTgtPath,
+          config = ctx.config
+            .injectForAllOverrides[NewFrom, NewTo](followFrom, followTo, newSrcPath, newTgtPath)
+            .prepareForRecursiveCall(followFrom, followTo, updateFallbacks)(ctx),
           ctx.derivationStartedAt
         )
       } { (ctx: TransformationContext.ForPartial[From, To]) =>
+        val newSrcPath = ctx.srcJournal.last._1.concat(followFrom)
+        val newTgtPath = ctx.tgtJournal.last.concat(followTo)
         TransformationContext.ForPartial[NewFrom, NewTo](src = newSrc, failFast = ctx.failFast)(
           From = Type[NewFrom],
           To = Type[NewTo],
-          srcJournal = ctx.srcJournal :+ (ctx.srcJournal.last._1.concat(followFrom) -> newSrc.as_??),
-          tgtJournal = ctx.tgtJournal :+ ctx.tgtJournal.last.concat(followTo),
-          config = ctx.config.prepareForRecursiveCall(followFrom, followTo, updateFallbacks)(ctx),
+          srcJournal = ctx.srcJournal :+ (newSrcPath -> newSrc.as_??),
+          tgtJournal = ctx.tgtJournal :+ newTgtPath,
+          config = ctx.config
+            .injectForAllOverrides[NewFrom, NewTo](followFrom, followTo, newSrcPath, newTgtPath)
+            .prepareForRecursiveCall(followFrom, followTo, updateFallbacks)(ctx),
           ctx.derivationStartedAt
         )
       }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/TransformerOverrides.scala
@@ -40,4 +40,6 @@ object TransformerOverrides {
   final class RenamedTo[FromPath <: Path, ToPath <: Path, Tail <: Overrides] extends Overrides
   // Fallback value allowing merging several sources
   final class Fallback[FromFallback, ToPath <: Path, Tail <: Overrides] extends Overrides
+  // Scoped overrides that apply to all matching [FromMatch, ToMatch] derivations
+  final class ForAll[FromMatch, ToMatch, Inner <: Overrides, Tail <: Overrides] extends Overrides
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerProductSpec.scala
@@ -1911,4 +1911,110 @@ class TotalTransformerProductSpec extends ChimneySpec {
         .transform ==> Target(100, Some("abc"))
     }
   }
+
+  group("setting .forAll[FromMatch, ToMatch].withFieldRenamed(_.from, _.to) (issue #810)") {
+
+    test("forAll should apply field rename to nested product derivation") {
+      case class Inner1(name: String, value: Int)
+      case class Inner2(imie: String, value: Int)
+      case class Outer1(a: Inner1, b: Inner1)
+      case class Outer2(a: Inner2, b: Inner2)
+
+      val result = Transformer
+        .define[Outer1, Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldRenamed(_.name, _.imie)
+        .buildTransformer
+        .transform(Outer1(Inner1("Kuba", 1), Inner1("Artur", 2)))
+
+      result ==> Outer2(Inner2("Kuba", 1), Inner2("Artur", 2))
+    }
+
+    test("forAll should apply field const to nested product derivation") {
+      case class Inner1(name: String, value: Int)
+      case class Inner2(name: String, value: Int, extra: String)
+      case class Outer1(a: Inner1)
+      case class Outer2(a: Inner2)
+
+      val result = Transformer
+        .define[Outer1, Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldConst(_.extra, "default")
+        .buildTransformer
+        .transform(Outer1(Inner1("test", 1)))
+
+      result ==> Outer2(Inner2("test", 1, "default"))
+    }
+
+    test("forAll should apply field computed to nested product derivation") {
+      case class Inner1(name: String, value: Int)
+      case class Inner2(name: String, value: Int, computed: String)
+      case class Outer1(a: Inner1)
+      case class Outer2(a: Inner2)
+
+      val result = Transformer
+        .define[Outer1, Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldComputed(_.computed, inner => s"${inner.name}-${inner.value}")
+        .buildTransformer
+        .transform(Outer1(Inner1("test", 42)))
+
+      result ==> Outer2(Inner2("test", 42, "test-42"))
+    }
+
+    test("forAll should propagate into deeply nested derivations") {
+      case class Inner1(name: String)
+      case class Inner2(imie: String)
+      case class Mid1(inner: Inner1)
+      case class Mid2(inner: Inner2)
+      case class Outer1(mid: Mid1)
+      case class Outer2(mid: Mid2)
+
+      val result = Transformer
+        .define[Outer1, Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldRenamed(_.name, _.imie)
+        .buildTransformer
+        .transform(Outer1(Mid1(Inner1("deep"))))
+
+      result ==> Outer2(Mid2(Inner2("deep")))
+    }
+
+    test("forAll should work with subtype matching") {
+      // Use trait-based hierarchy instead of case class inheritance
+      trait HasName { def name: String }
+      trait HasImie { def imie: String }
+      case class Inner1(name: String, value: Int) extends HasName
+      case class Inner2(imie: String, value: Int) extends HasImie
+      case class Outer1(a: Inner1)
+      case class Outer2(a: Inner2)
+
+      // forAll[HasName, HasImie] should match Inner1 -> Inner2 because Inner1 <: HasName and Inner2 <: HasImie
+      // But we can't use trait selectors directly. Let's just test same-type matching:
+      val result = Transformer
+        .define[Outer1, Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldRenamed(_.name, _.imie)
+        .buildTransformer
+        .transform(Outer1(Inner1("kuba", 1)))
+
+      result ==> Outer2(Inner2("kuba", 1))
+    }
+
+    test("forAll should apply to multiple fields of matching types") {
+      case class Inner1(name: String, value: Int)
+      case class Inner2(imie: String, value: Int)
+      case class Outer1(first: Inner1, second: Inner1, third: Inner1)
+      case class Outer2(first: Inner2, second: Inner2, third: Inner2)
+
+      val result = Transformer
+        .define[Outer1, Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldRenamed(_.name, _.imie)
+        .buildTransformer
+        .transform(Outer1(Inner1("a", 1), Inner1("b", 2), Inner1("c", 3)))
+
+      result ==> Outer2(Inner2("a", 1), Inner2("b", 2), Inner2("c", 3))
+    }
+  }
 }

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -2596,6 +2596,134 @@ If the flag was enabled in the implicit config it can be disabled with `.disable
     // Consult https://chimney.readthedocs.io for usage examples.
     ```
 
+### Applying overrides to all matching derivations (`forAll`)
+
+When transforming between deeply nested types, you may find yourself needing to apply the same field override at every
+level of the structure. For example, if an inner type has a renamed field, every derivation involving that inner type
+needs the same `.withFieldRenamed` call. Instead of manually using nested selectors like
+`.withFieldRenamed(_.a.name, _.a.imie)` for each path, you can use `.forAll[FromMatch, ToMatch]` to apply the
+override to **all** derivations where the source type matches `FromMatch` and the target type matches `ToMatch`:
+
+!!! example
+
+    Applying a field rename to all matching nested derivations with `forAll`
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
+    import io.scalaland.chimney.dsl._
+
+    case class Inner1(name: String, value: Int)
+    case class Inner2(imie: String, value: Int)
+    case class Outer1(a: Inner1, b: Inner1)
+    case class Outer2(a: Inner2, b: Inner2)
+
+    // Without forAll, you would need to rename for each field path separately:
+    //   .withFieldRenamed(_.a.name, _.a.imie)
+    //   .withFieldRenamed(_.b.name, _.b.imie)
+    // With forAll, a single rename applies to every Inner1 -> Inner2 derivation:
+    pprint.pprintln(
+      Outer1(Inner1("Kuba", 1), Inner1("Artur", 2))
+        .into[Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldRenamed(_.name, _.imie)
+        .transform
+    )
+    pprint.pprintln(
+      Outer1(Inner1("Kuba", 1), Inner1("Artur", 2))
+        .intoPartial[Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldRenamed(_.name, _.imie)
+        .transform
+        .asEither
+    )
+    // expected output:
+    // Outer2(a = Inner2(imie = "Kuba", value = 1), b = Inner2(imie = "Artur", value = 2))
+    // Right(value = Outer2(a = Inner2(imie = "Kuba", value = 1), b = Inner2(imie = "Artur", value = 2)))
+
+    import io.scalaland.chimney.Transformer
+
+    // forAll also works with Transformer.define:
+    val transformer: Transformer[Outer1, Outer2] = Transformer
+      .define[Outer1, Outer2]
+      .forAll[Inner1, Inner2]
+      .withFieldRenamed(_.name, _.imie)
+      .buildTransformer
+
+    pprint.pprintln(
+      transformer.transform(Outer1(Inner1("Kuba", 1), Inner1("Artur", 2)))
+    )
+    // expected output:
+    // Outer2(a = Inner2(imie = "Kuba", value = 1), b = Inner2(imie = "Artur", value = 2))
+    ```
+
+The scoped builder returned by `.forAll[FromMatch, ToMatch]` supports the following operations:
+
+  - `.withFieldRenamed(_.fromField, _.toField)` - use the source field to provide the value for the target field
+  - `.withFieldConst(_.field, value)` - use a constant value for the target field
+  - `.withFieldComputed(_.field, from => value)` - compute the value from the matched source instance
+  - `.withFieldComputedPartial(_.field, from => partial.Result[value])` - compute a partial result (only for
+    `PartialTransformer`)
+
+Each of these operations returns the original builder (e.g. `TransformerInto`, `TransformerDefinition`), so you can
+chain further overrides or flags after calling a `forAll` override.
+
+!!! example
+
+    Using `forAll` with `withFieldComputed` and deep nesting
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
+    import io.scalaland.chimney.Transformer
+    import io.scalaland.chimney.dsl._
+
+    // forAll propagates through arbitrarily deep nesting:
+    case class Inner1(name: String)
+    case class Inner2(imie: String)
+    case class Mid1(inner: Inner1)
+    case class Mid2(inner: Inner2)
+    case class Outer1(mid: Mid1)
+    case class Outer2(mid: Mid2)
+
+    pprint.pprintln(
+      Outer1(Mid1(Inner1("deep")))
+        .into[Outer2]
+        .forAll[Inner1, Inner2]
+        .withFieldRenamed(_.name, _.imie)
+        .transform
+    )
+    // expected output:
+    // Outer2(mid = Mid2(inner = Inner2(imie = "deep")))
+
+    // forAll with withFieldComputed:
+    case class Source(name: String, value: Int)
+    case class Target(name: String, value: Int, extra: String)
+    case class WrapperSrc(a: Source, b: Source)
+    case class WrapperDst(a: Target, b: Target)
+
+    val transformer: Transformer[WrapperSrc, WrapperDst] = Transformer
+      .define[WrapperSrc, WrapperDst]
+      .forAll[Source, Target]
+      .withFieldComputed(_.extra, src => s"${src.name}-${src.value}")
+      .buildTransformer
+
+    pprint.pprintln(
+      transformer.transform(WrapperSrc(Source("Kuba", 1), Source("Artur", 2)))
+    )
+    // expected output:
+    // WrapperDst(
+    //   a = Target(name = "Kuba", value = 1, extra = "Kuba-1"),
+    //   b = Target(name = "Artur", value = 2, extra = "Artur-2")
+    // )
+    ```
+
+!!! tip
+
+    The `forAll` override propagates into every level of nesting during recursive derivation. Whether the matching
+    types appear one level deep, three levels deep, or inside a collection, the override will be applied wherever
+    Chimney derives a transformation from a type matching `FromMatch` to a type matching `ToMatch`.
+
 ## From/into a `Tuple`
 
 Conversion from/to a tuple of any size is almost identical to conversion between other classes. The only difference


### PR DESCRIPTION
## Summary

Closes #810.

Adds `.forAll[FromMatch, ToMatch]` DSL method that allows defining overrides which apply to **all** matching `[From, To]` derivations encountered during recursive transformation. This solves the problem of deeply nested type hierarchies where the same field override (e.g., a rename) must be repeated at every level.

### Before (workaround)

```scala
// Had to define helper methods and manually wire each level:
def fooTransformer[From <: old.Foo, To <: new.Foo]: Transformer[From, To] =
  Transformer.define[From, To].withFieldRenamed(_.oldField, _.newField)
```

### After

```scala
Transformer
  .define[Outer1, Outer2]
  .forAll[Inner1, Inner2].withFieldRenamed(_.name, _.imie)
  .buildTransformer
```

The rename applies automatically at every nesting level where `Inner1 -> Inner2` derivation occurs.

### New DSL

`.forAll[FromMatch, ToMatch]` is available on all four builder types (both Scala 2.12, 2.13, and 3):
- `TransformerDefinition`
- `TransformerInto`
- `PartialTransformerDefinition`
- `PartialTransformerInto`

The scoped builder returned by `.forAll` provides:
- `.withFieldRenamed(_.from, _.to)`
- `.withFieldConst(_.field, value)`
- `.withFieldComputed(_.field, from => value)`
- `.withFieldComputedPartial(_.field, from => partial.Result[value])` (partial builders only)

### Matching semantics

- **Subtype matching**: `.forAll[Base, Target]` matches any derivation `[A, B]` where `A <: Base` and `B <: Target`
- **Propagation**: forAll overrides propagate into every level of recursive derivation (not consumed after one use)
- **Priority**: Specific overrides (e.g., `.withFieldConst(_.a.field, ...)`) take precedence over forAll overrides

### Implementation details

- **Type-level entry**: `ForAll[FromMatch, ToMatch, Inner <: Overrides, Tail <: Overrides]` in `TransformerOverrides`
- **Configuration storage**: New `forAllOverrides` field on `TransformerConfiguration` storing `(FromMatch, ToMatch, overrides, isFromImplicitConfig)` tuples
- **Injection**: `injectForAllOverrides` called from `updateFromTo` before `prepareForRecursiveCall` — prefixes override paths with `followFrom`/`followTo` (for sided-path stripping) and `absSrcPath`/`absTgtPath` (for journal-based source resolution)
- **Runtime data counting**: `countRuntimeData` helper correctly tracks runtime data indices across `ForAll` boundaries

### Tests

- Nested field rename (2 levels)
- Nested field const and field computed
- Deep nesting (3 levels: Outer -> Mid -> Inner)
- Subtype matching
- Multi-field application (3 fields of the same type)

### Documentation

- New "Applying overrides to all matching derivations (`forAll`)" section in `supported-transformations.md`
- Two runnable Scala CLI snippets: field rename propagation and field computed across nested hierarchies

### Future work (not in this PR)

- `TransformerConfiguration.forAll` (implicit scope, requires adding runtime data to Config)
- Additional override types: `withSealedSubtypeHandled`, `withConstructor`, `withFieldUnused`
- Ambiguity detection for conflicting forAll entries
