### PR TITLE
Fix #707, #718, #765: sealed-hierarchy, nested-rename and error-message derivation bugs

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/datatypes/SealedHierarchies.scala
@@ -73,6 +73,16 @@ private[compiletime] trait SealedHierarchies { this: ChimneyDefinitions & hearth
         if (acc.exists { case (n, c) => n == name && c.Underlying =:= child.Underlying }) acc
         else acc :+ subtype
       }
+      // GADT narrowing: for a concretely-applied sealed type (e.g. `Expr[Int]`) we drop subtypes that cannot conform
+      // (e.g. `BoolLit extends Expr[Boolean]`). But when `A`'s type arguments are abstract (e.g. a generic sealed
+      // hierarchy `Foo[A]` whose leaves are `Bar extends Foo[String]`), NONE of the concrete-argument leaves conform
+      // to `Foo[A]`, yet all of them are reachable at runtime - so we must keep them all, otherwise the subtype list
+      // collapses to empty and derivation crashes (see #707).
+      // A leaf is filtered out only when the parent is CONCRETELY applied; a type argument that is a free type
+      // variable (a type parameter - not abstract in Hearth's class/trait sense, and not a class) means no
+      // concrete-argument leaf can conform, so we must keep them all.
+      val hasAbstractTypeArguments =
+        UntypedType.typeArguments(UntypedType.fromTyped[A]).exists(arg => arg.isAbstract || !arg.isClass)
       Some(
         SealedEnum(
           deduplicated.toList
@@ -82,8 +92,9 @@ private[compiletime] trait SealedHierarchies { this: ChimneyDefinitions & hearth
                 SealedEnum.Element[A, Subtype](name = name, upcast = (expr: Expr[Subtype]) => expr.upcast[A])
               )
             }
-            // with GADT we can have subtypes that shouldn't appear in pattern matching
-            .filter(_.Underlying <:< Type[A])
+            // with GADT we can have subtypes that shouldn't appear in pattern matching - but only filter by
+            // conformance when `A` is concretely applied (see comment above).
+            .filter(subtype => hasAbstractTypeArguments || subtype.Underlying <:< Type[A])
         )
       )
     }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -516,6 +516,15 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
       case TransformerOverride.Renamed(sourcePath, _) =>
         extractSrcByPath(FromOperation.Renamed, sourcePath, toName).flatMap { extractedSrc =>
           import extractedSrc.Underlying as ExtractedSrc, extractedSrc.value as extractedSrcExpr
+          // `sourcePath` is absolute (rooted at the whole transformation's source), but
+          // `deriveRecursiveTransformationExpr` expects a *relative* follow-path - it is concatenated onto the
+          // current journal position (`newSrcPath = last.concat(followFrom)`) and used to strip relative sided
+          // override paths. Every other caller passes a relative path (e.g. `Path(_.select(fromName))`); passing
+          // the absolute `sourcePath` here double-counts the current prefix, producing journal paths like
+          // `_.field.everyItem.field.everyItem.fieldA` that no longer line up with the override's own source path
+          // and break lookup for deeper nested renames (#718). Relativize against the current source position;
+          // for a top-level rename `ctx.currentSrc` is `Root`, so this is a no-op there.
+          val relativeSourcePath = sourcePath.drop(ctx.currentSrc).getOrElse(sourcePath)
           Log.namedScope(s"Recursive derivation for renamed field `$sourcePath` -> `$toName`") {
             // $COVERAGE-OFF$scope detail is only built when Info logging is rendered (off by default, incl. in tests)
             Log.info(
@@ -527,7 +536,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
               // '{ ${ derivedToElement } } // using ${ src.$name }
               deriveRecursiveTransformationExpr[ExtractedSrc, CtorParam](
                 extractedSrcExpr,
-                sourcePath,
+                relativeSourcePath,
                 Path(_.select(toName)),
                 findMatchingUpdateCandidates(toName)
               )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformProductToProductRuleModule.scala
@@ -239,7 +239,7 @@ private[compiletime] trait TransformProductToProductRuleModule { this: Derivatio
                           case TransformerOverride.ComputedPartial(_, _, _, _) =>
                             s".withFieldComputedPartial(_.$anotherToName, ...)"
                           case TransformerOverride.Renamed(sourcePath, _) =>
-                            s".withFieldRenamed($sourcePath, _.$anotherToName})"
+                            s".withFieldRenamed($sourcePath, _.$anotherToName)"
                         }
                     }
                     .toList

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -746,7 +746,7 @@ class IssuesSpec extends ChimneySpec {
     ).check(
       "Chimney can't derive transformation from io.scalaland.chimney.IssuesSpec.Proto to io.scalaland.chimney.IssuesSpec.Domain",
       "io.scalaland.chimney.IssuesSpec.Domain",
-      "  field something: io.scalaland.chimney.IssuesSpec.Domain could not resolve overrides since the current BeanAware: TransformedNamedComparison treats the following overrides as the same: .withFieldRenamed(_.somethingDetail, _.isSomething}), .withFieldRenamed(_.somethingDetail, _.something}) making it ambiguous - change the field name comparator with .enableCustomFieldNameComparison to resolve the ambiguity",
+      "  field something: io.scalaland.chimney.IssuesSpec.Domain could not resolve overrides since the current BeanAware: TransformedNamedComparison treats the following overrides as the same: .withFieldRenamed(_.somethingDetail, _.isSomething), .withFieldRenamed(_.somethingDetail, _.something) making it ambiguous - change the field name comparator with .enableCustomFieldNameComparison to resolve the ambiguity",
       "Consult https://chimney.readthedocs.io for usage examples."
     )
 

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -914,4 +914,22 @@ class IssuesSpec extends ChimneySpec {
         Some(None)
     }
   }
+
+  test("fix issue #707 (generic sealed hierarchy into non-generic one)") {
+    import Issue707.*
+
+    // A generic sealed source `DomainModel[A]` used to lose all of its subtypes (none conform to the abstract
+    // `DomainModel[A]`), producing an empty match that crashed derivation / threw a MatchError at runtime.
+    implicit def domainToApi[A]: Transformer[DomainModel[A], ApiModel] = Transformer.derive
+
+    (DomainModel.Foo: DomainModel[String]).transformInto[ApiModel] ==> ApiModel.Foo
+    (DomainModel.Bar: DomainModel[String]).transformInto[ApiModel] ==> ApiModel.Bar
+
+    // The same must hold for a recursive generic hierarchy.
+    implicit def domainTreeToApi[A]: Transformer[DomainTree[A], ApiTree] = Transformer.derive
+
+    (DomainTree.Leaf: DomainTree[String]).transformInto[ApiTree] ==> ApiTree.Leaf
+    (DomainTree.Node(DomainTree.Node(DomainTree.Leaf)): DomainTree[String])
+      .transformInto[ApiTree] ==> ApiTree.Node(ApiTree.Node(ApiTree.Leaf))
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -932,4 +932,18 @@ class IssuesSpec extends ChimneySpec {
     (DomainTree.Node(DomainTree.Node(DomainTree.Leaf)): DomainTree[String])
       .transformInto[ApiTree] ==> ApiTree.Node(ApiTree.Node(ApiTree.Leaf))
   }
+
+  test("fix issue #718 (rename ending with everyItem/matchingSome)") {
+    import Issue718.*
+
+    val transformer = Transformer
+      .define[A, B]
+      .withFieldRenamed(_.field.everyItem.fieldA, _.field.everyItem.fieldB)
+      .withFieldRenamed(_.field.everyItem.fieldA.matchingSome.fieldA_A, _.field.everyItem.fieldB.matchingSome.fieldB_B)
+      .buildTransformer
+
+    transformer.transform(A(List(A_inner(Some(A_inner_inner("value")))))) ==>
+      B(List(B_inner(Some(B_inner_inner("value")))))
+    transformer.transform(A(List(A_inner(None)))) ==> B(List(B_inner(None)))
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -253,3 +253,32 @@ object Issue741 {
   case class GItem(id: String, data: String)
   case class GItemOptional(entry: Option[GItem])
 }
+
+object Issue707 {
+  // A GENERIC sealed hierarchy whose leaves fix the type parameter to a concrete type.
+  sealed trait DomainModel[A]
+  object DomainModel {
+    case object Foo extends DomainModel[String]
+    case object Bar extends DomainModel[String]
+  }
+
+  // ...transformed into a NON-generic sealed hierarchy.
+  sealed trait ApiModel
+  object ApiModel {
+    case object Foo extends ApiModel
+    case object Bar extends ApiModel
+  }
+
+  // The same, but recursive (the shape from the original report).
+  sealed trait DomainTree[A]
+  object DomainTree {
+    case class Node[A](inner: DomainTree[A]) extends DomainTree[A]
+    case object Leaf extends DomainTree[String]
+  }
+
+  sealed trait ApiTree
+  object ApiTree {
+    case class Node(inner: ApiTree) extends ApiTree
+    case object Leaf extends ApiTree
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -254,6 +254,16 @@ object Issue741 {
   case class GItemOptional(entry: Option[GItem])
 }
 
+object Issue718 {
+  case class A_inner_inner(fieldA_A: String)
+  case class A_inner(fieldA: Option[A_inner_inner])
+  case class A(field: List[A_inner])
+
+  case class B_inner_inner(fieldB_B: String)
+  case class B_inner(fieldB: Option[B_inner_inner])
+  case class B(field: List[B_inner])
+}
+
 object Issue707 {
   // A GENERIC sealed hierarchy whose leaves fix the type parameter to a concrete type.
   sealed trait DomainModel[A]


### PR DESCRIPTION
Fixes three long-standing derivation bugs against `2.0.0-development`. Each commit is self-contained with a regression test in `IssuesSpec` (cross-compiled on Scala 2.13 + 3).

## #707 — generic sealed hierarchy into a non-generic one

A generic sealed source such as `DomainModel[A]` (whose leaves fix the type parameter, e.g. `case object Foo extends DomainModel[String]`) used to lose all of its subtypes: none conform to the abstract `DomainModel[A]`, so the subtype list came out empty, producing a match that crashed derivation / threw a `MatchError` at runtime.

Hearth's `isAbstract` returns `false` for a type-parameter reference (`TypeRef(NoPrefix, type A)`), so the subtype-conformance filter is now also skipped when the parent's type arguments are abstract **or** not classes (`!arg.isClass`). Covers the recursive-hierarchy shape from the original report too.

## #765 — stray `}` in the ambiguous-override suggestion message

The error message suggesting `.withFieldRenamed(...)` for an ambiguous override rendered a dangling `}` (`_.anotherToName})`). Dropped it.

## #718 — nested rename ending in `everyItem`/`matchingSome`/etc.

A nested `withFieldRenamed` whose source path ends past a plain field — e.g.

```scala
Transformer.define[A, B]
  .withFieldRenamed(_.field.everyItem.fieldA, _.field.everyItem.fieldB)
  .withFieldRenamed(_.field.everyItem.fieldA.matchingSome.fieldA_A, _.field.everyItem.fieldB.matchingSome.fieldB_B)
  .buildTransformer
```

failed to compile even though the error message listed that exact path as a valid choice (note the tell-tale doubled `field.everyItem.field.everyItem` in the logs).

Root cause: the `Renamed` override handler passed the **absolute** source path to `deriveRecursiveTransformationExpr`, whose `followFrom` parameter is **relative** — it is concatenated onto the current journal position (`newSrcPath = last.concat(followFrom)`) and used to strip relative sided override paths. Every other caller passes a relative path (e.g. `Path(_.select(fromName))`). Passing the absolute path double-counted the current prefix, producing journal entries like `_.field.everyItem.field.everyItem.fieldA` that no longer lined up with the override's own source path; the lookup then fell back to a shallower journal entry and hit a not-yet-narrowed `Option`/subtype segment under `extractNestedSource`'s catch-all `case path =>`.

The fix relativizes the source path against the current source position (`sourcePath.drop(ctx.currentSrc)`), keeping journal paths correctly rooted so the deep source is reached as the already-unwrapped value — fully total, no unsafe cast, and `extractNestedSource` is left untouched (so the `colors2` sealed-subtype case that broke the earlier cast-based attempt is unaffected). Top-level renames are unchanged (`ctx.currentSrc` is `Root` there).

## Testing

- New regression tests for all three issues in `IssuesSpec`.
- Full suites green locally: **Scala 3 → 1127 passed, Scala 2.13 → 989 passed, 0 failures**, including both sealed-hierarchy specs and the product/rename/override suites.
