### PR TITLE
Add CamelSnakeCaseEquality and IgnorePrefix name comparisons

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -1,6 +1,6 @@
 package io.scalaland.chimney.dsl
 
-/** Provides a way of customizing how fields/subtypes shoud get matched betwen source value and target value.
+/** Provides a way of customizing how fields/subtypes should get matched between source value and target value.
   *
   * @see
   *   [[https://chimney.readthedocs.io/supported-transformations/#defining-custom-name-matching-predicate]] for more
@@ -47,6 +47,33 @@ object TransformedNamesComparison {
   case object CaseInsensitiveEquality extends TransformedNamesComparison {
 
     def namesMatch(fromName: String, toName: String): Boolean = fromName.equalsIgnoreCase(toName)
+  }
+
+  case object CamelSnakeCaseEquality extends TransformedNamesComparison {
+
+    private def snakeToCamel(snake: String): (String, Boolean) =
+      snake.split('_') match {
+        case Array(part) => (part, false)
+        case parts       =>
+          val camel = parts
+            .filter(_.nonEmpty) // Remove empty parts from consecutive underscores
+            .zipWithIndex
+            .map { case (part, idx) =>
+              if (idx == 0) part.toLowerCase
+              else part.toLowerCase.capitalize
+            }
+            .mkString
+          (camel, true)
+      }
+
+    def namesMatch(fromName: String, toName: String): Boolean = {
+      val (from, fromWasCamelCase) = snakeToCamel(fromName)
+      val (to, toWasCamelCase) = snakeToCamel(toName)
+      if (fromWasCamelCase == toWasCamelCase)
+        fromName == toName
+      else
+        from == to
+    }
   }
 
   type FieldDefault = BeanAware.type

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformedNamesComparison.scala
@@ -76,6 +76,12 @@ object TransformedNamesComparison {
     }
   }
 
+  /** Matches names after stripping a fixed prefix from the source name. */
+  abstract class IgnorePrefix(prefix: String) extends TransformedNamesComparison { this: Singleton =>
+
+    def namesMatch(fromName: String, toName: String): Boolean = fromName == prefix + toName
+  }
+
   type FieldDefault = BeanAware.type
   val FieldDefault: FieldDefault = BeanAware
 

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -912,4 +912,24 @@ class IssuesSpec extends ChimneySpec {
         Some(None)
     }
   }
+
+  test("fix issue #831") {
+    case class UserDAO(userId: Int, createdAt: String)
+    case class UserDTO(user_id: Int, created_at: String)
+    val userId = 123
+    val createdAt = "2024-12-03T12:00:00"
+    UserDAO(userId, createdAt)
+      .into[UserDTO]
+      .enableCustomFieldNameComparison(
+        TransformedNamesComparison.CamelSnakeCaseEquality
+      )
+      .transform ==> UserDTO(userId, createdAt)
+
+    UserDTO(userId, createdAt)
+      .into[UserDAO]
+      .enableCustomFieldNameComparison(
+        TransformedNamesComparison.CamelSnakeCaseEquality
+      )
+      .transform ==> UserDAO(userId, createdAt)
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
@@ -79,4 +79,35 @@ class TransformedNamesComparisonSpec extends ChimneySpec {
       TransformedNamesComparison.CaseInsensitiveEquality.namesMatch("SOME_FIELD", "someField") ==> false
     }
   }
+
+  group("TransformedNamesComparison.CamelSnakeCaseEquality") {
+
+    def namesMatches(from: String, to: String): Boolean =
+      TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch(
+        from,
+        to
+      ) && TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch(to, from)
+
+    test("should match identical names") {
+      TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch("_", "_") ==> true
+      TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch("someField", "someField") ==> true
+    }
+
+    test("should match conversion") {
+      namesMatches("some_Field", "someField") ==> true
+      namesMatches("some_field", "someField") ==> true
+      namesMatches("some_field_123", "someField123") ==> true
+      namesMatches("some__field", "someField") ==> true
+      namesMatches("_some__field", "someField") ==> true
+      namesMatches("SOME_FIELD", "someField") ==> true
+    }
+
+    test("should not match conversion") {
+      TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch("_", "__") ==> false
+      TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch("somefield", "some_field") ==> false
+      TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch("some_field", "some_Field") ==> false
+      TransformedNamesComparison.CamelSnakeCaseEquality.namesMatch("someField", "somefield") ==> false
+    }
+
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TransformedNamesComparisonSpec.scala
@@ -110,4 +110,28 @@ class TransformedNamesComparisonSpec extends ChimneySpec {
     }
 
   }
