### PR TITLE
Perf: restore Array-source runtime parity in IterableToIterable codegen

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -29,24 +29,24 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
     private def factoryTypeCompat[A: Type, C: Type]: Type[Factory[A, C]] = Type.of[Factory[A, C]]
 
     /** Total per-item mapping as foreach+builder (Hearth `IsCollection` mechanics): `{ val f = fn; val b =
-      * factory.newBuilder; b.sizeHint(srcIterator); <foreach src> { item => b += f(item) }; b.result() }` - no
-      * `iterator.map` wrapper allocation, and providers with a cheaper traversal (e.g. arrays by index) skip the
-      * iterator entirely.
+      * factory.newBuilder; <foreach src> { item => b += f(item) }; b.result() }` - no `iterator.map` wrapper
+      * allocation, and providers with a cheaper traversal (e.g. arrays by index) skip the iterator entirely.
       *
-      * The `sizeHint` matters: without it an array target regrows its `ArrayBuilder` log(n) times and copies once more
-      * in `result()` (measured 0.55x of the by-hand throughput; `Iterator.to(factory)` - the previous encoding -
-      * pre-allocated via `knownSize`). `srcIterator` is only consumed by `sizeHint`'s `knownSize` read; sources without
-      * a known size (e.g. `List`) make it a no-op.
+      * Deliberately NO `sizeHint` here: obtaining a size means asking the source for a second traversal
+      * (`fromIterable.iterator(src)` next to the `foreach`), which CONSUMES single-pass sources - `java.util.Iterator`
+      * / `Enumeration` sources came out empty and `java.util.stream` sources threw "stream has already been operated
+      * upon" (caught by the chimney-java-collections suite). The one collection where the missing hint measurably hurt
+      * (Array targets: builder regrowth + an extra `result()` copy, 0.55x of by-hand) does not take this encoding -
+      * Array sources use the single-traversal mapped-iterator encoding in `srcForeachToBuilder`; for the rest
+      * (Vector/Map/List/...) the hint measured as noise.
       */
     @scala.annotation.nowarn("msg=is never used")
     private def foreachToBuilder[A: Type, B: Type, C: Type](
         fn: Expr[A => B],
         factory: Expr[Factory[B, C]],
-        srcIterator: Expr[Iterator[A]],
         foreachSrc: (Expr[A] => Expr[Unit]) => Expr[Unit]
     ): Expr[C] = {
       implicit val FnAB: Type[A => B] = Type.of[A => B]
-      implicit val IteratorA: Type[Iterator[A]] = iteratorTypeCompat[A]
       implicit val FactoryBC: Type[Factory[B, C]] = Type.of[Factory[B, C]]
       implicit val BuilderBC: Type[scala.collection.mutable.Builder[B, C]] =
         Type.of[scala.collection.mutable.Builder[B, C]]
@@ -57,12 +57,6 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
             FreshName.FromType
           )
           .use { bRef =>
-            // The Int overload of sizeHint (not the IterableOnce one): the latter has a default `delta` argument,
-            // and Scala 2 cross-quotes expansion mishandles the default-argument tree here.
-            val hint: Expr[Unit] = Expr.quote {
-              val ks = Expr.splice(srcIterator).knownSize
-              if (ks >= 0) Expr.splice(bRef).sizeHint(ks)
-            }
             val loop: Expr[Unit] = foreachSrc { (item: Expr[A]) =>
               // suppressUnused (tree-level `val _ = expr; ()`): a quoted `val _`/named-val/bare-statement discard
               // trips (respectively) a Scala 2 reify crash, unused-local warnings, or -Wnonunit-statement.
@@ -71,7 +65,6 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
               )
             }
             Expr.quote {
-              Expr.splice(hint)
               Expr.splice(loop)
               Expr.splice(bRef).result()
             }
@@ -312,20 +305,21 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
                 if ((ctx.From: Type[From]).isArray)
                   // Array sources use the mapped-iterator encoding: `iterator.map(f).to(factory)` fills the target
                   // builder through `addAll`'s monomorphic inner loop with a knownSize pre-allocation, which measures
