### PR TITLE
Bump hearth to 0.4.0-55-g60be58f: verify #673 and #625 are fixed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val versions = new {
   // !!! It MUST be replaced by a proper hearth RELEASE (and the snapshots resolver removed again)
   // !!! BEFORE merging PR #903. Do NOT release/merge with a -SNAPSHOT hearth dependency.
   // !!! -----------------------------------------------------------------------------------------------------------
-  val hearth = "0.4.0-52-gaaf7e1a-SNAPSHOT"
+  val hearth = "0.4.0-55-g60be58f-SNAPSHOT"
   val cats = "2.13.0"
   // Latest published kindlings (its 0.3.0 depends on hearth 0.4.0, same as us; publishes JVM/JS/Native x 2.13/3).
   // TODO(kindlings-release): snapshot carrying kubuszok/kindlings#163 (NonEmptySeq/NonEmptyLazyList IsCollection

--- a/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/IssuesScala3Spec.scala
@@ -5,6 +5,14 @@ import scala.annotation.unused
 
 class IssuesScala3Spec extends ChimneySpec {
 
+  test("fix issue #625 (correct case picked for simple lowercase enum transformation)") {
+    import io.scalaland.chimney.fixtures.Issue625.*
+
+    Enum1.solo.transformInto[Enum2] ==> Enum2.solo
+    Enum1.team.transformInto[Enum2] ==> Enum2.team
+    Enum1.school.transformInto[Enum2] ==> Enum2.school
+  }
+
   test("fix issue #592 (givens in companion)") {
     case class Foo(a: Int, b: String)
     case class Bar(a: Int, b: String)

--- a/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/Issue.scala
+++ b/chimney/src/test/scala-3/io/scalaland/chimney/fixtures/Issue.scala
@@ -35,6 +35,19 @@ object Issue857 {
   }
 }
 
+object Issue625 {
+  // Lowercase, parameterless enum cases: the wrong case used to be picked (everything collapsed onto the first
+  // case, `solo`) because the generated `matchOn` reference was a bare lowercase `Ident` that dotty reinterpreted
+  // as a catch-all pattern variable (scala/scala3#20350).
+  enum Enum1 {
+    case solo, team, school
+  }
+
+  enum Enum2 {
+    case solo, team, school
+  }
+}
+
 object Issue835 {
   abstract class StatusEntity(val status: String)
 

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -946,4 +946,18 @@ class IssuesSpec extends ChimneySpec {
       B(List(B_inner(Some(B_inner_inner("value")))))
     transformer.transform(A(List(A_inner(None)))) ==> B(List(B_inner(None)))
   }
+
+  test("fix issue #673 (intersection-type source exposes members from all its parts)") {
+    import Issue673.*
+
+    val source: HasName with HasAge = new HasName with HasAge {
+      def name: String = "Alice"
+      def age: Int = 30
+    }
+
+    // Before the underlying Hearth fix, a value typed as `HasName with HasAge` (an `AndType` on Scala 3) exposed
+    // NONE of its parts' members, so neither `name` nor `age` was found. Now both are visible; as they are `def`s
+    // inherited from the traits, they are surfaced as method/inherited accessors.
+    source.into[Person].enableMethodAccessors.enableInheritedAccessors.transform ==> Person("Alice", 30)
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -254,6 +254,15 @@ object Issue741 {
   case class GItemOptional(entry: Option[GItem])
 }
 
+object Issue673 {
+  // A value typed as an intersection `HasName with HasAge` used to expose NONE of the members declared by its
+  // parts on Scala 3 (the AndType's `typeSymbol` is `NoSymbol`), so derivation could not see `name`/`age`.
+  trait HasName { def name: String }
+  trait HasAge { def age: Int }
+
+  case class Person(name: String, age: Int)
+}
+
 object Issue718 {
   case class A_inner_inner(fieldA_A: String)
   case class A_inner(fieldA: Option[A_inner_inner])


### PR DESCRIPTION
Two Chimney bugs reported against Scala 3 turned out to live in the macro backend that Hearth inherited from `chimney-macro-commons`, not in Chimney's own derivation. Both are now fixed upstream (hearth `60be58f`); this PR bumps the pin to `0.4.0-55-g60be58f-SNAPSHOT` and adds Chimney-level regression tests confirming the fixes against `2.0.0-development`.

## #625 — wrong case picked for a simple lowercase enum transformation

```scala
enum Enum1 { case solo, team, school }
enum Enum2 { case solo, team, school }

Enum1.school.transformInto[Enum2] // used to return Enum2.solo
```

Every case collapsed onto the first (`solo`) because the generated `matchOn` reference was a bare lowercase `Ident`, which dotty reinterprets as a catch-all pattern variable (scala/scala3#20350). Hearth now emits a singleton type test. Scala-3-only (enums); test lives in `IssuesScala3Spec`.

## #673 — `TypeName & TypeName` / intersection-type source failed derivation

A value typed as an intersection (e.g. `HasName with HasAge`, an `AndType` on Scala 3) exposed **none** of the members declared by its parts, so derivation failed with `no accessor named ...` even though the members existed. Hearth's method/base-class listing read members off the `AndType`'s `typeSymbol`, which is `NoSymbol`; it now unions the members of the parts. Cross-compiled test in `IssuesSpec` (Scala 2 already worked via refinement-type members, so it also guards 2.13).

## Verification

Each test was confirmed **red on the previous pin** (`-52`) and **green on the new pin** (`-55`):

- #673 — previously both accessors invisible (`no accessor named name/age`); now derives correctly.
- #625 — previously picked `solo` at runtime for every case; now dispatches correctly.

Full suites green locally on the new pin: **Scala 3 → 1141 passed, Scala 2.13 → 1002 passed, 0 failures.**

## Note on #899

The third reproduction from the same batch (Chimney #899 — `CyclicReference` when reflecting an enclosing mid-inference `val`) was investigated upstream and is **not** fixable at the Hearth layer this way (the macro never forces the member's signature, so no catchable exception reaches Hearth; the cycle is raised by the compiler's own namer). It remains open.

## Snapshot caveat

This keeps the temporary `-SNAPSHOT` hearth pin (the existing LOUD WARNING in `build.sbt` still applies) — to be replaced by a proper hearth release before the 2.0.0 line ships, same as the current state of `2.0.0-development`.
