### PR TITLE
Port Kindlings' derivation policy: opt-in scoping for structural derivation

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/AllowDerivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/AllowDerivation.scala
@@ -1,0 +1,16 @@
+package io.scalaland.chimney
+
+/** Marker used to permit Chimney's structural derivation in the current scope when the derivation policy is set to
+  * `opt-in` (see the derivation-policy chapter of the documentation).
+  *
+  * Do not instantiate it directly - `import io.scalaland.chimney.policy.allowDerivationForChimney` in the scope where
+  * the derivation should be allowed. Same idiom as Kindlings' per-module `policy` imports.
+  *
+  * A no-op under the default `always-allowed` policy.
+  *
+  * @see
+  *   [[https://chimney.readthedocs.io Chimney documentation - derivation policy chapter]]
+  *
+  * @since 2.0.0
+  */
+final class AllowDerivation

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/DerivationError.scala
@@ -17,6 +17,7 @@ object DerivationError {
       extends DerivationError(transformerDerivationError.toString)
   final case class PatcherError(patcherDerivationError: PatcherDerivationError)
       extends DerivationError(patcherDerivationError.toString)
+  final case class PolicyViolation(message: String) extends DerivationError(message)
 
   /** Classifies an arbitrary `Throwable` caught by MIO as a [[DerivationError]] before rendering. */
   def fromThrowable(error: Throwable): DerivationError = error match {
@@ -30,6 +31,8 @@ object DerivationError {
   def printErrors(derivationErrors: Seq[DerivationError]): String =
     derivationErrors
       .collectFirst {
+        case PolicyViolation(message) =>
+          message.linesIterator.map("  " + _).mkString("\n")
         case MacroException(exception) =>
           val stackTrace =
             exception.getStackTrace.view

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/DerivationPolicy.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/DerivationPolicy.scala
@@ -1,0 +1,181 @@
+package io.scalaland.chimney.internal.compiletime.derivation
+
+import hearth.fp.effect.MIO
+import io.scalaland.chimney.internal.compiletime.DerivationError
+
+/** Settings-driven gate controlling '''where''' Chimney's structural derivation (generating transformation code for
+  * `case class`es and `sealed` hierarchies / `enum`s) is allowed to happen. Direct port of Kindlings'
+  * `DerivationPolicy` (kubuszok/kindlings#85 - the "sanely-automatic" derivation-policy design), with the single
+  * `chimney` namespace instead of Kindlings' per-module ones.
+  *
+  * By default (`always-allowed`) nothing changes. Under `opt-in`, structural derivation is permitted only in
+  * designated scopes or behind the `io.scalaland.chimney.policy.allowDerivationForChimney` import; everywhere else the
+  * macro fails with an actionable message. Everything non-structural keeps working unconditionally: pre-existing
+  * implicits, subtype upcasts, options, eithers, collections, value classes - the policy rule sits directly before the
+  * ProductToProduct/SealedHierarchy (and PatchProductWithProduct) rules, so only the structural fallthrough is gated.
+  *
+  * Configuration keys (all under `chimney.policy.`):
+  *
+  * {{{
+  * -Xmacro-settings:chimney.policy.enabled=opt-in            // or always-allowed (default => current behavior)
+  * -Xmacro-settings:chimney.policy.allowedScopes=com.acme.mappings;com.acme.Instances
+  * -Xmacro-settings:chimney.policy.optInByImport=true        // default true
+  * }}}
+  *
+  * '''Why `;`/`|` and not `,` for `allowedScopes`''': the Scala 3 compiler splits a single `-Xmacro-settings:a,b`
+  * option on commas into `List("a","b")`, while Scala 2 keeps it as one `"a,b"` string - so a comma is not portable.
+  * `;` and `|` are never split by either compiler, so the value arrives intact and we split it ourselves.
+  */
+private[compiletime] trait DerivationPolicy { this: hearth.MacroCommons =>
+  // $COVERAGE-OFF$settings-driven behavior is exercised via unit tests of the pure core + documentation snippets
+
+  /** Computed once per macro expansion. On the default `always-allowed` path this short-circuits before touching
+    * [[Environment.enclosingScope]] or summoning the marker implicit, keeping the common path cheap.
+    */
+  protected lazy val derivationPolicyDecision: DerivationPolicy.Decision = {
+    val policyData = for {
+      data <- Environment.typedSettings.toOption
+      chimney <- data.get("chimney")
+      policy <- chimney.get("policy")
+    } yield policy
+
+    val mode = policyData.flatMap(_.get("enabled")).flatMap(_.asString) match {
+      case None      => DerivationPolicy.Mode.AlwaysAllowed
+      case Some(raw) =>
+        DerivationPolicy.parseMode(raw).getOrElse {
+          Environment.reportWarn(
+            s"chimney.policy.enabled: unrecognized value '$raw'. " +
+              s"Expected 'always-allowed' or 'opt-in'. Using 'always-allowed'."
+          )
+          DerivationPolicy.Mode.AlwaysAllowed
+        }
+    }
+
+    mode match {
+      case DerivationPolicy.Mode.AlwaysAllowed => DerivationPolicy.Decision.Allowed
+      case DerivationPolicy.Mode.OptIn         =>
+        val allowedScopes =
+          policyData
+            .flatMap(_.get("allowedScopes"))
+            .flatMap(_.asString)
+            .map(DerivationPolicy.splitScopes)
+            .getOrElse(Nil)
+        val optInByImport =
+          policyData.flatMap(_.get("optInByImport")).flatMap(_.asBoolean).getOrElse(true)
+        val enclosureFullNames = enclosingScope.toList.flatMap(_.fullName)
+        DerivationPolicy.decide(
+          allowedScopes = allowedScopes,
+          enclosureFullNames = enclosureFullNames,
+          optInByImport = optInByImport,
+          markerInScope = isDerivationOptInMarkerInScope
+        )
+    }
+  }
+
+  private def isDerivationOptInMarkerInScope: Boolean = {
+    implicit val AllowDerivationType: Type[io.scalaland.chimney.AllowDerivation] =
+      Type.of[io.scalaland.chimney.AllowDerivation]
+    Expr.summonImplicit[io.scalaland.chimney.AllowDerivation].isDefined
+  }
+
+  private var derivationPolicyChecked = false
+
+  /** The single policy check, run at most once per macro expansion. Yields `()` when derivation is permitted here
+    * (recording, the first time, that the check passed so all nested derivations skip it); fails the [[MIO]] with a
+    * [[DerivationError.PolicyViolation]] when denied.
+    *
+    * Intended to be the body of a rule placed directly BEFORE the structural rules: everything non-structural was
+    * already handled by the earlier rules, and once the outermost structural derivation is permitted every nested one
+    * is too.
+    */
+  protected def checkDerivationPolicyOncePerExpansion(derivationName: => String): MIO[Unit] =
+    MIO.pure(()).flatMap { _ =>
+      if (derivationPolicyChecked) MIO.pure(())
+      else
+        derivationPolicyDecision match {
+          case DerivationPolicy.Decision.Allowed =>
+            derivationPolicyChecked = true
+            MIO.pure(())
+          case denied: DerivationPolicy.Decision.Denied =>
+            MIO.fail(DerivationError.PolicyViolation(derivationPolicyDeniedMessage(derivationName, denied)))
+        }
+    }
+
+  private def derivationPolicyDeniedMessage(derivationName: String, denied: DerivationPolicy.Decision.Denied): String = {
+    val base =
+      if (denied.allowedScopes.nonEmpty)
+        s"""Structural derivation of $derivationName is enabled only in the following scopes:
+           |${denied.allowedScopes.map(" - " + _).mkString("\n")}
+           |
+           |Currently you are in the following scope: ${denied.currentScope.getOrElse("<unknown>")}.""".stripMargin
+      else
+        s"Structural derivation of $derivationName is globally disabled."
+
+    if (denied.optInByImport)
+      base +
+        s"""|
+            |
+            |You are allowed to enable this derivation locally by adding the import:
+            |import io.scalaland.chimney.policy.allowDerivationForChimney""".stripMargin
+    else base
+  }
+  // $COVERAGE-ON$
+}
+
+private[compiletime] object DerivationPolicy {
+
+  /** Parsed value of `chimney.policy.enabled`. */
+  sealed trait Mode extends Product with Serializable
+  object Mode {
+    case object AlwaysAllowed extends Mode
+    case object OptIn extends Mode
+  }
+
+  /** Outcome of evaluating the policy for the current macro-expansion point. */
+  sealed trait Decision extends Product with Serializable
+  object Decision {
+    case object Allowed extends Decision
+    final case class Denied(currentScope: Option[String], allowedScopes: List[String], optInByImport: Boolean)
+        extends Decision
+  }
+
+  def parseMode(raw: String): Option[Mode] = raw.trim.toLowerCase match {
+    case "always-allowed" | "always-allow" | "always" | "allowed" => Some(Mode.AlwaysAllowed)
+    case "opt-in" | "optin"                                       => Some(Mode.OptIn)
+    case _                                                        => None
+  }
+
+  /** Splits an `allowedScopes` setting value on `;` or `|` (NOT `,` - see [[DerivationPolicy]] for why), trimming and
+    * dropping empty entries.
+    */
+  def splitScopes(raw: String): List[String] =
+    raw.split("[;|]").iterator.map(_.trim).filter(_.nonEmpty).toList
+
+  /** Package-prefix-aware scope match: an `allowed` entry matches `fullName` when it is equal to it, or is a
+    * dotted-segment / member prefix of it (so a package entry covers everything nested under it, and an object/class
+    * entry covers its inner derivations). Boundaries recognized: `.`, `#`, `$`.
+    */
+  def scopeMatches(allowed: String, fullName: String): Boolean = {
+    val a = allowed.trim
+    a.nonEmpty && (fullName == a ||
+      fullName.startsWith(a + ".") ||
+      fullName.startsWith(a + "#") ||
+      fullName.startsWith(a + "$"))
+  }
+
+  def scopeAllows(allowedScopes: List[String], enclosureFullNames: List[String]): Boolean =
+    allowedScopes.exists(a => enclosureFullNames.exists(fn => scopeMatches(a, fn)))
+
+  /** Pure core of the decision (unit-tested directly). `markerInScope` is by-name so the (non-free) marker-implicit
+    * summon is only forced when the scope check has already failed and opt-in-by-import is enabled.
+    */
+  def decide(
+      allowedScopes: List[String],
+      enclosureFullNames: List[String],
+      optInByImport: Boolean,
+      markerInScope: => Boolean
+  ): Decision =
+    if (scopeAllows(allowedScopes, enclosureFullNames)) Decision.Allowed
+    else if (optInByImport && markerInScope) Decision.Allowed
+    else Decision.Denied(enclosureFullNames.headOption, allowedScopes, optInByImport)
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/DerivationPolicy.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/DerivationPolicy.scala
@@ -8,10 +8,10 @@ import io.scalaland.chimney.internal.compiletime.DerivationError
   * `DerivationPolicy` (kubuszok/kindlings#85 - the "sanely-automatic" derivation-policy design), with the single
   * `chimney` namespace instead of Kindlings' per-module ones.
   *
-  * By default (`always-allowed`) nothing changes. Under `opt-in`, structural derivation is permitted only in
-  * designated scopes or behind the `io.scalaland.chimney.policy.allowDerivationForChimney` import; everywhere else the
-  * macro fails with an actionable message. Everything non-structural keeps working unconditionally: pre-existing
-  * implicits, subtype upcasts, options, eithers, collections, value classes - the policy rule sits directly before the
+  * By default (`always-allowed`) nothing changes. Under `opt-in`, structural derivation is permitted only in designated
+  * scopes or behind the `io.scalaland.chimney.policy.allowDerivationForChimney` import; everywhere else the macro fails
+  * with an actionable message. Everything non-structural keeps working unconditionally: pre-existing implicits, subtype
+  * upcasts, options, eithers, collections, value classes - the policy rule sits directly before the
   * ProductToProduct/SealedHierarchy (and PatchProductWithProduct) rules, so only the structural fallthrough is gated.
   *
   * Configuration keys (all under `chimney.policy.`):
@@ -101,7 +101,10 @@ private[compiletime] trait DerivationPolicy { this: hearth.MacroCommons =>
         }
     }
 
-  private def derivationPolicyDeniedMessage(derivationName: String, denied: DerivationPolicy.Decision.Denied): String = {
+  private def derivationPolicyDeniedMessage(
+      derivationName: String,
+      denied: DerivationPolicy.Decision.Denied
+  ): String = {
     val base =
       if (denied.allowedScopes.nonEmpty)
         s"""Structural derivation of $derivationName is enabled only in the following scopes:

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/patcher/Derivation.scala
@@ -42,6 +42,8 @@ private[compiletime] trait Derivation
     TransformMapToMapRule,
     TransformIterableToIterableRule,
     TransformSubtypesRule,
+    // Directly before the structural rules - see the transformer chain / DerivationPolicy.
+    TransformDerivationPolicyRule,
     PatchProductWithProductRule,
     TransformSealedHierarchyToSealedHierarchyRule,
     PatchNotMatchedRule

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/Derivation.scala
@@ -20,6 +20,7 @@ private[compiletime] trait Derivation
     with integrations.TotallyBuildIterables
     with integrations.TotallyOrPartiallyBuildIterables
     with ChimneyEngineExtensionApi
+    with io.scalaland.chimney.internal.compiletime.derivation.DerivationPolicy
     with rules.TransformationRules
     with rules.TransformImplicitRuleModule
     with rules.TransformImplicitPartialFallbackToTotalRuleModule
@@ -38,6 +39,7 @@ private[compiletime] trait Derivation
     with rules.TransformEitherToEitherRuleModule
     with rules.TransformMapToMapRuleModule
     with rules.TransformIterableToIterableRuleModule
+    with rules.TransformDerivationPolicyRuleModule
     with rules.TransformProductToProductRuleModule
     with rules.TransformSealedHierarchyToSealedHierarchyRuleModule {
   this: hearth.MacroCommons & hearth.std.StdExtensions =>
@@ -62,6 +64,9 @@ private[compiletime] trait Derivation
     TransformEitherToEitherRule,
     TransformMapToMapRule,
     TransformIterableToIterableRule,
+    // Directly before the structural rules: gates exactly "derive new code for a product/sum type" (a no-op yield
+    // under the default always-allowed policy) - everything above stays ungated. See DerivationPolicy.
+    TransformDerivationPolicyRule,
     TransformProductToProductRule,
     TransformSealedHierarchyToSealedHierarchyRule
   )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformDerivationPolicyRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformDerivationPolicyRuleModule.scala
@@ -1,0 +1,22 @@
+package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
+
+import hearth.fp.effect.MIO
+import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+
+private[compiletime] trait TransformDerivationPolicyRuleModule { this: Derivation & hearth.MacroCommons =>
+
+  /** Enforces the derivation policy (see
+    * [[io.scalaland.chimney.internal.compiletime.derivation.DerivationPolicy DerivationPolicy]]) directly before the
+    * structural rules (ProductToProduct / SealedHierarchyToSealedHierarchy / PatchProductWithProduct): any [From, To]
+    * pair reaching this position fell through every non-structural rule, so gating here gates exactly "generating new
+    * transformation code for a product/sum type". The check runs once per macro expansion - when the outermost
+    * structural derivation is permitted, every nested one is too - and always yields to the next rule when permitted.
+    */
+  protected object TransformDerivationPolicyRule extends Rule("DerivationPolicy") {
+
+    def expand[From, To](implicit ctx: TransformationContext[From, To]): MIO[Rule.ExpansionResult[To]] =
+      checkDerivationPolicyOncePerExpansion(
+        s"Chimney transformation from ${Type.prettyPrint[From]} to ${Type.prettyPrint[To]}"
+      ) >> attemptNextRule
+  }
+}

--- a/chimney/src/main/scala/io/scalaland/chimney/policy/package.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/policy/package.scala
@@ -1,0 +1,25 @@
+package io.scalaland.chimney
+
+package object policy {
+
+  /** Import this value to permit Chimney's structural derivation in the current scope when the derivation policy is
+    * `opt-in`:
+    *
+    * {{{
+    * import io.scalaland.chimney.policy.allowDerivationForChimney
+    * }}}
+    *
+    * Configured with (see the derivation-policy chapter of the documentation):
+    *
+    * {{{
+    * -Xmacro-settings:chimney.policy.enabled=opt-in
+    * -Xmacro-settings:chimney.policy.allowedScopes=com.acme.mappings;com.acme.Instances
+    * -Xmacro-settings:chimney.policy.optInByImport=true
+    * }}}
+    *
+    * A no-op under the default `always-allowed` policy.
+    *
+    * @since 2.0.0
+    */
+  implicit val allowDerivationForChimney: AllowDerivation = new AllowDerivation
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/internal/compiletime/derivation/DerivationPolicySpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/internal/compiletime/derivation/DerivationPolicySpec.scala
@@ -1,0 +1,58 @@
+package io.scalaland.chimney.internal.compiletime.derivation
+
+import io.scalaland.chimney.ChimneySpec
+
+/** Unit tests of the pure decision core (port of Kindlings' DerivationPolicySpec) - the settings-driven wiring is
+  * compile-time-global, so end-to-end behavior is exercised through documentation snippets instead.
+  */
+class DerivationPolicySpec extends ChimneySpec {
+
+  import DerivationPolicy.*
+
+  test("parseMode accepts documented spellings and rejects everything else") {
+    parseMode("always-allowed") ==> Some(Mode.AlwaysAllowed)
+    parseMode("Always") ==> Some(Mode.AlwaysAllowed)
+    parseMode(" opt-in ") ==> Some(Mode.OptIn)
+    parseMode("optin") ==> Some(Mode.OptIn)
+    parseMode("nope") ==> None
+  }
+
+  test("splitScopes splits on ; and | but never on ,") {
+    splitScopes("a.b;c.d") ==> List("a.b", "c.d")
+    splitScopes("a.b | c.d") ==> List("a.b", "c.d")
+    splitScopes("a,b") ==> List("a,b")
+    splitScopes(" ; ;a.b; ") ==> List("a.b")
+  }
+
+  test("scopeMatches is a segment-aware prefix match") {
+    scopeMatches("com.acme", "com.acme") ==> true
+    scopeMatches("com.acme", "com.acme.json.Codecs") ==> true
+    scopeMatches("com.acme.Codecs", "com.acme.Codecs$Inner") ==> true
+    scopeMatches("com.acme.Codecs", "com.acme.Codecs#member") ==> true
+    scopeMatches("com.acme", "com.acmeister") ==> false
+    scopeMatches("", "com.acme") ==> false
+  }
+
+  test("decide: allowed scope wins without forcing the marker") {
+    var markerForced = false
+    decide(
+      allowedScopes = List("com.acme"),
+      enclosureFullNames = List("com.acme.json.Instances"),
+      optInByImport = true,
+      markerInScope = { markerForced = true; true }
+    ) ==> Decision.Allowed
+    markerForced ==> false
+  }
+
+  test("decide: marker allows when scopes do not match and optInByImport is on") {
+    decide(List("com.acme"), List("com.other.Handler"), optInByImport = true, markerInScope = true) ==>
+      Decision.Allowed
+    decide(List("com.acme"), List("com.other.Handler"), optInByImport = false, markerInScope = true) ==>
+      Decision.Denied(Some("com.other.Handler"), List("com.acme"), optInByImport = false)
+  }
+
+  test("decide: denial carries the current scope and configured scopes for the error message") {
+    decide(Nil, List("com.other.Handler"), optInByImport = true, markerInScope = false) ==>
+      Decision.Denied(Some("com.other.Handler"), Nil, optInByImport = true)
+  }
+}

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -1039,6 +1039,46 @@ For the reasons above the recommendations are as follows:
   - use benchmarks to ensure it is reasonably fast
   - and keep on using `import dsl._` until you have some good proof that (recursive) semi-automatic derivation is needed 
 
+### Derivation policy: restricting where derivation may happen
+
+!!! tip
+
+    Available since Chimney 2.0.0. Same design and configuration keys as
+    [Kindlings' derivation policy](https://kubuszok.github.io/kindlings/user-guide/derivation-policy/).
+
+Some teams want tighter control over **where** transformations come into existence — for example, to ensure every
+canonical mapping is defined in one designated place rather than materialized ad-hoc at a random call site. The
+**derivation policy** provides this without a separate semi-automatic API: it is a compile-time switch configured
+entirely through `-Xmacro-settings`.
+
+The policy gates only **structural derivation** — generating new transformation code for a `case class` or a `sealed`
+hierarchy / `enum`. Everything else keeps working unconditionally: pre-existing implicits (your hand-written
+`Transformer`s), subtype upcasts, options, eithers, collections, value classes.
+
+```scala
+// build.sbt
+Compile / scalacOptions ++= Seq(
+  // opt-in (gated) or always-allowed (default - current behavior):
+  "-Xmacro-settings:chimney.policy.enabled=opt-in",
+  // scopes (packages, objects or classes, by fully-qualified name) where structural derivation is permitted;
+  // separate entries with ; or | - NEVER , (Scala 3 splits a -Xmacro-settings option on commas, Scala 2 does not):
+  "-Xmacro-settings:chimney.policy.allowedScopes=com.acme.mappings;com.acme.Instances",
+  // whether the opt-in import below also permits derivation (default: true):
+  "-Xmacro-settings:chimney.policy.optInByImport=true"
+)
+```
+
+When the policy is `opt-in` and a macro would structurally derive outside an allowed scope, compilation fails with an
+actionable message. Derivation can then be permitted locally with the opt-in import:
+
+```scala
+import io.scalaland.chimney.policy.allowDerivationForChimney
+```
+
+The check runs once per macro expansion: if the outermost derivation happens in an allowed place, all transformations
+nested in it (recursively derived fields, subtypes, collection elements) are permitted as part of it — you define the
+transformation once, in an allowed location, and use it as an implicit everywhere else.
+
 ## Bidirectional transformations
 
 In some cases you might want to derive 2 transformations: from some type into another type and back. Most of the time,


### PR DESCRIPTION
Ports [Kindlings' derivation policy](https://kubuszok.github.io/kindlings/user-guide/derivation-policy/) to Chimney — same design, semantics, configuration keys and import idiom, under the `chimney` namespace:

```text
-Xmacro-settings:chimney.policy.enabled=opt-in        # default: always-allowed (current behavior)
-Xmacro-settings:chimney.policy.allowedScopes=com.acme.mappings;com.acme.Instances
-Xmacro-settings:chimney.policy.optInByImport=true    # default: true
```

plus `import io.scalaland.chimney.policy.allowDerivationForChimney` for local opt-in.

**Placement** (the one Chimney-specific decision): the gate is a new `TransformDerivationPolicyRule` inserted directly **before the structural rules** (ProductToProduct/SealedHierarchy; PatchProductWithProduct in the patcher chain). Anything reaching that position fell through every non-structural rule, so the gate covers exactly "generate new code for a product/sum type" — pre-existing implicits, upcasts, options, eithers, collections and value classes stay ungated, matching Kindlings' documented contract. Checked once per expansion (an allowed outermost derivation covers everything nested); denial fails fast with an actionable message (new `DerivationError.PolicyViolation`) listing allowed scopes, the current scope, and the opt-in import. Under the default policy the rule is a pure yield-through.

Tests: port of Kindlings' `DerivationPolicySpec` (pure decision core — the settings are compile-time-global, so e2e goes through doc snippets, as in Kindlings). Docs: new cookbook section mirroring Kindlings' derivation-policy page.

Verified: chimney3 1124 + chimney 986.