+
+  group("TransformedNamesComparison.IgnorePrefix") {
+
+    test("should match when the source name equals the prefix followed by the target name") {
+      IgnoreFooPrefix.namesMatch("FooBar", "Bar") ==> true
+      IgnoreFooPrefix.namesMatch("FooBaz", "Baz") ==> true
+    }
+
+    test("should match identical names only when the prefix is empty") {
+      IgnoreFooPrefix.namesMatch("Bar", "Bar") ==> false
+      IgnoreFooPrefix.namesMatch("Foo", "Foo") ==> false
+    }
+
+    test("should not match when the prefix is missing or the names differ") {
+      IgnoreFooPrefix.namesMatch("Bar", "FooBar") ==> false
+      IgnoreFooPrefix.namesMatch("BarFoo", "Bar") ==> false
+      IgnoreFooPrefix.namesMatch("FooBar", "Baz") ==> false
+    }
+  }
 }
+
+/** Extended outside of `TransformedNamesComparison` to make sure `IgnorePrefix` is not `sealed` and can be reused by
+  * downstream code, as documented.
+  */
+case object IgnoreFooPrefix extends TransformedNamesComparison.IgnorePrefix("Foo")

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -233,9 +233,9 @@ Similarly `Patcher` has `.withPatchedValueFlag(pathFromPatchedValue)`:
 
 ## Checking for unused source fields/unmatched target subtypes
 
-While most of the time Chimney is picked for generating mapping between 2 data types wit as little hassle as possible,
+While most of the time Chimney is picked for generating mapping between 2 data types with as little hassle as possible,
 some people use type mapping tools to express mapping as a declarative description of the transformation. As a Part of
-that requirement is making it explicit, that some field in the source value was dropped, or that matching between 2
+that requirement is making it explicit that some field in the source value was dropped, or that matching between 2
 `sealed` hierarchies didn't use one target subtype.
 
 These can be enabled with `UnusedFieldPolicy`:
@@ -302,7 +302,7 @@ These can be enabled with `UnusedFieldPolicy`:
 
 and `UnmatchedSubtypePolicy`:
 
-!!! example "Subptype has to be explicitly ignored to compile"
+!!! example "Subtype has to be explicitly ignored to compile"
 
     ```scala
     //> using dep io.scalaland::chimney::{{ chimney_version() }}
@@ -500,7 +500,7 @@ Since Chimney 1.6.0 we are able to [scope the flag to a particular field](#const
 
 If the particular flag we want to use in limited scope is `.enableDefaultValues`, we might also consider
 [`.enableDefaultValueOfType[A]`](supported-transformations.md#allowing-fallback-to-the-constructors-default-values)
-available since Chimney 1.2.0 (but scoped flag would work as well!).
+available since Chimney 1.2.0 (but a scoped flag would work as well!).
 
 !!! example "Enabling default values only for 1 type"
 
@@ -664,7 +664,7 @@ Many users are not aware that Chimney can transform one Scala collection into an
     // List(Bar(a = 10))
     ```
 
-even though transforming all values of a collection (and even the type of a collection!) was supported since Chimney 0.2.0:
+even though transforming all values of a collection (and even the type of collection!) was supported since Chimney 0.2.0:
 
 !!! example
 
@@ -1327,7 +1327,7 @@ collection), then you can:
 
 !!! example "Converting from Cats collections"
 
-   ```scala
+    ```scala
     //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
@@ -1403,7 +1403,7 @@ collection), then you can:
 
 !!! example "Converting between Cats collections of the same type"
 
-   ```scala
+    ```scala
     //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
@@ -1435,7 +1435,7 @@ collection), then you can:
 
 !!! example "Converting using implicit ~> (FunctionK)"
 
