### PR TITLE
Add regression tests for #739, #899, #720 (already fixed on 2.0.0)

### DIFF
--- a/chimney/src/test/java/io/scalaland/chimney/javafixtures/jissue720/Side.java
+++ b/chimney/src/test/java/io/scalaland/chimney/javafixtures/jissue720/Side.java
@@ -1,0 +1,21 @@
+package io.scalaland.chimney.javafixtures.jissue720;
+
+// #720: a Java enum declared WITH utility methods - javac emits an abstract enum class with per-constant
+// anonymous subclasses - used to crash Chimney's Scala 3 derivation with
+// `expected a term symbol, but received class Side`.
+public enum Side {
+    LEFT {
+        @Override
+        public boolean isLeft() {
+            return true;
+        }
+    },
+    RIGHT {
+        @Override
+        public boolean isLeft() {
+            return false;
+        }
+    };
+
+    public abstract boolean isLeft();
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -980,4 +980,24 @@ class IssuesSpec extends ChimneySpec {
       )
       .transform ==> UserDAO(userId, createdAt)
   }
+
+  test("fix issue #739 (transformation from Tuple10 and onwards)") {
+    import Issue739.*
+
+    val t10: Tuple10[String, String, String, String, String, String, String, String, String, String] =
+      ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+    t10.transformInto[Order10] ==> Order10("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+
+    val t22 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
+    t22.transformInto[Order22] ==>
+      Order22(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
+  }
+
+  test("fix issue #899 (case class member computed as `this.transformInto[B]`)") {
+    import Issue899.*
+
+    // The reproduction is that `Issue899` compiles at all (it used to crash Scala 2.13 derivation with a
+    // CyclicReference); this asserts the derived value for good measure.
+    A().foo ==> B()
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -301,3 +301,66 @@ object Issue707 {
     case object Leaf extends ApiTree
   }
 }
+
+object Issue720 {
+  // Cross-Scala target (sealed hierarchy of case objects) for the method-bearing Java enum in
+  // javafixtures/jissue720/Side.java.
+  sealed trait ScalaSide extends Product with Serializable
+  object ScalaSide {
+    case object LEFT extends ScalaSide
+    case object RIGHT extends ScalaSide
+  }
+}
+
+object Issue739 {
+  // Transforming from Tuple10 and onwards (by position) used to fail to derive.
+  case class Order10(
+      f1: String,
+      f2: String,
+      f3: String,
+      f4: String,
+      f5: String,
+      f6: String,
+      f7: String,
+      f8: String,
+      f9: String,
+      f10: String
+  )
+
+  case class Order22(
+      f1: Int,
+      f2: Int,
+      f3: Int,
+      f4: Int,
+      f5: Int,
+      f6: Int,
+      f7: Int,
+      f8: Int,
+      f9: Int,
+      f10: Int,
+      f11: Int,
+      f12: Int,
+      f13: Int,
+      f14: Int,
+      f15: Int,
+      f16: Int,
+      f17: Int,
+      f18: Int,
+      f19: Int,
+      f20: Int,
+      f21: Int,
+      f22: Int
+  )
+}
+
+object Issue899 {
+  import io.scalaland.chimney.dsl.*
+
+  // A case class member computed as `this.transformInto[B]` (NO explicit type) used to crash the Scala 2.13
+  // derivation with `CyclicReference: illegal cyclic reference involving value foo`; it works on Scala 3. The
+  // regression check is that this object COMPILES on both.
+  case class A() {
+    val foo = this.transformInto[B]
+  }
+  case class B()
+}

--- a/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
+++ b/chimney/src/test/scalajvm/io/scalaland/chimney/TotalTransformerJavaEnumSpec.scala
@@ -9,6 +9,15 @@ import scala.annotation.{nowarn, unused}
 @nowarn("msg=unused import")
 class TotalTransformerJavaEnumSpec extends ChimneySpec {
 
+  test("fix issue #720 (Java enum declared with utility methods)") {
+    import io.scalaland.chimney.fixtures.Issue720.*
+
+    // A Java enum with per-constant method bodies (see javafixtures/jissue720/Side.java) used to crash Scala 3
+    // derivation with `expected a term symbol, but received class Side`.
+    (jissue720.Side.LEFT: jissue720.Side).transformInto[ScalaSide] ==> ScalaSide.LEFT
+    (jissue720.Side.RIGHT: jissue720.Side).transformInto[ScalaSide] ==> ScalaSide.RIGHT
+  }
+
   test(
     """transform from Java Enum "subset" instances to sealed hierarchy "superset" of case objects without modifiers"""
   ) {


### PR DESCRIPTION
Three bugs reported against 1.x are already resolved on the 2.0.0/Hearth line (`master`). This adds regression tests so they can't silently come back — merging this closes all three.

## Tests added

- **#739** — transformation from `Tuple10`..`Tuple22` (by position) into a case class. Cross-compiled (2.13 + 3). Fixture `Issue739` + test in `IssuesSpec`.
- **#899** — a case class member `val foo = this.transformInto[B]` (no explicit type) used to crash Scala 2.13 derivation with `CyclicReference: illegal cyclic reference involving value foo`; fixed via the **Hearth 0.4.1** bump. The `Issue899` fixture *compiling* is the regression check; cross-compiled, asserts the value too.
- **#720** — a Java enum declared with utility methods (javac emits an abstract enum class with per-constant subclasses) used to crash Scala 3 derivation with `expected a term symbol, but received class Side`. Adds the Java fixture `javafixtures/jissue720/Side.java` + `Issue720` Scala enum + test in `IssuesScala3Spec`.

## Verification

- #739 + #899: green on **Scala 2.13 and 3**.
- #720: green on **Scala 3** (Java-enum spec is JVM/Scala-3).

No production code changes — these are pure regression tests confirming the current behavior.

Fixes #739, fixes #899, fixes #720.