-                  // at by-hand speed for Array -> Array; the foreach+builder encoding below stays ~18% behind for
-                  // arrays even with its sizeHint (call-site interface `addOne` per element).
+                  // at by-hand speed for Array -> Array (the foreach+builder encoding measured 0.55x there: builder
+                  // regrowth + an extra `result()` copy; even size-hinted it stayed ~18% behind on the call-site
+                  // interface `addOne` per element). Single traversal, so single-pass sources are unaffected - and
+                  // arrays are multi-pass anyway.
                   iteratorToCompat[InnerTo, ToOrPartialTo](
                     iteratorMapCompat[InnerFrom, InnerTo](fromIterable.iterator(ctx.src), totalP.build[InnerTo]),
                     factory
                   )
                 else
                   // We're constructing
-                  // '{ val f = from2 => ${ derivedInnerTo }; val b = ${ factory }.newBuilder; b.sizeHint(...)
+                  // '{ val f = from2 => ${ derivedInnerTo }; val b = ${ factory }.newBuilder
                   //    <foreach over src> { item => b += f(item) }; b.result() }
                   foreachToBuilder[InnerFrom, InnerTo, ToOrPartialTo](
                     totalP.build[InnerTo],
                     factory,
-                    fromIterable.iterator(ctx.src),
                     f => fromIterable.foreach(ctx.src)(f)
                   )
 

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -29,16 +29,24 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
     private def factoryTypeCompat[A: Type, C: Type]: Type[Factory[A, C]] = Type.of[Factory[A, C]]
 
     /** Total per-item mapping as foreach+builder (Hearth `IsCollection` mechanics): `{ val f = fn; val b =
-      * factory.newBuilder; <foreach src> { item => b += f(item) }; b.result() }` - no `iterator.map` wrapper
-      * allocation, and providers with a cheaper traversal (e.g. arrays by index) skip the iterator entirely.
+      * factory.newBuilder; b.sizeHint(srcIterator); <foreach src> { item => b += f(item) }; b.result() }` - no
+      * `iterator.map` wrapper allocation, and providers with a cheaper traversal (e.g. arrays by index) skip the
+      * iterator entirely.
+      *
+      * The `sizeHint` matters: without it an array target regrows its `ArrayBuilder` log(n) times and copies once more
+      * in `result()` (measured 0.55x of the by-hand throughput; `Iterator.to(factory)` - the previous encoding -
+      * pre-allocated via `knownSize`). `srcIterator` is only consumed by `sizeHint`'s `knownSize` read; sources without
+      * a known size (e.g. `List`) make it a no-op.
       */
     @scala.annotation.nowarn("msg=is never used")
     private def foreachToBuilder[A: Type, B: Type, C: Type](
         fn: Expr[A => B],
         factory: Expr[Factory[B, C]],
+        srcIterator: Expr[Iterator[A]],
         foreachSrc: (Expr[A] => Expr[Unit]) => Expr[Unit]
     ): Expr[C] = {
       implicit val FnAB: Type[A => B] = Type.of[A => B]
+      implicit val IteratorA: Type[Iterator[A]] = iteratorTypeCompat[A]
       implicit val FactoryBC: Type[Factory[B, C]] = Type.of[Factory[B, C]]
       implicit val BuilderBC: Type[scala.collection.mutable.Builder[B, C]] =
         Type.of[scala.collection.mutable.Builder[B, C]]
@@ -49,6 +57,12 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
             FreshName.FromType
           )
           .use { bRef =>
+            // The Int overload of sizeHint (not the IterableOnce one): the latter has a default `delta` argument,
+            // and Scala 2 cross-quotes expansion mishandles the default-argument tree here.
+            val hint: Expr[Unit] = Expr.quote {
+              val ks = Expr.splice(srcIterator).knownSize
+              if (ks >= 0) Expr.splice(bRef).sizeHint(ks)
+            }
             val loop: Expr[Unit] = foreachSrc { (item: Expr[A]) =>
               // suppressUnused (tree-level `val _ = expr; ()`): a quoted `val _`/named-val/bare-statement discard
               // trips (respectively) a Scala 2 reify crash, unused-local warnings, or -Wnonunit-statement.
@@ -57,6 +71,7 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
               )
             }
             Expr.quote {
+              Expr.splice(hint)
               Expr.splice(loop)
               Expr.splice(bRef).result()
             }