-   ```scala
+    ```scala
     //> using dep org.typelevel::cats-core::{{ libraries.cats }}
     //> using dep io.scalaland::chimney-cats::{{ chimney_version() }}
     //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -6225,8 +6225,10 @@ Arguments taken by both `.enableCustomFieldNameComparison` and `.enableCustomSub
     
  - `TransformedNamesComparison.CaseInsensitiveEquality` - 2 names are considered equal if `equalsIgnoreCase` returns
   `true`
+ - `TransformedNamesComparison.CamelSnakeCaseEquality` - 2 names are considered equal if they are identical `String`s OR if they are
+   identical after you convert them from snake to camel case (e.g. `snake_case` -> `snakeCase`, `camelCase` -> `camelCase`)
 
-However, these 3 do not exhaust all possible comparisons and you might need to provide one yourself. 
+However, these 4 do not exhaust all possible comparisons, and you might need to provide one yourself. 
 
 !!! warning
 

--- a/docs/docs/supported-transformations.md
+++ b/docs/docs/supported-transformations.md
@@ -6227,8 +6227,13 @@ Arguments taken by both `.enableCustomFieldNameComparison` and `.enableCustomSub
   `true`
  - `TransformedNamesComparison.CamelSnakeCaseEquality` - 2 names are considered equal if they are identical `String`s OR if they are
    identical after you convert them from snake to camel case (e.g. `snake_case` -> `snakeCase`, `camelCase` -> `camelCase`)
+ - `TransformedNamesComparison.IgnorePrefix` - a base class (rather than a ready-to-use value) that you extend with a fixed
+   prefix, e.g. `case object FooNamesComparison extends TransformedNamesComparison.IgnorePrefix("Foo")`. The source name
+   matches the target name if it equals the prefix followed by the target name (e.g. `FooBar` matches `Bar`). This is handy for
+   code-generated types such as Protobuf enums whose variants
+   [repeat the enum name as a prefix](https://buf.build/blog/totw-3-enum-names-need-prefixes)
 
-However, these 4 do not exhaust all possible comparisons, and you might need to provide one yourself. 
+However, these 5 do not exhaust all possible comparisons, and you might need to provide one yourself. 
 
 !!! warning
 


### PR DESCRIPTION
Merges and cleans up two community contributions that add built-in `TransformedNamesComparison` strategies, with docs and tests, and fixes a documentation-rendering regression.

**Attribution:** each commit is authored by the original PR author, with the fixups co-authored. Please merge preserving history (rebase/merge commit), **not squash**, so the original authors keep their commit attribution.

## `CamelSnakeCaseEquality` — closes #831 (from #882, authored by @ajozwik)

A built-in snake_case ↔ camelCase name-matching strategy, so users no longer have to hand-roll one. Implementation, tests (`IssuesSpec` + `TransformedNamesComparisonSpec`) and the `supported-transformations.md` entry come from #882.

**Fix vs #882 / #883:** those PRs de-indented the `Scala 2` / `Scala 3` labels inside the first `!!! example` admonition in `cookbook.md`, which would push them (and their code blocks) *outside* the admonition and break its rendering. This keeps the labels indented. The other, legitimate doc fixes from #882 are retained (typos, `Subptype` → `Subtype`, and correcting the Cats-section code fences from 3 to 4 spaces). #883 is a strict subset of #882's cookbook changes and is superseded here.

## `IgnorePrefix` (from #871, authored by Yann Moisan / @YannMoisan)

A base comparison you extend with a fixed prefix, matching a source name to a target name after stripping that prefix from the source side — common for code-generated types such as Protobuf enums whose variants repeat the enum name as a prefix.

**Changes vs #871:**
- Drop `sealed` — as written it could not be extended by downstream code, which is the entire intended usage (`case object Foo extends TransformedNamesComparison.IgnorePrefix("Foo")`). A test object defined in a separate file now guards this.
- Replace the free-form usage/motivation comment with a one-line Scaladoc consistent with the sibling comparisons.
- Add unit tests and a user-facing entry in `supported-transformations.md`.

## Verification
- Tests pass on Scala 2.13 and Scala 3 (`TransformedNamesComparisonSpec`, `IssuesSpec`).
- `scalafmtCheckAll` clean; `mimaReportBinaryIssues` reports no binary-compatibility issues.
- Docs build locally with MkDocs Material; rendered HTML confirms the `!!! example` admonitions are intact.

Closes #831. Supersedes #871, #882, #883.