### PR TITLE
Add map/contramap/imap combinators to Transformer, PartialTransformer, Codec and Iso

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Codec.scala
@@ -21,7 +21,42 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
   *
   * @since 1.2.0
   */
-final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: PartialTransformer[Dto, Domain])
+final case class Codec[Domain, Dto](encode: Transformer[Domain, Dto], decode: PartialTransformer[Dto, Domain]) {
+
+  /** Creates a new [[io.scalaland.chimney.Codec]] with the `Domain` side replaced by `NewDomain`, given a bijection
+    * between the two.
+    *
+    * @tparam NewDomain
+    *   the new domain type
+    * @param f
+    *   conversion from the old `Domain` to `NewDomain`
+    * @param g
+    *   conversion from `NewDomain` back to the old `Domain`
+    * @return
+    *   new [[io.scalaland.chimney.Codec]] between `NewDomain` and `Dto`
+    *
+    * @since 2.0.0
+    */
+  def imapDomain[NewDomain](f: Domain => NewDomain)(g: NewDomain => Domain): Codec[NewDomain, Dto] =
+    Codec(encode.contramap(g), decode.map(f))
+
+  /** Creates a new [[io.scalaland.chimney.Codec]] with the `Dto` side replaced by `NewDto`, given a bijection between
+    * the two.
+    *
+    * @tparam NewDto
+    *   the new DTO type
+    * @param f
+    *   conversion from the old `Dto` to `NewDto`
+    * @param g
+    *   conversion from `NewDto` back to the old `Dto`
+    * @return
+    *   new [[io.scalaland.chimney.Codec]] between `Domain` and `NewDto`
+    *
+    * @since 2.0.0
+    */
+  def imapDto[NewDto](f: Dto => NewDto)(g: NewDto => Dto): Codec[Domain, NewDto] =
+    Codec(encode.map(f), decode.contramap(g))
+}
 
 /** Companion of [[io.scalaland.chimney.Codec]].
   *

--- a/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Iso.scala
@@ -20,7 +20,42 @@ import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverr
   *
   * @since 1.2.0
   */
-final case class Iso[First, Second](first: Transformer[First, Second], second: Transformer[Second, First])
+final case class Iso[First, Second](first: Transformer[First, Second], second: Transformer[Second, First]) {
+
+  /** Creates a new [[io.scalaland.chimney.Iso]] with the `First` side replaced by `NewFirst`, given a bijection between
+    * the two.
+    *
+    * @tparam NewFirst
+    *   the new first type
+    * @param f
+    *   conversion from the old `First` to `NewFirst`
+    * @param g
+    *   conversion from `NewFirst` back to the old `First`
+    * @return
+    *   new [[io.scalaland.chimney.Iso]] between `NewFirst` and `Second`
+    *
+    * @since 2.0.0
+    */
+  def imapFirst[NewFirst](f: First => NewFirst)(g: NewFirst => First): Iso[NewFirst, Second] =
+    Iso(first.contramap(g), second.map(f))
+
+  /** Creates a new [[io.scalaland.chimney.Iso]] with the `Second` side replaced by `NewSecond`, given a bijection
+    * between the two.
+    *
+    * @tparam NewSecond
+    *   the new second type
+    * @param f
+    *   conversion from the old `Second` to `NewSecond`
+    * @param g
+    *   conversion from `NewSecond` back to the old `Second`
+    * @return
+    *   new [[io.scalaland.chimney.Iso]] between `First` and `NewSecond`
+    *
+    * @since 2.0.0
+    */
+  def imapSecond[NewSecond](f: Second => NewSecond)(g: NewSecond => Second): Iso[First, NewSecond] =
+    Iso(first.map(f), second.contramap(g))
+}
 
 /** Companion of [[io.scalaland.chimney.Iso]].
   *

--- a/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/PartialTransformer.scala
@@ -64,6 +64,98 @@ trait PartialTransformer[From, To] {
     */
   final def transformFailFast(src: From): partial.Result[To] =
     transform(src, failFast = true)
