### PR TITLE
Adopt hearth's IsCollectionOf.sizeHintForBuilder for builder pre-allocation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val versions = new {
   // !!! It MUST be replaced by a proper hearth RELEASE (and the snapshots resolver removed again)
   // !!! BEFORE merging PR #903. Do NOT release/merge with a -SNAPSHOT hearth dependency.
   // !!! -----------------------------------------------------------------------------------------------------------
-  val hearth = "0.4.0-45-g8dcd069-SNAPSHOT"
+  val hearth = "0.4.0-52-gaaf7e1a-SNAPSHOT"
   val cats = "2.13.0"
   // Latest published kindlings (its 0.3.0 depends on hearth 0.4.0, same as us; publishes JVM/JS/Native x 2.13/3).
   // TODO(kindlings-release): snapshot carrying kubuszok/kindlings#163 (NonEmptySeq/NonEmptyLazyList IsCollection

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyBuildIterables.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyBuildIterables.scala
@@ -341,6 +341,9 @@ trait TotallyBuildIterables { this: Derivation & hearth.MacroCommons & hearth.st
           def foreach(collection: Expr[M])(f: Expr[Item] => Expr[Unit]): Expr[Unit] =
             isCollectionOf.foreach(collection)(f)
 
+          override def builderSizeHint(collection: Expr[M]): Option[Expr[Int]] =
+            isCollectionOf.sizeHintForBuilder(collection)
+
           def to[Collection2: Type](
               collection: Expr[M],
               factory: Expr[Factory[Item, Collection2]]
@@ -404,6 +407,9 @@ trait TotallyBuildIterables { this: Derivation & hearth.MacroCommons & hearth.st
           def foreach(collection: Expr[M])(f: Expr[(K, V)] => Expr[Unit]): Expr[Unit] =
             if (pairIsTuple) isMapOf.foreach(collection)(f.asInstanceOf[Expr[Pair] => Expr[Unit]])
             else isMapOf.foreach(collection)(pair => f(toTuple(pair)))
+
+          override def builderSizeHint(collection: Expr[M]): Option[Expr[Int]] =
+            isMapOf.sizeHintForBuilder(collection)
 
           def to[Collection2: Type](
               collection: Expr[M],

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyOrPartiallyBuildIterables.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/integrations/TotallyOrPartiallyBuildIterables.scala
@@ -27,6 +27,14 @@ trait TotallyOrPartiallyBuildIterables { this: Derivation & hearth.MacroCommons 
         factory: Expr[Factory[Item, Collection2]]
     ): Expr[Collection2]
 
+    /** Expression computing the collection's size for pre-allocating a builder (`Builder.sizeHint`), or `None` when no
+      * SAFE size expression exists. Safety contract is hearth's `IsCollectionOf.sizeHintForBuilder` (hearth#354): the
+      * expression must be cheap and must NOT traverse/consume the collection - single-pass sources stay `None` (the
+      * default) - and may evaluate to a negative value at runtime when unknown (callers guard with `>= 0`).
+      * Hearth-backed instances delegate to the provider; everything else keeps the default.
+      */
+    def builderSizeHint(collection: Expr[Collection]): Option[Expr[Int]] = None
+
     val asMap: Option[(ExistentialType, ExistentialType)]
   }
   object TotallyOrPartiallyBuildIterable {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformIterableToIterableRuleModule.scala
@@ -29,21 +29,22 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
     private def factoryTypeCompat[A: Type, C: Type]: Type[Factory[A, C]] = Type.of[Factory[A, C]]
 
     /** Total per-item mapping as foreach+builder (Hearth `IsCollection` mechanics): `{ val f = fn; val b =
-      * factory.newBuilder; <foreach src> { item => b += f(item) }; b.result() }` - no `iterator.map` wrapper
-      * allocation, and providers with a cheaper traversal (e.g. arrays by index) skip the iterator entirely.
+      * factory.newBuilder; <if hinted: b.sizeHint(...)>; <foreach src> { item => b += f(item) }; b.result() }` - no
+      * `iterator.map` wrapper allocation, and providers with a cheaper traversal (e.g. arrays by index) skip the
+      * iterator entirely.
       *
-      * Deliberately NO `sizeHint` here: obtaining a size means asking the source for a second traversal
-      * (`fromIterable.iterator(src)` next to the `foreach`), which CONSUMES single-pass sources - `java.util.Iterator`
-      * / `Enumeration` sources came out empty and `java.util.stream` sources threw "stream has already been operated
-      * upon" (caught by the chimney-java-collections suite). The one collection where the missing hint measurably hurt
-      * (Array targets: builder regrowth + an extra `result()` copy, 0.55x of by-hand) does not take this encoding -
-      * Array sources use the single-traversal mapped-iterator encoding in `srcForeachToBuilder`; for the rest
-      * (Vector/Map/List/...) the hint measured as noise.
+      * `sizeHint` comes from [[TotallyOrPartiallyBuildIterable.builderSizeHint]] (ultimately hearth's per-provider
+      * `IsCollectionOf.sizeHintForBuilder`, hearth#354), so it exists ONLY when a non-consuming size expression exists -
+      * single-pass sources are `None` by construction (obtaining a size generically would be a second traversal, which
+      * emptied java Iterator/Enumeration sources and broke java streams before). The expression may evaluate to a
+      * negative value at runtime (unknown size), hence the `>= 0` guard. Array sources still use the single-traversal
+      * mapped-iterator encoding in `srcForeachToBuilder` (measured faster than even a hinted builder loop).
       */
     @scala.annotation.nowarn("msg=is never used")
     private def foreachToBuilder[A: Type, B: Type, C: Type](
         fn: Expr[A => B],
         factory: Expr[Factory[B, C]],
+        sizeHint: Option[Expr[Int]],
         foreachSrc: (Expr[A] => Expr[Unit]) => Expr[Unit]
     ): Expr[C] = {
       implicit val FnAB: Type[A => B] = Type.of[A => B]
@@ -57,6 +58,16 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
             FreshName.FromType
           )
           .use { bRef =>
+            val hint: Expr[Unit] = sizeHint match {
+              case Some(size) =>
+                // The Int overload of sizeHint (not the IterableOnce one): the latter has a default `delta`
+                // argument, and Scala 2 cross-quotes expansion mishandles the default-argument tree.
+                Expr.quote {
+                  val ks = Expr.splice(size)
+                  if (ks >= 0) Expr.splice(bRef).sizeHint(ks)
+                }
+              case None => Expr.quote(())
+            }
             val loop: Expr[Unit] = foreachSrc { (item: Expr[A]) =>
               // suppressUnused (tree-level `val _ = expr; ()`): a quoted `val _`/named-val/bare-statement discard
               // trips (respectively) a Scala 2 reify crash, unused-local warnings, or -Wnonunit-statement.
@@ -65,6 +76,7 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
               )
             }
             Expr.quote {
+              Expr.splice(hint)
               Expr.splice(loop)
               Expr.splice(bRef).result()
             }
@@ -316,10 +328,12 @@ private[compiletime] trait TransformIterableToIterableRuleModule {
                 else
                   // We're constructing
                   // '{ val f = from2 => ${ derivedInnerTo }; val b = ${ factory }.newBuilder
+                  //    <if the provider has a safe size: b.sizeHint(...)>
                   //    <foreach over src> { item => b += f(item) }; b.result() }
                   foreachToBuilder[InnerFrom, InnerTo, ToOrPartialTo](
                     totalP.build[InnerTo],
                     factory,
+                    fromIterable.builderSizeHint(ctx.src),
                     f => fromIterable.foreach(ctx.src)(f)
                   )
 


### PR DESCRIPTION
Completes the size-hint story from #906 with the principled mechanism ([hearth#354](https://github.com/kubuszok/hearth/pull/354)): the **provider** declares when a non-consuming size expression exists, so single-pass sources (java `Iterator`/`Enumeration`/`Stream`) are `None` **by construction** — the failure mode that forced the #906 revert is unrepresentable.

- `TotallyOrPartiallyBuildIterable.builderSizeHint` (default `None`); hearth-backed iterable + map supports delegate to `IsCollectionOf.sizeHintForBuilder`.
- `foreachToBuilder` emits `val ks = <size>; if (ks >= 0) b.sizeHint(ks)` when hinted (`Int` overload — Scala 2 cross-quotes mishandles the `IterableOnce` overload's default arg).
- Array sources keep the mapped-iterator encoding from #906 (still faster than even a hinted builder loop).

**Measured** (vs pre-Hearth macro-commons): `vectorTransformChimneyInto` **1.09×** (best yet; 1.03–1.06× unhinted), array 0.99× parity (unchanged), map 1.01×.

**Verified:** chimney 1118 + 980, chimney-java-collections 70 + 70 (the suite that catches single-pass double-traversal). Pinned to `0.4.0-52-gaaf7e1a-SNAPSHOT` (first snapshot carrying hearth#354).