### PR TITLE
Bump kindlings to 0.3.1 release; drop the snapshot resolver (last -SNAPSHOT gone)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,6 @@ val mavenCentralSnapshots = "Maven Central Snapshots" at "https://central.sonaty
 // TODO: remove this once we have a release of Scala 2.13.17
 Global / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
-// hearth itself is now on a release (0.4.1); this resolver remains only for the kindlingsCatsIntegration
-// -SNAPSHOT pinned below (see its note). TODO: REMOVE once kindlingsCatsIntegration is on a release too.
-Global / resolvers += mavenCentralSnapshots
-
 // Versions:
 
 val versions = new {
@@ -36,10 +32,9 @@ val versions = new {
   // Dependencies.
   val hearth = "0.4.1"
   val cats = "2.13.0"
-  // TODO(kindlings-release): snapshot carrying kubuszok/kindlings#163 (NonEmptySeq/NonEmptyLazyList IsCollection
-  // providers); it is the last -SNAPSHOT dependency. Return to a released kindlings (on hearth 0.4.1) before
-  // merging PR #903.
-  val kindlingsCatsIntegration = "0.3.0-24-gfc36d68-SNAPSHOT"
+  // kindlings 0.3.1 is the first release on hearth 0.4.1 and includes kubuszok/kindlings#163
+  // (NonEmptySeq/NonEmptyLazyList IsCollection providers).
+  val kindlingsCatsIntegration = "0.3.1"
   val kindProjector = "0.13.4"
   val munit = "1.3.4"
   val scalaCollectionCompat = "2.14.0"


### PR DESCRIPTION
`kindlings-cats-integration` **0.3.1** is now published — the first release built against **hearth 0.4.1**, and it carries kindlings#163 (the `NonEmptySeq`/`NonEmptyLazyList` `IsCollection` providers) that the snapshot pin was there for.

## Changes
- `kindlingsCatsIntegration`: `0.3.0-24-gfc36d68-SNAPSHOT` → `"0.3.1"`.
- **Removed the Maven Central Snapshots *resolver*** (`Global / resolvers += mavenCentralSnapshots`). With hearth on `0.4.1` and kindlings on `0.3.1`, there are **no more `-SNAPSHOT` dependencies**, so nothing needs the snapshots repo for resolution.
- Kept the `mavenCentralSnapshots` **val** — `publishTo` still uses it to publish Chimney's own snapshots.

This clears the last item of the hearth-migration TODO (the "no `-SNAPSHOT` before releasing" blocker).

## Verification
`chimneyCats` (which pulls kindlings) resolves cleanly **without** the snapshot resolver and its tests pass on both:
- Scala 3 → **312 passed, 0 failed**
- Scala 2.13 → **312 passed, 0 failed**