+
+  /** Creates a new [[io.scalaland.chimney.PartialTransformer]] by applying a pure function to the successful result of
+    * this transformation.
+    *
+    * {{{
+    *   val parseInt: PartialTransformer[String, Int] = PartialTransformer(str => partial.Result.fromCatching(str.toInt))
+    *
+    *   case class Length(length: Int)
+    *
+    *   implicit val toLength: PartialTransformer[String, Length] = parseInt.map(Length(_))
+    * }}}
+    *
+    * @tparam To2
+    *   type of the mapped output value
+    * @param f
+    *   a pure function that maps `To` to `To2`
+    * @return
+    *   new [[io.scalaland.chimney.PartialTransformer]] from `From` to `To2`
+    *
+    * @since 2.0.0
+    */
+  final def map[To2](f: To => To2): PartialTransformer[From, To2] =
+    (src: From, failFast: Boolean) => transform(src, failFast).map(f)
+
+  /** Creates a new [[io.scalaland.chimney.PartialTransformer]] by applying a partial function to the successful result
+    * of this transformation, allowing the mapping itself to fail.
+    *
+    * {{{
+    *   val parseInt: PartialTransformer[String, Int] = PartialTransformer(str => partial.Result.fromCatching(str.toInt))
+    *
+    *   case class Positive(value: Int)
+    *
+    *   implicit val toPositive: PartialTransformer[String, Positive] =
+    *     parseInt.mapPartial(i => partial.Result.fromOption(Option.when(i > 0)(Positive(i))))
+    * }}}
+    *
+    * @tparam To2
+    *   type of the mapped output value
+    * @param f
+    *   a function that maps `To` to a [[io.scalaland.chimney.partial.Result]] of `To2`
+    * @return
+    *   new [[io.scalaland.chimney.PartialTransformer]] from `From` to `To2`
+    *
+    * @since 2.0.0
+    */
+  final def mapPartial[To2](f: To => partial.Result[To2]): PartialTransformer[From, To2] =
+    (src: From, failFast: Boolean) => transform(src, failFast).flatMap(f)
+
+  /** Creates a new [[io.scalaland.chimney.PartialTransformer]] by applying a pure function to the source before this
+    * transformation.
+    *
+    * {{{
+    *   val parseInt: PartialTransformer[String, Int] = PartialTransformer(str => partial.Result.fromCatching(str.toInt))
+    *
+    *   case class Raw(raw: String)
+    *
+    *   implicit val rawToInt: PartialTransformer[Raw, Int] = parseInt.contramap(_.raw)
+    * }}}
+    *
+    * @tparam From2
+    *   type of the new input value
+    * @param f
+    *   a pure function that maps `From2` to `From`
+    * @return
+    *   new [[io.scalaland.chimney.PartialTransformer]] from `From2` to `To`
+    *
+    * @since 2.0.0
+    */
+  final def contramap[From2](f: From2 => From): PartialTransformer[From2, To] =
+    (src: From2, failFast: Boolean) => transform(f(src), failFast)
+
+  /** Creates a new [[io.scalaland.chimney.PartialTransformer]] by applying a partial function to the source before this
+    * transformation, allowing the preprocessing itself to fail.
+    *
+    * {{{
+    *   val parseInt: PartialTransformer[String, Int] = PartialTransformer(str => partial.Result.fromCatching(str.toInt))
+    *
+    *   implicit val trimmedToInt: PartialTransformer[String, Int] =
+    *     parseInt.contramapPartial(str => partial.Result.fromOption(Option(str).map(_.trim).filter(_.nonEmpty)))
+    * }}}
+    *
+    * @tparam From2
+    *   type of the new input value
+    * @param f
+    *   a function that maps `From2` to a [[io.scalaland.chimney.partial.Result]] of `From`
+    * @return
+    *   new [[io.scalaland.chimney.PartialTransformer]] from `From2` to `To`
+    *
+    * @since 2.0.0
+    */
+  final def contramapPartial[From2](f: From2 => partial.Result[From]): PartialTransformer[From2, To] =
+    (src: From2, failFast: Boolean) => f(src).flatMap(from => transform(from, failFast))
 }
 
 /** Companion of [[io.scalaland.chimney.PartialTransformer]].

--- a/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/Transformer.scala
@@ -36,6 +36,52 @@ trait Transformer[From, To] {
     * @since 0.1.0
     */
   def transform(src: From): To
