### PR TITLE
Fix Sonatype Release: publish the 2.x line on JDK 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,10 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - uses: coursier/setup-action@v3.0.0
         with:
-          jvm: 'temurin:1.8.0-392'
+          # Chimney 2.x targets -release 17 (Scala 3) / -release 11 (Scala 2.13) and its Scala 3.8 compiler
+          # bridge is compiled for Java 17, so publishing must run on JDK 17+ (the old JDK 8 fails with
+          # UnsupportedClassVersionError). The -release flags keep the emitted artifacts JDK 11/17 compatible.
+          jvm: 'temurin:17'
           apps: sbt
       - name: Publish all projects
         run:  sbt ci-release


### PR DESCRIPTION
The "Sonatype Release" workflow started failing on `master` after it became the 2.x (Scala 3.8) line.

## Root cause
The workflow publishes on **JDK 8** (`temurin:1.8.0-392`). Chimney 2.x uses Scala 3.8, whose compiler bridge (`dotty/tools/xsbt/CompilerBridge`) is compiled for **Java 17** (class file version 61). On JDK 8 (class version 52) the publish run dies with:

```
java.lang.UnsupportedClassVersionError: dotty/tools/xsbt/CompilerBridge has been
compiled by a more recent version of the Java Runtime (class file version 61.0),
this version of the Java Runtime only recognizes class file versions up to 52.0
(chimney3 / Compile / compileIncremental)
```

The 1.x line (now `line-1.x`) is Scala 3.3 and still builds on JDK 8, which is why its releases pass.

## Fix
Bump the publish JVM to `temurin:17` — matching `ci.yml`, which already builds/tests the 2.x line on JDK 17+. The `-release 17` (Scala 3) / `-release 11` (Scala 2.13) scalac flags keep the emitted artifacts compatible with JDK 17 / 11 respectively, so the published bytecode target is unchanged.

## Heads-up — separate follow-up (needs a tag decision, not a workflow change)
The failed run also showed the snapshot version resolving to `1.11.0-64-g7d9880d-SNAPSHOT` — dynver derives it from the latest reachable tag (`1.11.0`), so `master` (2.x) currently publishes into the **1.11.x** snapshot namespace, colliding with `line-1.x`. That's fixed by tagging `master` with the intended 2.x milestone (e.g. `2.0.0-M4`), which is a maintainer call — not addressed here.
