### PR TITLE
Kindlings-style debug API: debug._ import, chimney.logDerivation, chimney.timeout + flame-graph docs

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/LogDerivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/LogDerivation.scala
@@ -1,0 +1,15 @@
+package io.scalaland.chimney
+
+/** Marker used to enable derivation debug logging for every Chimney macro expansion that sees it in the implicit
+  * scope.
+  *
+  * Do not instantiate it directly - `import io.scalaland.chimney.debug._` in the file you want to inspect (or enable
+  * logging project-wide with `-Xmacro-settings:chimney.logDerivation=true`). Same idiom as Kindlings' per-module
+  * `debug._` imports.
+  *
+  * @see
+  *   [[https://chimney.readthedocs.io Chimney documentation - debugging chapter]]
+  *
+  * @since 2.0.0
+  */
+final class LogDerivation

--- a/chimney/src/main/scala/io/scalaland/chimney/LogDerivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/LogDerivation.scala
@@ -1,7 +1,6 @@
 package io.scalaland.chimney
 
-/** Marker used to enable derivation debug logging for every Chimney macro expansion that sees it in the implicit
-  * scope.
+/** Marker used to enable derivation debug logging for every Chimney macro expansion that sees it in the implicit scope.
   *
   * Do not instantiate it directly - `import io.scalaland.chimney.debug._` in the file you want to inspect (or enable
   * logging project-wide with `-Xmacro-settings:chimney.logDerivation=true`). Same idiom as Kindlings' per-module

--- a/chimney/src/main/scala/io/scalaland/chimney/debug/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/debug/package.scala
@@ -1,0 +1,19 @@
+package io.scalaland.chimney
+
+package object debug {
+
+  /** Import this value to enable derivation debug logging for all Chimney macros expanded in the file:
+    *
+    * {{{
+    * import io.scalaland.chimney.debug._
+    * }}}
+    *
+    * The macro prints the matched rules, summoned implicits and the generated code to the compiler output - the same
+    * information `.enableMacrosLogging` shows, but without touching the transformation definition.
+    *
+    * Alternatively, enable it project-wide with scalac option: `-Xmacro-settings:chimney.logDerivation=true`.
+    *
+    * @since 2.0.0
+    */
+  implicit val logDerivationForChimney: LogDerivation = new LogDerivation
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/GatewayCommons.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/GatewayCommons.scala
@@ -39,11 +39,31 @@ private[compiletime] trait GatewayCommons {
     * ("Derived final expression is: ..." and "Derivation took ...") as regular `Info` logs, so they show up in the
     * journal Hearth renders on the success path. Otherwise a no-op (no logs are rendered - see [[extractExprAndLog]]).
     */
+  /** Kindlings-style EXTERNAL logging enablement, checked in addition to the `.enableMacrosLogging` DSL flag and the
+    * `chimney.transformer.MacrosLogging`/`chimney.patcher.MacrosLogging` macro settings:
+    *
+    *   - a [[io.scalaland.chimney.LogDerivation]] implicit in scope at the expansion site (placed there by
+    *     `import io.scalaland.chimney.debug._`) - per-file enablement without touching the transformation,
+    *   - the `-Xmacro-settings:chimney.logDerivation=true` scalac option - project-wide enablement.
+    *
+    * Evaluated lazily once per macro expansion (the implicit search is a cheap miss in the common case).
+    */
+  protected lazy val isLogDerivationEnabledExternally: Boolean = {
+    implicit val LogDerivationType: Type[io.scalaland.chimney.LogDerivation] =
+      Type.of[io.scalaland.chimney.LogDerivation]
+    Expr.summonImplicit[io.scalaland.chimney.LogDerivation].isDefined || (for {
+      data <- Environment.typedSettings.toOption
+      chimney <- data.get("chimney")
+      shouldLog <- chimney.get("logDerivation").flatMap(_.asBoolean)
+    } yield shouldLog).getOrElse(false)
+  }
+
   protected def enableLoggingIfFlagEnabled[Out](
       result: MIO[Expr[Out]],
-      isMacroLoggingEnabled: Boolean,
+      isMacroLoggingEnabledByFlag: Boolean,
       derivationStartedAt: java.time.Instant
-  ): MIO[Expr[Out]] =
+  ): MIO[Expr[Out]] = {
+    val isMacroLoggingEnabled = isMacroLoggingEnabledByFlag || isLogDerivationEnabledExternally
     if (isMacroLoggingEnabled)
       result.flatTap { expr =>
         val duration = java.time.Duration.between(derivationStartedAt, java.time.Instant.now())
@@ -51,6 +71,7 @@ private[compiletime] trait GatewayCommons {
           Log.info(f"Derivation took ${duration.getSeconds}%d.${duration.getNano}%09d s")
       }
     else result
+  }
 
   /** Runs the derivation program and either returns its expression or aborts with the user-facing error message.
     *
@@ -62,8 +83,9 @@ private[compiletime] trait GatewayCommons {
   protected def extractExprAndLog[Out](
       result: MIO[Expr[Out]],
       errorHeader: => String,
-      isMacroLoggingEnabled: Boolean
+      isMacroLoggingEnabledByFlag: Boolean
   ): Expr[Out] = {
+    val isMacroLoggingEnabled = isMacroLoggingEnabledByFlag || isLogDerivationEnabledExternally
     // Builds Chimney's exact user-facing error text (errorHeader + DerivationErrors prettyPrint + doc-URL footer). The
     // `renderedLogs` are the journal Hearth already rendered for us; they are empty unless MacrosLogging is enabled and
     // the derivation failed, so every error-message test (which does not enable logging) still sees byte-identical text.
@@ -161,9 +183,57 @@ private[compiletime] trait GatewayCommons {
   /** Chimney had no explicit timeout (the old hand-rolled `unsafe.runSync` ran unbounded); Hearth's default is 2s,
     * which is far too low for large derivations. Pick a generous ceiling so ordinary compiles never time out spuriously
     * (manual termination via Ctrl+C still works through Hearth's `TerminationObserver` regardless of this value).
+    *
+    * Overridable Kindlings-style with `-Xmacro-settings:chimney.timeout=30s` (accepted formats: `30`, `30s`, `5000ms`,
+    * `1m` - same grammar as Kindlings' per-module `timeout` settings; unlike Kindlings the DEFAULT stays generous).
     */
-  private val macroExpansionTimeout: FiniteDuration =
-    FiniteDuration(10, java.util.concurrent.TimeUnit.MINUTES)
+  private lazy val macroExpansionTimeout: FiniteDuration =
+    (for {
+      data <- Environment.typedSettings.toOption
+      chimney <- data.get("chimney")
+      timeoutData <- chimney.get("timeout")
+      duration <- timeoutData.asInt
+        .filter(_ > 0)
+        .map(n => FiniteDuration(n.toLong, java.util.concurrent.TimeUnit.SECONDS))
+        .orElse(
+          timeoutData.asLong.filter(_ > 0).map(n => FiniteDuration(n, java.util.concurrent.TimeUnit.SECONDS))
+        )
+        .orElse(timeoutData.asString.flatMap(parseTimeoutString))
+    } yield duration).getOrElse(GatewayCommons.DefaultMacroExpansionTimeout)
+
+  private def parseTimeoutString(str: String): Option[FiniteDuration] = str.trim match {
+    case GatewayCommons.TimeoutDurationPattern(num, unit) =>
+      val n = num.toLong
+      if (n > 0) {
+        val tu = unit match {
+          case "ms" | "millis" | "milliseconds" => java.util.concurrent.TimeUnit.MILLISECONDS
+          case "s" | "second" | "seconds"       => java.util.concurrent.TimeUnit.SECONDS
+          case "m" | "minute" | "minutes"       => java.util.concurrent.TimeUnit.MINUTES
+        }
+        Some(FiniteDuration(n, tu))
+      } else {
+        Environment.reportWarn(
+          s"chimney.timeout: value must be positive, got '$str'. " +
+            s"Using default of ${GatewayCommons.DefaultMacroExpansionTimeout.toMinutes}m."
+        )
+        None
+      }
+    case _ =>
+      Environment.reportWarn(
+        s"chimney.timeout: unrecognized format '$str'. Expected formats: 30, 30s, 5000ms, 1m. " +
+          s"Using default of ${GatewayCommons.DefaultMacroExpansionTimeout.toMinutes}m."
+      )
+      None
+  }
 
   private val chimneyDocUrl = "https://chimney.readthedocs.io"
+}
+
+private[compiletime] object GatewayCommons {
+
+  private val DefaultMacroExpansionTimeout: FiniteDuration =
+    FiniteDuration(10, java.util.concurrent.TimeUnit.MINUTES)
+
+  // Same grammar as Kindlings' per-module `timeout` settings.
+  private val TimeoutDurationPattern = """^\s*(\d+)\s*(ms|millis|milliseconds|s|seconds?|m|minutes?)\s*$""".r
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/DebugImportSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/DebugImportSpec.scala
@@ -1,0 +1,21 @@
+package io.scalaland.chimney
+
+class DebugImportSpec extends ChimneySpec {
+
+  import DebugImportSpec.*
+
+  test("import io.scalaland.chimney.debug._ places a LogDerivation in scope and does not break derivation") {
+    import io.scalaland.chimney.debug.*
+    import io.scalaland.chimney.dsl.*
+
+    // The import's whole contract: the implicit is visible to the expansion (which turns on the derivation log -
+    // rendered to compiler info output, not asserted on, same as .enableMacrosLogging) and the result is unchanged.
+    val _ = implicitly[LogDerivation]
+    Bar("abc", 10).transformInto[Foo] ==> Foo("abc", 10)
+  }
+}
+
+object DebugImportSpec {
+  case class Foo(x: String, y: Int)
+  case class Bar(x: String, y: Int)
+}

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -2619,6 +2619,80 @@ would generate:
     + Derivation took 0.113354000 s
     ```
 
+### Debug logging without touching the code (import or scalac option)
+
+!!! tip
+
+    Available since Chimney 2.0.0. The same idiom is used by every
+    [Kindlings](https://kubuszok.github.io/kindlings/) module.
+
+Besides the `.enableMacrosLogging` flag, logging can be enabled without modifying the transformation itself:
+
+**Via import (per-file)** - add the debug import to the file you want to inspect; every Chimney macro expanded in that
+file will print its log:
+
+!!! example
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    import io.scalaland.chimney.dsl._
+    import io.scalaland.chimney.debug._
+
+    case class Foo(x: String, y: Int)
+    case class Bar(x: String, y: Int)
+
+    Bar("abc", 10).transformInto[Foo] // prints the derivation log
+    ```
+
+The import places a `LogDerivation` implicit in scope; when a macro sees it, it prints the matched rules, summoned
+implicits and the generated code.
+
+**Via scalac option (project-wide)** - no code changes needed:
+
+!!! example
+
+    ```scala
+    // build.sbt
+    scalacOptions += "-Xmacro-settings:chimney.logDerivation=true"
+    ```
+
+(The older `-Xmacro-settings:chimney.transformer.MacrosLogging=true` and `chimney.patcher.MacrosLogging=true` options
+keep working and enable logging for only one kind of macro.)
+
+### Profiling derivation with flame graphs
+
+Chimney's derivation engine runs on [Hearth](https://kubuszok.github.io/hearth/), which can profile how long each
+derivation step takes and emit a flame graph per macro expansion. Add these scalac options:
+
+!!! example
+
+    ```scala
+    // build.sbt
+    scalacOptions ++= Seq(
+      "-Xmacro-settings:hearth.mioBenchmarkScopes=true",
+      "-Xmacro-settings:hearth.mioBenchmarkFlameGraphDir=/tmp/chimney-flamegraphs"
+    )
+    ```
+
+This generates `.speedscope.json` files in the specified directory - one per macro expansion. Open them at
+[speedscope.app](https://www.speedscope.app/) to visualize where compilation time is spent. This is most useful when a
+specific transformation takes noticeably long to derive.
+
+### Derivation timeout
+
+Every Chimney macro enforces a timeout, so a runaway derivation fails compilation with a clear error instead of
+hanging the compiler. The default is generous (**10 minutes**) so ordinary compiles never time out spuriously; it can
+be overridden when needed:
+
+!!! example
+
+    ```scala
+    // build.sbt
+    scalacOptions += "-Xmacro-settings:chimney.timeout=30s"
+    ```
+
+Accepted formats: `30` (seconds), `30s`, `5000ms`, `1m`.
+
 ## More sources, videos and tutorials
 
 Videos/presentations including or describing Chimney:


### PR DESCRIPTION
Ports [Kindlings' documented debugging idioms](https://kubuszok.github.io/kindlings/user-guide/debugging/) to Chimney, same API shape, `chimney.*` namespace:

| Capability | How |
|---|---|
| Debug log, per-file | `import io.scalaland.chimney.debug._` (places a `LogDerivation` implicit; macro ORs it into the existing logging gate) |
| Debug log, project-wide | `-Xmacro-settings:chimney.logDerivation=true` |
| Debug log, per-transformation | `.enableMacrosLogging` (unchanged) |
| Flame graphs | `hearth.mioBenchmark*` settings — now documented in the troubleshooting chapter |
| Timeout | `-Xmacro-settings:chimney.timeout=30s` (Kindlings grammar: `30`/`30s`/`5000ms`/`1m`; default stays 10 min) |

The external-enablement check lives centrally in `GatewayCommons` (one lazy per expansion — a cheap implicit-search miss in the common case), so transformers, patchers and iso/codec derivations all honor it.

Verified: chimney3 1119 + chimney 981 (new `DebugImportSpec`; the `-Werror` iteration incidentally proved the log renders through the import path).