+
+  /** Creates a new [[io.scalaland.chimney.Transformer]] by applying a pure function to the result of this
+    * transformation.
+    *
+    * {{{
+    *   val stringLength: Transformer[String, Int] = _.length
+    *
+    *   case class Length(length: Int)
+    *
+    *   implicit val toLength: Transformer[String, Length] = stringLength.map(Length(_))
+    * }}}
+    *
+    * @tparam To2
+    *   type of the mapped output value
+    * @param f
+    *   a pure function that maps `To` to `To2`
+    * @return
+    *   new [[io.scalaland.chimney.Transformer]] from `From` to `To2`
+    *
+    * @since 2.0.0
+    */
+  final def map[To2](f: To => To2): Transformer[From, To2] =
+    (src: From) => f(transform(src))
+
+  /** Creates a new [[io.scalaland.chimney.Transformer]] by applying a pure function to the source before this
+    * transformation.
+    *
+    * {{{
+    *   val stringLength: Transformer[String, Int] = _.length
+    *
+    *   case class Id(id: String)
+    *
+    *   implicit val idLength: Transformer[Id, Int] = stringLength.contramap(_.id)
+    * }}}
+    *
+    * @tparam From2
+    *   type of the new input value
+    * @param f
+    *   a pure function that maps `From2` to `From`
+    * @return
+    *   new [[io.scalaland.chimney.Transformer]] from `From2` to `To`
+    *
+    * @since 2.0.0
+    */
+  final def contramap[From2](f: From2 => From): Transformer[From2, To] =
+    (src: From2) => transform(f(src))
 }
 
 /** Companion of [[io.scalaland.chimney.Transformer]].

--- a/chimney/src/test/scala/io/scalaland/chimney/CodecSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/CodecSpec.scala
@@ -1,0 +1,32 @@
+package io.scalaland.chimney
+
+class CodecSpec extends ChimneySpec {
+
+  // Domain <-> Dto: encode is total, decode validates (partial)
+  private val intStringCodec: Codec[Int, String] = Codec(
+    encode = (i: Int) => i.toString,
+    decode = PartialTransformer[String, Int](str => partial.Result.fromCatching(str.toInt))
+  )
+
+  test("imapDomain") {
+    case class Id(value: Int)
+
+    val idCodec: Codec[Id, String] = intStringCodec.imapDomain(Id(_))(_.value)
+
+    idCodec.encode.transform(Id(42)) ==> "42"
+    idCodec.decode.transform("42") ==> partial.Result.fromValue(Id(42))
+    idCodec.decode.transform("abc").asErrorPathMessageStrings ==> Iterable(("", """For input string: "abc""""))
+  }
+
+  test("imapDto") {
+    case class Wrapper(raw: String)
+
+    val wrappedCodec: Codec[Int, Wrapper] = intStringCodec.imapDto(Wrapper(_))(_.raw)
+
+    wrappedCodec.encode.transform(42) ==> Wrapper("42")
+    wrappedCodec.decode.transform(Wrapper("42")) ==> partial.Result.fromValue(42)
+    wrappedCodec.decode.transform(Wrapper("abc")).asErrorPathMessageStrings ==> Iterable(
+      ("", """For input string: "abc"""")
+    )
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/IsoSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IsoSpec.scala
@@ -1,0 +1,27 @@
+package io.scalaland.chimney
+
+class IsoSpec extends ChimneySpec {
+
+  case class Celsius(value: Int)
+  case class Kelvin(value: Int)
+
+  // First <-> Second, both directions total
+  private val celsiusKelvin: Iso[Celsius, Kelvin] =
+    Iso((c: Celsius) => Kelvin(c.value + 273), (k: Kelvin) => Celsius(k.value - 273))
+
+  test("imapFirst") {
+    // rebase the First side onto a raw Int
+    val intKelvin: Iso[Int, Kelvin] = celsiusKelvin.imapFirst(_.value)(Celsius(_))
+
+    intKelvin.first.transform(0) ==> Kelvin(273)
+    intKelvin.second.transform(Kelvin(273)) ==> 0
+  }
+
+  test("imapSecond") {
+    // rebase the Second side onto a raw Int
+    val celsiusInt: Iso[Celsius, Int] = celsiusKelvin.imapSecond(_.value)(Kelvin(_))
+
+    celsiusInt.first.transform(Celsius(0)) ==> 273
+    celsiusInt.second.transform(273) ==> Celsius(0)
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerSpec.scala
@@ -73,4 +73,59 @@ class PartialTransformerSpec extends ChimneySpec {
       // no second error due to fail fast mode
     )
   }
+
+  test("map") {
+    val toNextInt = pt1.map(_ + 1)
+
+    toNextInt.transform("100") ==> partial.Result.fromValue(101)
+    // the mapping runs only on the successful result, errors are propagated untouched
+    toNextInt.transform("abc").asErrorPathMessageStrings ==> Iterable(("", """For input string: "abc""""))
+  }
+
+  test("mapPartial") {
+    val toPositive = pt1.mapPartial { i =>
+      if (i > 0) partial.Result.fromValue(i) else partial.Result.fromErrorString("must be positive")
+    }
+
+    toPositive.transform("100") ==> partial.Result.fromValue(100)
+    // the mapping itself may fail
+    toPositive.transform("-5").asErrorPathMessageStrings ==> Iterable(("", "must be positive"))
+    // an error from the original transformation short-circuits the mapping
+    toPositive.transform("abc").asErrorPathMessageStrings ==> Iterable(("", """For input string: "abc""""))
+  }
+
+  test("contramap") {
+    case class Raw(raw: String)
+
+    val rawToInt = pt1.contramap[Raw](_.raw)
+
+    rawToInt.transform(Raw("100")) ==> partial.Result.fromValue(100)
+    rawToInt.transform(Raw("abc")).asErrorPathMessageStrings ==> Iterable(("", """For input string: "abc""""))
+  }
+
+  test("contramapPartial") {
+    val trimmedToInt = pt1.contramapPartial[String] { str =>
+      val trimmed = str.trim
+      if (trimmed.nonEmpty) partial.Result.fromValue(trimmed) else partial.Result.fromErrorString("blank input")
+    }
+
+    trimmedToInt.transform("  100  ") ==> partial.Result.fromValue(100)
+    // the preprocessing itself may fail, short-circuiting the original transformation
+    trimmedToInt.transform("   ").asErrorPathMessageStrings ==> Iterable(("", "blank input"))
+    // a successful preprocessing still delegates errors to the original transformation
+    trimmedToInt.transform("abc").asErrorPathMessageStrings ==> Iterable(("", """For input string: "abc""""))
+  }
+
+  test("combinators preserve fail-fast mode") {
+    // pt4 accumulates two errors in the default mode
+    val derivedContramap = pt4.contramap[FooStr](identity)
+    derivedContramap.transform(FooStr("abc", "xyz")).asErrorPathMessageStrings ==> Iterable(
+      ("s1", """For input string: "abc""""),
+      ("s2", """For input string: "xyz"""")
+    )
+    // ...but stops at the first error in fail-fast mode, proving the flag is threaded through
+    derivedContramap.transformFailFast(FooStr("abc", "xyz")).asErrorPathMessageStrings ==> Iterable(
+      ("s1", """For input string: "abc"""")
+    )
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerSpec.scala
@@ -1,0 +1,41 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+
+class TotalTransformerSpec extends ChimneySpec {
+
+  // SAM syntax still works after adding the combinators (single abstract method preserved)
+  private val stringLength: Transformer[String, Int] = _.length
+
+  test("map") {
+    case class Length(length: Int)
+
+    val toLength: Transformer[String, Length] = stringLength.map(Length(_))
+
+    toLength.transform("test") ==> Length(4)
+
+    // the produced instance is usable as an implicit for derivation
+    implicit val t: Transformer[String, Length] = toLength
+    "test".into[Length].transform ==> Length(4)
+  }
+
+  test("contramap") {
+    case class Id(id: String)
+
+    val idLength: Transformer[Id, Int] = stringLength.contramap(_.id)
+
+    idLength.transform(Id("test")) ==> 4
+
+    implicit val t: Transformer[Id, Int] = idLength
+    Id("test").into[Int].transform ==> 4
+  }
+
+  test("map and contramap compose") {
+    case class Id(id: String)
+    case class Length(length: Int)
+
+    val idToLength: Transformer[Id, Length] = stringLength.contramap[Id](_.id).map(Length(_))
+
+    idToLength.transform(Id("hello")) ==> Length(5)
+  }
+}

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -1157,6 +1157,118 @@ or `Codec` (for bidirectional conversion which always succeeds in one way, but m
 Both `Iso` and `Codec` are only available through semiautomatic derivation. Currently, they only provide
 `withFieldRenamed` value override and flags overrides. 
 
+## Adapting existing type class instances
+
+Sometimes you already have a `Transformer`, `PartialTransformer`, `Iso` or `Codec` and you only need to tweak its
+input or output type, without deriving a brand new instance. Every one of these type classes provides combinators for
+exactly that, so you can reuse an existing instance instead of paying for another derivation.
+
+`Transformer` can adapt its output with `map` and its input with `contramap`:
+
+!!! example "Adapting a `Transformer`"
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
+    import io.scalaland.chimney.Transformer
+    import io.scalaland.chimney.dsl._
+
+    val stringLength: Transformer[String, Int] = _.length
+
+    case class Id(id: String)
+    case class Length(length: Int)
+
+    // contramap adapts the input side, map adapts the output side
+    implicit val idLength: Transformer[Id, Length] =
+      stringLength.contramap[Id](_.id).map(Length(_))
+
+    pprint.pprintln(Id("test").transformInto[Length])
+    // expected output:
+    // Length(length = 4)
+    ```
+
+`PartialTransformer` adds partial variants - `mapPartial` and `contramapPartial` - for when the adaptation itself can
+fail:
+
+!!! example "Adapting a `PartialTransformer`"
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
+    import io.scalaland.chimney.PartialTransformer
+    import io.scalaland.chimney.partial.Result
+
+    val parseInt: PartialTransformer[String, Int] =
+      PartialTransformer[String, Int](str => Result.fromCatching(str.toInt))
+
+    val parsePositive: PartialTransformer[String, Int] =
+      parseInt.mapPartial { i =>
+        if (i > 0) Result.fromValue(i)
+        else Result.fromErrorString("must be positive")
+      }
+
+    pprint.pprintln(parsePositive.transform("10").asOption)
+    pprint.pprintln(parsePositive.transform("-1").asOption)
+    pprint.pprintln(parsePositive.transform("oops").asOption)
+    // expected output:
+    // Some(value = 10)
+    // None
+    // None
+    ```
+
+`Iso` and `Codec` are bidirectional, so their combinators are invariant - they take a pair of functions (there and
+back). `Iso` uses `imapFirst`/`imapSecond` and `Codec` uses `imapDomain`/`imapDto`:
+
+!!! example "Adapting an `Iso`"
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
+    import io.scalaland.chimney.Iso
+
+    case class Celsius(value: Int)
+    case class Kelvin(value: Int)
+
+    val celsiusKelvin: Iso[Celsius, Kelvin] =
+      Iso((c: Celsius) => Kelvin(c.value + 273), (k: Kelvin) => Celsius(k.value - 273))
+
+    // rebase the First side onto a raw Int using a bijection
+    val intKelvin: Iso[Int, Kelvin] = celsiusKelvin.imapFirst(_.value)(Celsius(_))
+
+    pprint.pprintln(intKelvin.first.transform(0))
+    pprint.pprintln(intKelvin.second.transform(Kelvin(300)))
+    // expected output:
+    // Kelvin(value = 273)
+    // 27
+    ```
+
+!!! example "Adapting a `Codec`"
+
+    ```scala
+    //> using dep io.scalaland::chimney::{{ chimney_version() }}
+    //> using dep com.lihaoyi::pprint::{{ libraries.pprint }}
+    import io.scalaland.chimney.{Codec, PartialTransformer}
+    import io.scalaland.chimney.partial.Result
+
+    val intStringCodec: Codec[Int, String] = Codec(
+      (i: Int) => i.toString,
+      PartialTransformer[String, Int](str => Result.fromCatching(str.toInt))
+    )
+
+    case class Id(value: Int)
+
+    // rebase the Domain side onto Id using a bijection
+    val idCodec: Codec[Id, String] = intStringCodec.imapDomain(Id(_))(_.value)
+
+    pprint.pprintln(idCodec.encode.transform(Id(42)))
+    pprint.pprintln(idCodec.decode.transform("42").asOption)
+    pprint.pprintln(idCodec.decode.transform("bad").asOption)
+    // expected output:
+    // "42"
+    // Some(value = Id(value = 42))
+    // None
+    ```
+
 ## Java collections' integration
 
 Since `2.0.0` Java's types are supported out of the box on the JVM - no extra dependency, no import


### PR DESCRIPTION
Re-lands #591 (by @danicheg) on top of the current 2.0.0 backend and completes it per the review feedback there. @danicheg is the commit author; I co-authored the completion.

Closes #591. Resolves the feature request behind it.

## What's added

Combinators are plain `final def`s directly on the type classes (the dedicated `*Ops` trait from the original review is no longer needed now that the trait hierarchy has been flattened; `@FunctionalInterface`/SAM syntax stays intact):

| Type class | Combinators |
|---|---|
| `Transformer[From, To]` | `map(To => To2)`, `contramap(From2 => From)` |
| `PartialTransformer[From, To]` | `map`, `mapPartial(To => Result[To2])`, `contramap`, `contramapPartial(From2 => Result[From])` |
| `Iso[First, Second]` (invariant) | `imapFirst(f)(g)`, `imapSecond(f)(g)` |
| `Codec[Domain, Dto]` (invariant) | `imapDomain(f)(g)`, `imapDto(f)(g)` |

### Design notes (addressing the #591 review)
- **Full symmetry / parity:** both `Transformer` and `PartialTransformer` get `map` *and* `contramap`; `PartialTransformer` additionally gets the partial variants `mapPartial` / `contramapPartial` (input- and output-side).
- **All applicable type classes:** `Iso` and `Codec` are bidirectional, so they get *invariant* `imap*` combinators taking a there-and-back pair `(f)(g)` (cats-style ordering: `f` forward, `g` backward). They're implemented in terms of the `Transformer`/`PartialTransformer` combinators.
- **`failFast` is threaded through** the `PartialTransformer` combinators (test `combinators preserve fail-fast mode` proves it).
- `Patcher` is intentionally excluded — map/contramap doesn't map onto patching semantics.

## Tests
- `TotalTransformerSpec`, `PartialTransformerSpec` (extended), `CodecSpec`, `IsoSpec` — one case per combinator, incl. error-propagation and fail-fast.
- Green on Scala 2.13 and Scala 3.

## Docs
- New cookbook section **"Adapting existing type class instances"** with four runnable examples, all verified through the `scala-cli-md-spec` snippet harness.

## Verification
- `chimney`/`chimney3` `testOnly` for the four specs: 15 passing each.
- `scalafmtCheckAll` clean.
- MiMa: `2.0.0-development` has empty `mimaPreviousArtifacts` (major-version reset), so nothing to check; all additions are source- and binary-additive regardless.

Note on scope: this was rebuilt fresh rather than `git rebase`d — #591's branch is 471 commits behind and predates the Hearth backend migration (#903), so a literal rebase was not viable.