### PR TITLE
Perf: adopt Hearth's Type.Cache and filter-first method listing (hearth#347)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val versions = new {
   // !!! It MUST be replaced by a proper hearth RELEASE (and the snapshots resolver removed again)
   // !!! BEFORE merging PR #903. Do NOT release/merge with a -SNAPSHOT hearth dependency.
   // !!! -----------------------------------------------------------------------------------------------------------
-  val hearth = "0.4.0-29-gecc3bdb-SNAPSHOT"
+  val hearth = "0.4.1-perf10-SNAPSHOT"
   val cats = "2.13.0"
   // Latest published kindlings (its 0.3.0 depends on hearth 0.4.0, same as us; publishes JVM/JS/Native x 2.13/3).
   // TODO(kindlings-release): snapshot carrying kubuszok/kindlings#163 (NonEmptySeq/NonEmptyLazyList IsCollection

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val versions = new {
   // !!! It MUST be replaced by a proper hearth RELEASE (and the snapshots resolver removed again)
   // !!! BEFORE merging PR #903. Do NOT release/merge with a -SNAPSHOT hearth dependency.
   // !!! -----------------------------------------------------------------------------------------------------------
-  val hearth = "0.4.0-43-gb391704-SNAPSHOT"
+  val hearth = "0.4.0-44-g6a36a2b-SNAPSHOT"
   val cats = "2.13.0"
   // Latest published kindlings (its 0.3.0 depends on hearth 0.4.0, same as us; publishes JVM/JS/Native x 2.13/3).
   // TODO(kindlings-release): snapshot carrying kubuszok/kindlings#163 (NonEmptySeq/NonEmptyLazyList IsCollection

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val versions = new {
   // !!! It MUST be replaced by a proper hearth RELEASE (and the snapshots resolver removed again)
   // !!! BEFORE merging PR #903. Do NOT release/merge with a -SNAPSHOT hearth dependency.
   // !!! -----------------------------------------------------------------------------------------------------------
-  val hearth = "0.4.0-44-g6a36a2b-SNAPSHOT"
+  val hearth = "0.4.0-45-g8dcd069-SNAPSHOT"
   val cats = "2.13.0"
   // Latest published kindlings (its 0.3.0 depends on hearth 0.4.0, same as us; publishes JVM/JS/Native x 2.13/3).
   // TODO(kindlings-release): snapshot carrying kubuszok/kindlings#163 (NonEmptySeq/NonEmptyLazyList IsCollection

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val versions = new {
   // !!! It MUST be replaced by a proper hearth RELEASE (and the snapshots resolver removed again)
   // !!! BEFORE merging PR #903. Do NOT release/merge with a -SNAPSHOT hearth dependency.
   // !!! -----------------------------------------------------------------------------------------------------------
-  val hearth = "0.4.1-perf10-SNAPSHOT"
+  val hearth = "0.4.0-43-gb391704-SNAPSHOT"
   val cats = "2.13.0"
   // Latest published kindlings (its 0.3.0 depends on hearth 0.4.0, same as us; publishes JVM/JS/Native x 2.13/3).
   // TODO(kindlings-release): snapshot carrying kubuszok/kindlings#163 (NonEmptySeq/NonEmptyLazyList IsCollection

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/PlatformBridge.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/PlatformBridge.scala
@@ -7,12 +7,6 @@ import scala.quoted.Quotes
   */
 abstract private[compiletime] class PlatformBridge(q: Quotes)
     extends hearth.MacroCommonsScala3(using q)
-    with ChimneyDefinitions {
-
-  /** Scala 3 override of [[MacroCommonsCompat.cacheScopeToken]]: the ACTIVE Cross-Quotes `Quotes`. Each `Expr.splice`
-    * evaluates its thunks under a fresh nested `Quotes`, so values a `TypeCache` materializes during one splice are
-    * never handed out during another (the cross-quotes usage contract; Iso/Codec derive two instances - two sibling
-    * splices - per expansion).
-    */
-  override protected def cacheScopeToken: AnyRef = CrossQuotes.ctx[scala.quoted.Quotes]
-}
+    with ChimneyDefinitions
+// NOTE: the `cacheScopeToken` override is GONE: Hearth's `Type.Cache` partitions by the active Cross-Quotes scope
+// itself since hearth#347 (the same splice-scoping Chimney's removed `TypeCache` implemented).

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/MacroCommonsCompat.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/MacroCommonsCompat.scala
@@ -10,7 +10,8 @@ package io.scalaland.chimney.internal.compiletime
   * the #317/#318 shims (`prependFreshValCompat`, `withMacroEntryCtxCompat`, the Scala 3 derive-first `*InstanceCompat`
   * overrides): chimney honors the cross-quotes usage contract ("an expr that is spliced has to be created inside the
   * expr that is splicing it") - derivations run inside the splice that consumes them (see `ChimneyExprs`) and caches
-  * never hand out `Expr`s across splices (see [[TypeCache]]).
+  * never hand out `Expr`s across splices (Hearth's `Type.Cache` partitions by the active Cross-Quotes scope since
+  * hearth#347, which is also why Chimney's own scope-partitioned `TypeCache` could be deleted).
   */
 private[compiletime] trait MacroCommonsCompat { this: hearth.MacroCommons =>
 
@@ -146,47 +147,7 @@ private[compiletime] trait MacroCommonsCompat { this: hearth.MacroCommons =>
   // with inline `Type.of[...]` (or a helper def with its own `[X: Type]` parameters when existential-imported types
   // are involved).
 
-  /** Identity of the Cross-Quotes scope the calling code is currently evaluated under.
-    *
-    * Scala 3 `PlatformBridge` overrides this with the ACTIVE `Quotes` (each `Expr.splice` evaluates its thunks under a
-    * fresh nested `Quotes`); on Scala 2 there is no expr scoping, so the default is a single constant token per cake
-    * instance. Used by [[TypeCache]] to keep cached values scope-local.
-    */
-  protected def cacheScopeToken: AnyRef = this
-
-  /** Caches a computed `F[A]` per `Type[A]` (keys compared with `=:=`) WITHIN a single Cross-Quotes scope.
-    *
-    * CROSS-QUOTES USAGE CONTRACT: an expr that is spliced has to be created inside the expr that is splicing it - so a
-    * cache accessed from inside an `Expr.splice` must NOT hand out values materialized during a DIFFERENT splice
-    * evaluation (deriving a second instance in one expansion - Iso/Codec - would then use the first splice's `Expr`s
-    * and `-Xcheck-macros` aborts with a ScopeException). Cached values here routinely embed materialized `Expr`s
-    * (summoned integration implicits, provider views, default-value exprs), so entries are partitioned by
-    * [[cacheScopeToken]]: within one scope the memoization is as effective as before, a new scope recomputes (fresh
-    * summons/exprs) instead of leaking foreign-scope trees. On Scala 2 the token is constant and this behaves like a
-    * plain per-expansion cache.
-    */
-  final protected class TypeCache[F[_]] {
-    sealed private trait Entry {
-      type Underlying
-      val key: Type[Underlying]
-      val value: F[Underlying]
-    }
-    private object Entry {
-      def apply[A](key: Type[A], value: F[A]): Entry { type Underlying = A } = new Impl(key, value)
-      final class Impl[A](val key: Type[A], val value: F[A]) extends Entry { type Underlying = A }
-    }
-    private val storage =
-      scala.collection.mutable.Map.empty[AnyRef, scala.collection.mutable.ListBuffer[Entry]]
-
-    def apply[A](key: Type[A])(newValue: => F[A]): F[A] = {
-      val entries = storage.getOrElseUpdate(cacheScopeToken, scala.collection.mutable.ListBuffer.empty[Entry])
-      entries.find(_.key =:= key) match {
-        case Some(found) => found.value.asInstanceOf[F[A]]
-        case None        =>
-          val value = newValue
-          entries += Entry(key, value)
-          value
-      }
-    }
-  }
+  // NOTE: Chimney's own `TypeCache` (with `cacheScopeToken` splice-scope partitioning) is GONE: since hearth#347
+  // Hearth's `Type.Cache` is itself partitioned by the active Cross-Quotes scope (and hash-bucketed by dealiased
+  // type symbol), so the derivation caches use `new Type.Cache[F]` + `getOrPut` directly.
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypes.scala
@@ -176,9 +176,9 @@ private[compiletime] trait ProductTypes { this: ChimneyDefinitions & hearth.Macr
       SingletonValue.unapply(A).filter(_ => Type.isAvailable[A](Everywhere))
 
     private type CachedExtraction[A] = Option[Product.Extraction[A]]
-    private val extractionCache = new TypeCache[CachedExtraction]
+    private val extractionCache = new Type.Cache[CachedExtraction]
     def parseExtraction[A](implicit A0: Type[A]): Option[Product.Extraction[A]] =
-      extractionCache(A0)(parseExtractionImpl(dealiasedType(A0)))
+      extractionCache.getOrPut(A0)(parseExtractionImpl(dealiasedType(A0)))
     private def parseExtractionImpl[A](implicit A: Type[A]): Option[Product.Extraction[A]] =
       Some(Product.Extraction(NamedTuple.unapply(Type[A]) match {
         case Some(namedTuple) => namedTupleGetters[A](namedTuple)
@@ -186,15 +186,20 @@ private[compiletime] trait ProductTypes { this: ChimneyDefinitions & hearth.Macr
       }))
 
     private def methodGetters[A: Type]: Product.Getters[A] = {
-      val candidates = (Type[A].methods: List[Method]).iterator
-        // Instance methods only - Hearth's `methods` also lists companion-object members.
-        .collect { case oi: Method.OnInstance => (oi: Method) }
-        .filter(_.isAvailable(Everywhere))
-        .filter(_.isNullary)
-        .filterNot(hasTypeParameters) // remove methods with type parameters
-        .filterNot(method => ProductTypes.isGarbageName(method.name.trim))
-        .filterNot(method => method.name.endsWith("_=") || method.name.endsWith("_$eq")) // Scala var setters
-        .toList
+      // Filter-first pattern: `unsortedMethods` skips Hearth's expensive position-resolving sort, and `Method.sort`
+      // then restores the exact same stable order on the small filtered subset (its sort key is per-method, so
+      // filter-then-sort == sort-then-filter), paying position resolution only for the methods that survived.
+      val candidates = Method.sort(
+        (Type[A].unsortedMethods: List[Method]).iterator
+          // Instance methods only - Hearth's `unsortedMethods` also lists companion-object members.
+          .collect { case oi: Method.OnInstance => (oi: Method) }
+          .filter(_.isAvailable(Everywhere))
+          .filter(_.isNullary)
+          .filterNot(hasTypeParameters) // remove methods with type parameters
+          .filterNot(method => ProductTypes.isGarbageName(method.name.trim))
+          .filterNot(method => method.name.endsWith("_=") || method.name.endsWith("_$eq")) // Scala var setters
+          .toList
+      )
 
       // Getter ordering: constructor arg vals (in ctor order) ++ body vals ++ accessors and getters.
       val ctorParamOrder: Map[String, Int] = Type[A].primaryConstructor.fold(Map.empty[String, Int]) { ctor =>
@@ -249,16 +254,23 @@ private[compiletime] trait ProductTypes { this: ChimneyDefinitions & hearth.Macr
 
     private def setterCandidatesOf[A: Type]: List[(String, Method)] = {
       val seen = scala.collection.mutable.Set.empty[String]
-      (Type[A].methods: List[Method]).iterator
-        .collect { case oi: Method.OnInstance => (oi: Method) }
-        .filter(_.isAvailable(Everywhere))
-        .filter(_.isUnary)
-        .filterNot(hasTypeParameters)
-        .filterNot(method => ProductTypes.isGarbageName(method.name.trim))
-        .filter { method =>
-          val n = method.name.trim
-          ProductTypes.BeanAware.isSetterName(n) || n.endsWith("_=") || n.endsWith("_$eq")
-        }
+      // Filter-first pattern (see `methodGetters`): setter order is user-observable (it is the order the generated
+      // code calls the setters in, and the order they are reported in), so the filtered subset is re-sorted into
+      // `methods`' stable declaration order.
+      val candidates = Method.sort(
+        (Type[A].unsortedMethods: List[Method]).iterator
+          .collect { case oi: Method.OnInstance => (oi: Method) }
+          .filter(_.isAvailable(Everywhere))
+          .filter(_.isUnary)
+          .filterNot(hasTypeParameters)
+          .filterNot(method => ProductTypes.isGarbageName(method.name.trim))
+          .filter { method =>
+            val n = method.name.trim
+            ProductTypes.BeanAware.isSetterName(n) || n.endsWith("_=") || n.endsWith("_$eq")
+          }
+          .toList
+      )
+      candidates.iterator
         .map { method =>
           // Scala 3's JB setters _are_ methods ending with _= due to change in @BeanProperty behavior.
           // We have to drop that suffix to align names, so that comparing is possible.
@@ -271,10 +283,10 @@ private[compiletime] trait ProductTypes { this: ChimneyDefinitions & hearth.Macr
     }
 
     private type CachedConstructor[A] = Option[Product.Constructor[A]]
-    private val constructorCache = new TypeCache[CachedConstructor]
+    private val constructorCache = new Type.Cache[CachedConstructor]
     def parseConstructor[A](implicit A0: Type[A]): Option[Product.Constructor[A]] =
       // dealiasedType: alias-transparent parsing (e.g. NamedTuple aliases at override-path positions - see above).
-      constructorCache(A0)(parseConstructorImpl(dealiasedType(A0)))
+      constructorCache.getOrPut(A0)(parseConstructorImpl(dealiasedType(A0)))
     private def parseConstructorImpl[A](implicit A: Type[A]): Option[Product.Constructor[A]] = {
       val singleton = parseSingleton[A]
       if (singleton.isDefined) {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
@@ -33,8 +33,8 @@ private[compiletime] trait SealedHierarchies { this: ChimneyDefinitions & hearth
   protected object SealedHierarchy {
 
     private type Cached[A] = Option[SealedEnum[A]]
-    private val enumCache = new TypeCache[Cached]
-    def parse[A: Type]: Option[SealedEnum[A]] = enumCache(Type[A]) {
+    private val enumCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[SealedEnum[A]] = enumCache.getOrPut(Type[A]) {
       if (isSealed[A] || isJavaEnum[A]) subtypesToEnum[A](flattenedSubtypes[A])
       else None
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ValueClasses.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/ValueClasses.scala
@@ -90,8 +90,8 @@ private[compiletime] trait ValueClasses {
   protected object WrapperClassType {
 
     private type Cached[A] = Option[Existential[WrapperClass[A, *]]]
-    private val wrapperClassCache = new TypeCache[Cached]
-    def parse[A: Type]: Option[Existential[WrapperClass[A, *]]] = wrapperClassCache(Type[A]) {
+    private val wrapperClassCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Existential[WrapperClass[A, *]]] = wrapperClassCache.getOrPut(Type[A]) {
       hearthSupport[A].orElse(methodBasedParse[A])
     }
     def unapply[A](tpe: Type[A]): Option[Existential[WrapperClass[A, *]]] = parse(using tpe)
@@ -178,8 +178,8 @@ private[compiletime] trait ValueClasses {
     private lazy val AnyValType: Type[AnyVal] = Type.of[AnyVal]
 
     private type Cached[A] = Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]]
-    private val valueClassCache = new TypeCache[Cached]
-    def parse[A: Type]: Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]] = valueClassCache(Type[A]) {
+    private val valueClassCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Existential.UpperBounded[AnyVal, ValueClass[A, *]]] = valueClassCache.getOrPut(Type[A]) {
       // Java boxed primitives surface through the UNGATED ValueClassType: `java.lang.Integer` is
       // the Java spelling of an AnyVal, its Inner (`Int`) genuinely IS <: AnyVal, and the chimney-java-collections
       // implicits it replaces required no flag either. The actual unwrap/wrap exprs come from Hearth's built-in
@@ -218,8 +218,8 @@ private[compiletime] trait ValueClasses {
   protected object PartialWrapperClassType {
 
     private type Cached[A] = Option[Existential[PartialWrapperClass[A, *]]]
-    private val partialWrapperClassCache = new TypeCache[Cached]
-    def parse[A: Type]: Option[Existential[PartialWrapperClass[A, *]]] = partialWrapperClassCache(Type[A]) {
+    private val partialWrapperClassCache = new Type.Cache[Cached]
+    def parse[A: Type]: Option[Existential[PartialWrapperClass[A, *]]] = partialWrapperClassCache.getOrPut(Type[A]) {
       // Total wrapping wins - a type that parses as a (provider-provided PlainValue or Method-based) WrapperClass
       // must keep its total expansion; smart-constructor support only ADDS types nothing else could handle.
       if (WrapperClassType.parse[A].isDefined) None

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/OptionalValues.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/OptionalValues.scala
@@ -50,9 +50,9 @@ trait OptionalValues { this: Derivation & hearth.MacroCommons & hearth.std.StdEx
     private lazy val OptionCtor: Type.Ctor1[Option] = Type.Ctor1.of[Option]
 
     private type Cached[A] = Option[Existential[OptionalValue[A, *]]]
-    private val optionalCache = new TypeCache[Cached]
+    private val optionalCache = new Type.Cache[Cached]
     def parse[Optional](implicit Optional: Type[Optional]): Option[Existential[OptionalValue[Optional, *]]] =
-      optionalCache(Optional)(
+      optionalCache.getOrPut(Optional)(
         providedSupport[Optional].orElse(buildInOptionSupport[Optional]).orElse(hearthProviderSupport[Optional])
       )
     def unapply[Optional](Optional: Type[Optional]): Option[Existential[OptionalValue[Optional, *]]] = parse(using

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartialOuterTransformers.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartialOuterTransformers.scala
@@ -32,9 +32,9 @@ trait PartialOuterTransformers { this: Derivation & hearth.MacroCommons =>
   }
   protected object PartialOuterTransformer {
 
-    private val implicitCache = new TypeCache[Option]
+    private val implicitCache = new Type.Cache[Option]
     def parse[From, To](implicit from: Type[From], to: Type[To]): Option[PartialOuterTransformer[From, To]] =
-      implicitCache(
+      implicitCache.getOrPut(
         Type[integrations.PartialOuterTransformer[From, To, From, To]]
           .asInstanceOf[Type[PartialOuterTransformer[From, To]]]
       )(summonPartialOuterTransformer[From, To])

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartiallyBuildIterables.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/PartiallyBuildIterables.scala
@@ -119,9 +119,9 @@ trait PartiallyBuildIterables { this: Derivation & hearth.MacroCommons & hearth.
   protected object PartiallyBuildIterable {
 
     private type Cached[M] = Option[Existential[PartiallyBuildIterable[M, *]]]
-    private val partiallyBulidIterableCache = new TypeCache[Cached]
+    private val partiallyBulidIterableCache = new Type.Cache[Cached]
     def parse[M](implicit M: Type[M]): Option[Existential[PartiallyBuildIterable[M, *]]] =
-      partiallyBulidIterableCache(M)(providedSupport[M].orElse(hearthProviderSupport[M]))
+      partiallyBulidIterableCache.getOrPut(M)(providedSupport[M].orElse(hearthProviderSupport[M]))
     def unapply[M](M: Type[M]): Option[Existential[PartiallyBuildIterable[M, *]]] = parse(using M)
 
     private def providedSupport[Collection: Type]: Option[Existential[PartiallyBuildIterable[Collection, *]]] =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotalOuterTransformers.scala
@@ -30,9 +30,9 @@ trait TotalOuterTransformers { this: Derivation & hearth.MacroCommons =>
   }
   protected object TotalOuterTransformer {
 
-    private val implicitCache = new TypeCache[Option]
+    private val implicitCache = new Type.Cache[Option]
     def parse[From, To](implicit from: Type[From], to: Type[To]): Option[TotalOuterTransformer[From, To]] =
-      implicitCache(
+      implicitCache.getOrPut(
         Type[integrations.TotalOuterTransformer[From, To, From, To]].asInstanceOf[Type[TotalOuterTransformer[From, To]]]
       )(summonTotalOuterTransformer[From, To])
     def unapply[From, To](pair: (Type[From], Type[To])): Option[TotalOuterTransformer[From, To]] =

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyBuildIterables.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyBuildIterables.scala
@@ -221,9 +221,9 @@ trait TotallyBuildIterables { this: Derivation & hearth.MacroCommons & hearth.st
   protected object TotallyBuildIterable {
 
     private type Cached[M] = Option[Existential[TotallyBuildIterable[M, *]]]
-    private val totallyBulidIterableCache = new TypeCache[Cached]
+    private val totallyBulidIterableCache = new Type.Cache[Cached]
     def parse[M](implicit M: Type[M]): Option[Existential[TotallyBuildIterable[M, *]]] =
-      totallyBulidIterableCache(M)(providedSupport[M].orElse(hearthSupport[M]))
+      totallyBulidIterableCache.getOrPut(M)(providedSupport[M].orElse(hearthSupport[M]))
     def unapply[M](M: Type[M]): Option[Existential[TotallyBuildIterable[M, *]]] = parse(using M)
 
     private def providedSupport[Collection: Type]: Option[Existential[TotallyBuildIterable[Collection, *]]] =


### PR DESCRIPTION
Adopts two Hearth facilities that landed in [hearth#347](https://github.com/kubuszok/hearth/pull/347) (pinned here via the `0.4.0-43-gb391704-SNAPSHOT` master snapshot), deleting Chimney-side re-implementations:

## `TypeCache` → Hearth `Type.Cache` (all 11 sites)
Chimney's `TypeCache` existed because caches routinely embed materialized `Expr`s, and handing those out across `Expr.splice` scopes aborts under `-Xcheck-macros` (ScopeException) — so it partitioned entries by `cacheScopeToken`. Since hearth#347, Hearth's `Type.Cache` does the same splice-scope partitioning itself **and** hash-buckets entries by dealiased type symbol (the old cache did a linear `=:=` scan per lookup — the bucketed lookup only `=:=`-compares same-symbol candidates, which pays off on modules with many distinct types). `TypeCache`, `cacheScopeToken`, and the Scala 3 `PlatformBridge` override are deleted (net −33 lines).

## `methodGetters`/`setterCandidatesOf`: filter-first listing
`Type[A].methods` resolves every declared member's source position just to sort the full listing. These call sites now use `Type[A].unsortedMethods`, filter down to the relevant subset, and restore the exact stable order with the new `Method.sort` (its sort key is per-method, so `sort(xs.filter(p)) == sort(xs).filter(p)`) — position resolution is paid only for the methods that survive filtering. Ordering is preserved deliberately: setter order is user-observable (it is the order the generated code calls setters in, and the order error messages list them — asserted by the JavaBean specs, which caught the naive unsorted variant).

## Verified
`chimney3/test` (1118 passed) + `chimney/test` (980 passed) against the published snapshot. Profiling on the dense derivation load: Chimney `TypeCache` frames 28.1% → 0% (work now hosted by the bucketed cache), `sortMethodsBy` 1.8% → 0.9%.

Part of the compile-time performance work tracked in Hearth's `docs/contributing/compile-time-perf-roadmap.md` (end-to-end old-vs-new ratio currently 1.30×/1.27×, from 3×/2× pre-optimization).