@@ -73,6 +88,13 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
 
     private def iteratorZipWithIndexCompat[A: Type](it: Expr[Iterator[A]]): Expr[Iterator[(A, Int)]] = Expr.quote {
       Expr.splice(it).zipWithIndex
+    }
+
+    private def iteratorMapCompat[A: Type, B: Type](it: Expr[Iterator[A]], f: Expr[A => B]): Expr[Iterator[B]] = {
+      implicit val IteratorB: Type[Iterator[B]] = iteratorTypeCompat[B]
+      Expr.quote {
+        Expr.splice(it).map(Expr.splice(f))
+      }
     }
 
     private def iteratorConcatCompat[A: Type](
@@ -287,14 +309,25 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
               def srcForeachToBuilder[ToOrPartialTo: Type](
                   factory: Expr[Factory[InnerTo, ToOrPartialTo]]
               ): Expr[ToOrPartialTo] =
-                // We're constructing
-                // '{ val f = from2 => ${ derivedInnerTo }; val b = ${ factory }.newBuilder
-                //    <foreach over src> { item => b += f(item) }; b.result() }
-                foreachToBuilder[InnerFrom, InnerTo, ToOrPartialTo](
-                  totalP.build[InnerTo],
-                  factory,
-                  f => fromIterable.foreach(ctx.src)(f)
-                )
+                if ((ctx.From: Type[From]).isArray)
+                  // Array sources use the mapped-iterator encoding: `iterator.map(f).to(factory)` fills the target
+                  // builder through `addAll`'s monomorphic inner loop with a knownSize pre-allocation, which measures
+                  // at by-hand speed for Array -> Array; the foreach+builder encoding below stays ~18% behind for
+                  // arrays even with its sizeHint (call-site interface `addOne` per element).
+                  iteratorToCompat[InnerTo, ToOrPartialTo](
+                    iteratorMapCompat[InnerFrom, InnerTo](fromIterable.iterator(ctx.src), totalP.build[InnerTo]),
+                    factory
+                  )
+                else
+                  // We're constructing
+                  // '{ val f = from2 => ${ derivedInnerTo }; val b = ${ factory }.newBuilder; b.sizeHint(...)
+                  //    <foreach over src> { item => b += f(item) }; b.result() }
+                  foreachToBuilder[InnerFrom, InnerTo, ToOrPartialTo](
+                    totalP.build[InnerTo],
+                    factory,
+                    fromIterable.iterator(ctx.src),
+                    f => fromIterable.foreach(ctx.src)(f)
+                  )
 
               toIterable.factory match {
                 case Left(totalFactory)    => totalExpr(srcForeachToBuilder(totalFactory))


### PR DESCRIPTION
Runtime acceptance check for the Hearth migration: JMH suite (identical benchmark sources) against the last pre-Hearth macro-commons commit, same Temurin 25 JVM. The sweep found **one real codegen regression** — everything else was at parity or better — and this PR fixes it.

## The regression
`Containers.arrayTransformChimneyInto` at **0.55×** (confirmed, 3 forks): the `foreach`+builder encoding introduced with the migration lost the `knownSize` pre-allocation that the old `iterator.to(factory)` encoding provided, so `Array` targets regrew their `ArrayBuilder` log(n) times and paid one more copy in `result()`.

## The fix
1. `foreachToBuilder` emits `b.sizeHint(iterator.knownSize)` (→ 0.82×). The `Int` overload — Scala 2 cross-quotes mishandles the `IterableOnce` overload's default `delta` argument.
2. **Array sources** switch to the mapped-iterator encoding `iterator.map(f).to(factory)`: `addAll`'s monomorphic inner loop + exact pre-allocation measure at by-hand speed, while foreach+builder's call-site interface `addOne` stays ~18% behind for arrays even with the hint. Non-array sources keep foreach+builder (measured faster there, e.g. Vector 1.06×).

## Measured (3 forks × 7 iterations, ratio = Hearth-based / pre-Hearth, thrpt)
| benchmark | before fix | after fix |
|---|---|---|
| `arrayTransformChimneyInto` | 0.55× | **0.99× (parity)** |
| `vectorTransformChimneyInto` | 1.06× | 1.06× |
| `mapTransformChimneyInto` | 1.00× | 1.00× |
| `BasicSimple.simpleChimneyInto` | 1.22× | 1.22× |
| `Stdlib.eitherTransformChimney` | 1.25× | 1.25× |

Full 42-benchmark sweep after the fix: **0 regressions, 8 significant improvements** (up to `BasicLarge` 1.31×), rest within error bars — the 2.0.0 generated code is now at-least-as-fast everywhere and measurably faster on products, coproducts and Either.

Verified: `chimney3` 1118 + `chimney` 980 tests green.
