### PR TITLE
Migrate build to sbt 2.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,11 @@ jobs:
       matrix:
         scala: ["2_13", "3"]
         platform: ["jvm", "js", "native"]
-        # Chimney 2.x JDK baselines: Scala 2.13 targets JDK 11+ (-release 11), Scala 3 targets JDK 17+ (-release 17) -
-        # each Scala version is tested on its minimum plus the latest LTS.
-        jvm: ['temurin:11', 'temurin:1.21.0.1']
-        exclude:
-          - scala: "3"
-            jvm: 'temurin:11'
-        include:
-          - { scala: "3", platform: "jvm", jvm: 'temurin:17' }
-          - { scala: "3", platform: "js", jvm: 'temurin:17' }
-          - { scala: "3", platform: "native", jvm: 'temurin:17' }
+        # sbt 2.x requires JDK 17+ to run, so JDK 17 is the floor for every job (the old Scala 2.13-on-JDK-11
+        # job is no longer possible - sbt itself won't start on 11). Emitted artifacts stay JDK-11 compatible
+        # for Scala 2.13 (-release 11) and JDK-17 for Scala 3 (-release 17) via the -release flags; each Scala
+        # version is also exercised on the latest LTS.
+        jvm: ['temurin:17', 'temurin:1.21.0.1']
       fail-fast: false
 
     steps:

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,3 @@
 -XX:-OmitStackTraceInFastThrow
 -XX:+UseG1GC
--Xmx2g
+-Xmx6g

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,11 @@ import scoverage.ScoverageKeys.coverageScalacPluginVersion
 lazy val isCI = sys.env.get("CI").contains("true")
 ThisBuild / scalafmtOnCompile := !isCI
 
+// sbt 2.x promotes dependency eviction conflicts to hard errors by default (sbt 1.x defaulted to a warning). One such
+// conflict is benign here: on Scala Native, cats-laws (Test) pulls scalacheck -> scala-native test-interface 0.5.8,
+// while chimney uses 0.5.12 - a compatible 0.5.x upgrade sbt resolves to 0.5.12. Restore the sbt 1.x warn level.
+ThisBuild / evictionErrorLevel := Level.Warn
+
 // Used to publish snapshots to Maven Central.
 val mavenCentralSnapshots = "Maven Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots"
 
@@ -15,69 +20,12 @@ val mavenCentralSnapshots = "Maven Central Snapshots" at "https://central.sonaty
 Global / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
 // Versions:
-
-val versions = new {
-  // Versions we are publishing for.
-  val scala213 = "2.13.18"
-  val scala3 = "3.8.4"
-  // For chimney-sandwich-test-cases-3 ONLY: sbt forbids Scala 2.13 subprojects from depending on Scala 3.8+
-  // subprojects (sbt-8728), and 2.13's -Ytasty-reader tops out below TASTy 28.8 - see the module for details.
-  val scala3Sandwich = "3.7.3"
-
-  // Which versions should be cross-compiled for publishing
-  val scalas = List(scala213, scala3)
-
-  val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
-
-  // Dependencies.
-  val hearth = "0.4.1"
-  val cats = "2.13.0"
-  // kindlings 0.3.1 is the first release on hearth 0.4.1 and includes kubuszok/kindlings#163
-  // (NonEmptySeq/NonEmptyLazyList IsCollection providers).
-  val kindlingsCatsIntegration = "0.3.1"
-  val kindProjector = "0.13.4"
-  val munit = "1.3.4"
-  val scalaCollectionCompat = "2.14.0"
-  val scalaJavaCompat = "1.0.2"
-  val scalaJavaTime = "2.7.0"
-  val scalapbRuntime = scalapb.compiler.Version.scalapbVersion
-
-  // Explicitly handle Scala 2.13 and Scala 3 separately.
-  def fold[A](scalaVersion: String)(for2_13: => Seq[A], for3: => Seq[A]): Seq[A] =
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, 13)) => for2_13
-      case Some((3, _))  => for3
-      case _             => Seq.empty // for sbt
-    }
-}
-
-// Development settings:
-
-val dev = new {
-
-  val props = scala.util
-    .Using(new java.io.FileInputStream("dev.properties")) { fis =>
-      val props = new java.util.Properties()
-      props.load(fis)
-      props
-    }
-    .get
-
-  // Which version should be used in IntelliJ
-  val ideScala = props.getProperty("ide.scala") match {
-    case "2.13" => versions.scala213
-    case "3"    => versions.scala3
-  }
-  val idePlatform = props.getProperty("ide.platform") match {
-    case "jvm"    => VirtualAxis.jvm
-    case "js"     => VirtualAxis.js
-    case "native" => VirtualAxis.native
-  }
-
-  def isIdeScala(scalaVersion: String): Boolean =
-    CrossVersion.partialVersion(scalaVersion) == CrossVersion.partialVersion(ideScala)
-  def isIdePlatform(platform: VirtualAxis): Boolean = platform == idePlatform
-}
+//
+// `versions` (publish/dependency versions + the `fold` helper) and `dev` (IDE dev settings) are defined as objects in
+// project/BuildVersions.scala. Under sbt 1.x they were `val ... = new { ... }` in build.sbt, but sbt 2.x compiles
+// build.sbt with Scala 3, which hides an anonymous object's members and does not bring build.sbt-local objects into
+// the settings scope - so they were moved to project/*.scala, where they are real objects on the meta-build classpath
+// and remain referenceable here unqualified (`versions.scala3`, `dev.idePlatform`, ...).
 
 // Common settings:
 
@@ -192,22 +140,25 @@ val settings = Seq(
     for2_13 = Seq.empty
   ),
   Compile / console / scalacOptions --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings", "-Werror"),
+  // NOTE: the empties are typed `Seq.empty[String]`. sbt 2.x caches setting values and needs a JsonFormat for the
+  // value type; untyped `Seq.empty` infers `Seq[Nothing]`, for which no JsonFormat exists (the fold's other call sites
+  // infer `Seq[String]` from their non-empty branch, so only this both-empty call needs the annotation).
   Test / compile / scalacOptions --= versions.fold(scalaVersion.value)(
-    for3 = Seq.empty,
-    for2_13 = Seq.empty
+    for3 = Seq.empty[String],
+    for2_13 = Seq.empty[String]
   ),
   coverageExcludedPackages := ".*DefCache.*" // DefCache is kind-a experimental utility
 )
 
 val dependencies = Seq(
   libraryDependencies ++= Seq(
-    "org.scalameta" %%% "munit" % versions.munit % Test
+    "org.scalameta" %% "munit" % versions.munit % Test
   ),
   libraryDependencies ++= versions.fold(scalaVersion.value)(
     for3 = Seq.empty,
     for2_13 = Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-      compilerPlugin("org.typelevel" % "kind-projector" % versions.kindProjector cross CrossVersion.full)
+      compilerPlugin(("org.typelevel" % "kind-projector" % versions.kindProjector).cross(CrossVersion.full))
     )
   )
 )
@@ -266,9 +217,17 @@ val mimaSettings = Seq(
 val noPublishSettings =
   Seq(publish / skip := true, publishArtifact := false)
 
+// NOTE: sbt 2.x's in-core projectMatrix flipped the cell-id suffix scheme vs sbt 1.x (sbt-projectmatrix). Under
+// sbt 1.x the Scala 2.13 cell was unsuffixed and Scala 3 was "3" (`chimney`, `chimney3`); under sbt 2.x the Scala 3
+// cell is unsuffixed and Scala 2.13 is "2_13" (`chimney`, `chimney2_13`). Platform still lives in the name (JS/Native).
+// These generated flat ids are the valid command-line references; the axis form `name@scalaBinaryVersion=3` also works
+// for Scala 3 but not for 2.13 (the `.` in the value breaks the parser), so we stick to flat ids everywhere.
 val ciCommand = (platform: String, scalaSuffix: String) => {
   val isJVM = platform == "JVM"
   val isSandwichable = isJVM
+  // The `scalaSuffix` argument still uses the old sbt 1.x convention ("" = 2.13, "3" = Scala 3); translate it to the
+  // sbt 2.x cell suffix ("" = Scala 3, "2_13" = Scala 2.13).
+  val cellScalaSuffix = if (scalaSuffix == "3") "" else "2_13"
 
   val clean = Vector("clean")
   def withCoverage(tasks: String*): Vector[String] =
@@ -283,13 +242,13 @@ val ciCommand = (platform: String, scalaSuffix: String) => {
       if (isSandwichable) "chimneySandwichTests" else ""
     )
     if name.nonEmpty
-  } yield s"$name${if (isJVM) "" else platform}$scalaSuffix"
+  } yield s"$name${if (isJVM) "" else platform}$cellScalaSuffix"
   def tasksOf(name: String): Vector[String] = projects.map(project => s"$project/$name")
 
   val tasks = if (isJVM) {
     clean ++
       withCoverage((tasksOf("compile") ++ tasksOf("test") ++ tasksOf("coverageReport")).toSeq *) ++
-      Vector("benchmarks/compile") ++
+      Vector("benchmarks2_13/compile") ++ // benchmarks is Scala 2.13 / JVM only
       tasksOf("mimaReportBinaryIssues")
   } else {
     clean ++ tasksOf("test")
@@ -301,12 +260,9 @@ val ciCommand = (platform: String, scalaSuffix: String) => {
 val publishLocalForTests = {
   val jvm = for {
     module <- Vector("chimney", "chimneyCats", "chimneyProtobufs")
-    moduleVersion <- Vector(module, module + "3")
-  } yield moduleVersion + "/publishLocal"
-  val js = for {
-    module <- Vector("chimney").map(_ + "JS")
-    moduleVersion <- Vector(module)
-  } yield moduleVersion + "/publishLocal"
+    cellScalaSuffix <- Vector("2_13", "") // Scala 2.13 then Scala 3
+  } yield s"$module$cellScalaSuffix/publishLocal"
+  val js = Vector("chimneyJS2_13/publishLocal") // Scala 2.13 / JS
   jvm ++ js
 }.mkString(" ; ")
 
@@ -338,10 +294,10 @@ lazy val root = project
          | - Scala JVM adds no suffix to a project name seen in build.sbt
          | - Scala.js adds the "JS" suffix to a project name seen in build.sbt
          | - Scala Native adds the "Native" suffix to a project name seen in build.sbt
-         | - Scala 2.13 adds no suffix to a project name seen in build.sbt
-         | - Scala 3 adds the suffix "3" to a project name seen in build.sbt
+         | - Scala 3 adds no suffix to a project name seen in build.sbt
+         | - Scala 2.13 adds the suffix "2_13" to a project name seen in build.sbt (sbt 2.x flipped the sbt 1.x scheme)
          |
-         |When working with IntelliJ or Scala Metals, edit "val ideScala = ..." and "val idePlatform = ..." within "val versions" in build.sbt to control which Scala version you're currently working with.
+         |When working with IntelliJ or Scala Metals, edit "ide.scala"/"ide.platform" in dev.properties (read by `dev` in project/BuildVersions.scala) to control which Scala version you're currently working with.
          |
          |If you need to test library locally in a different project, use publish-local-for-tests or manually publishLocal:
          | - chimney
@@ -356,8 +312,8 @@ lazy val root = project
           "Compile and test all projects in all Scala versions and platforms (beware! it uses a lot of memory and might OOM!)"
         )
         .noAlias,
-      sbtwelcome.UsefulTask("chimney3/console", "Drop into REPL with Chimney DSL imported (3)").noAlias,
-      sbtwelcome.UsefulTask("chimney/console", "Drop into REPL with Chimney DSL imported (2.13)").noAlias,
+      sbtwelcome.UsefulTask("chimney/console", "Drop into REPL with Chimney DSL imported (3)").noAlias,
+      sbtwelcome.UsefulTask("chimney2_13/console", "Drop into REPL with Chimney DSL imported (2.13)").noAlias,
       sbtwelcome
         .UsefulTask(releaseCommand(git.gitCurrentTags.value), "Publish everything to release or snapshot repository")
         .alias("ci-release"),
@@ -400,9 +356,9 @@ lazy val chimney = projectMatrix
       for3 = Seq("-skip-by-regex:io\\.scalaland\\.chimney\\.internal"),
       for2_13 = Seq("-skip-packages", "io.scalaland.chimney.internal")
     ),
-    libraryDependencies += "com.kubuszok" %%% "hearth" % versions.hearth,
+    libraryDependencies += "com.kubuszok" %% "hearth" % versions.hearth,
     // ChimneySpec is based on hearth-munit's MacroSuite (group/==>/compileErrors-check utilities).
-    libraryDependencies += "com.kubuszok" %%% "hearth-munit" % versions.hearth % Test,
+    libraryDependencies += "com.kubuszok" %% "hearth-munit" % versions.hearth % Test,
     // Cross-quotes: on Scala 2 they are macros (part of hearth), on Scala 3 they are a compiler plugin.
     libraryDependencies ++= versions.fold(scalaVersion.value)(
       for2_13 = Seq.empty,
@@ -433,7 +389,7 @@ lazy val chimneyEngineTestExtension = projectMatrix
     name := "chimney-engine-test-extension",
     description := "Test-only Hearth StandardMacroExtension used by chimney's engine test suites",
     mimaFailOnNoPrevious := false, // this module is not published
-    libraryDependencies += "com.kubuszok" %%% "hearth" % versions.hearth,
+    libraryDependencies += "com.kubuszok" %% "hearth" % versions.hearth,
     // Cross-quotes: on Scala 2 they are macros (part of hearth), on Scala 3 they are a compiler plugin.
     libraryDependencies ++= versions.fold(scalaVersion.value)(
       for2_13 = Seq.empty,
@@ -460,7 +416,7 @@ lazy val chimneyChimneyExtensionTest = projectMatrix
     name := "chimney-chimney-extension-test",
     description := "Test-only Chimney ChimneyMacroExtension used to prove the engine-aware macro-extension SPI",
     mimaFailOnNoPrevious := false, // this module is not published
-    libraryDependencies += "com.kubuszok" %%% "hearth" % versions.hearth,
+    libraryDependencies += "com.kubuszok" %% "hearth" % versions.hearth,
     // Cross-quotes: on Scala 2 they are macros (part of hearth), on Scala 3 they are a compiler plugin.
     libraryDependencies ++= versions.fold(scalaVersion.value)(
       for2_13 = Seq.empty,
@@ -486,13 +442,13 @@ lazy val chimneyCats = projectMatrix
   .settings(dependencies *)
   .settings(
     Compile / console / initialCommands := "import io.scalaland.chimney.*, io.scalaland.chimney.dsl.*, io.scalaland.chimney.cats.*",
-    libraryDependencies += "org.typelevel" %%% "cats-core" % versions.cats,
-    libraryDependencies += "org.typelevel" %%% "cats-laws" % versions.cats % Test,
+    libraryDependencies += "org.typelevel" %% "cats-core" % versions.cats,
+    libraryDependencies += "org.typelevel" %% "cats-laws" % versions.cats % Test,
     // Since 2.0.0 chimney-cats also ships a Chimney `ChimneyMacroExtension` (ServiceLoader-registered, see
     // src/main/resources/META-INF/services): engine-aware SpecialCaseHandlers restoring the total NonEmpty<->NonEmpty
     // (Traverse), NonEmptyMap/NonEmptySet and FunctionK conversions that used to live as `CatsDataImplicits`. The
     // handlers use Hearth's API + cross-quotes directly (hearth itself already comes transitively through chimney).
-    libraryDependencies += "com.kubuszok" %%% "hearth" % versions.hearth,
+    libraryDependencies += "com.kubuszok" %% "hearth" % versions.hearth,
     // Cross-quotes: on Scala 2 they are macros (part of hearth), on Scala 3 they are a compiler plugin.
     libraryDependencies ++= versions.fold(scalaVersion.value)(
       for2_13 = Seq.empty,
@@ -505,7 +461,7 @@ lazy val chimneyCats = projectMatrix
     // build with Scala 3.8+ (older compilers throw "Forward incompatible TASTy file" from hearth's extension loading).
     // Since hearth#325 (0.4.1) an unloadable extension jar is SKIPPED gracefully instead of poisoning every derivation
     // in the module - but the specs here obviously still need the extension to actually load.
-    libraryDependencies += "com.kubuszok" %%% "kindlings-cats-integration" % versions.kindlingsCatsIntegration % Test
+    libraryDependencies += "com.kubuszok" %% "kindlings-cats-integration" % versions.kindlingsCatsIntegration % Test
   )
   .dependsOn(chimney % s"$Test->$Test;$Compile->$Compile")
 
@@ -539,7 +495,7 @@ lazy val chimneyProtobufs = projectMatrix
       .Settings(
         // Scala.js and Scala Native decided to not implement java.time and let an external library do it,
         // meanwhile we want to provide some type class instances for types in java.time.
-        libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % versions.scalaJavaTime
+        libraryDependencies += "io.github.cquiroz" %% "scala-java-time" % versions.scalaJavaTime
       )) *
   )
   .enablePlugins(GitVersioning, GitBranchPrompt)
@@ -567,7 +523,7 @@ lazy val chimneyProtobufs = projectMatrix
     // replaced the corresponding implicits, so those conversions work WITHOUT any import once this jar is on the
     // classpath. The providers use Hearth's API + cross-quotes directly, hence the explicit dependencies below
     // (hearth itself already comes transitively through the chimney module).
-    libraryDependencies += "com.kubuszok" %%% "hearth" % versions.hearth,
+    libraryDependencies += "com.kubuszok" %% "hearth" % versions.hearth,
     // Cross-quotes: on Scala 2 they are macros (part of hearth), on Scala 3 they are a compiler plugin.
     libraryDependencies ++= versions.fold(scalaVersion.value)(
       for2_13 = Seq.empty,
@@ -625,7 +581,11 @@ lazy val chimneySandwichTests = projectMatrix
     moduleName := "chimney-sandwich-tests",
     name := "chimney-sandwich-tests",
     description := "Tests macros in 2.13x3 cross-compilation",
-    mimaFailOnNoPrevious := false // this module is not published
+    mimaFailOnNoPrevious := false, // this module is not published
+    // This module IS the 2.13x3 sandwich: each cell depends on a test-cases fixture built with the OTHER Scala version
+    // (Scala 3 cell -> chimney-sandwich-test-cases-213, Scala 2.13 cell -> chimney-sandwich-test-cases-3). sbt 2.x
+    // rejects a cross-Scala projectDependency by default; opt in since the mismatch is the whole point here.
+    allowMismatchScala := true
   )
   .dependsOn(chimney % s"$Test->$Test;$Compile->$Compile")
   .dependsOn(chimneySandwichTestCases213 % s"$Test->$Test;$Compile->$Compile")

--- a/docs/Justfile
+++ b/docs/Justfile
@@ -5,5 +5,22 @@ serve: build
   docker run --rm -it -p 8000:8000 -v ${PWD}:/docs --env "CI_LATEST_TAG=$(git describe --tags)" mkdocs-chimney-docs
 
 test-snippets:
-  cd .. && sbt publish-local-for-tests
-  cd .. && scala-cli run scripts/test-snippets.scala -- --extra "chimney-version=$(sbt -batch -error 'print chimney/version')" "$PWD/docs/docs"
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd ..
+  sbt --client "publish-local-for-tests"
+  # sbt 2.x leaks ANSI escapes and a trailing `[success] elapsed time` line into `-error` output, so the
+  # old unfiltered `$(sbt -batch -error 'print chimney/version')` fed a polluted version to scala-cli and
+  # broke snippet dependency resolution. Query with a NON-client sbt (the `--client` thin client does not
+  # write `print` results to captured stdout in a non-TTY), strip ANSI, then grep out the version. Keep the
+  # sbt call and the pipeline as SEPARATE `|| true` statements so `set -euo pipefail` (grep no-match -> 1,
+  # head SIGPIPE -> 141) cannot abort before the guard. Mirrors how kindlings/hearth query their versions.
+  raw="$(sbt -batch -error 'print chimney/version' 2>&1 || true)"
+  chimney_version="$(printf '%s\n' "${raw}" | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*' | head -1 || true)"
+  if [ -z "${chimney_version}" ]; then
+    echo "ERROR: could not determine chimney version. sbt output was:" >&2
+    printf '%s\n' "${raw}" >&2
+    exit 1
+  fi
+  echo "Using chimney-version=${chimney_version}"
+  scala-cli run scripts/test-snippets.scala -- --extra "chimney-version=${chimney_version}" "$PWD/docs/docs"

--- a/project/BuildVersions.scala
+++ b/project/BuildVersions.scala
@@ -1,0 +1,69 @@
+import sbt.*
+import sbt.librarymanagement.CrossVersion
+
+// Build-level version/axis config (`versions`) and IDE dev settings (`dev`). These live in project/*.scala rather
+// than build.sbt because sbt 2.x compiles build.sbt with Scala 3, which (a) widens a build.sbt-local
+// `val x = new { ... }` to `Object` and hides its members, and (b) does not bring a build.sbt-local `object`/`class`
+// into the settings scope. As real objects on the meta-build classpath they are visible in build.sbt unqualified
+// (`versions.scala3`, `dev.idePlatform`, ...), exactly as before the sbt 2 migration.
+
+object versions {
+  // Versions we are publishing for.
+  val scala213 = "2.13.18"
+  val scala3 = "3.8.4"
+  // For chimney-sandwich-test-cases-3 ONLY: sbt forbids Scala 2.13 subprojects from depending on Scala 3.8+
+  // subprojects (sbt-8728), and 2.13's -Ytasty-reader tops out below TASTy 28.8 - see the module for details.
+  val scala3Sandwich = "3.7.3"
+
+  // Which versions should be cross-compiled for publishing
+  val scalas = List(scala213, scala3)
+
+  val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
+
+  // Dependencies.
+  val hearth = "0.4.1"
+  val cats = "2.13.0"
+  // kindlings 0.3.1 is the first release on hearth 0.4.1 and includes kubuszok/kindlings#163
+  // (NonEmptySeq/NonEmptyLazyList IsCollection providers).
+  val kindlingsCatsIntegration = "0.3.1"
+  val kindProjector = "0.13.4"
+  val munit = "1.3.4"
+  val scalaCollectionCompat = "2.14.0"
+  val scalaJavaCompat = "1.0.2"
+  val scalaJavaTime = "2.7.0"
+  val scalapbRuntime = scalapb.compiler.Version.scalapbVersion
+
+  // Explicitly handle Scala 2.13 and Scala 3 separately.
+  def fold[A](scalaVersion: String)(for2_13: => Seq[A], for3: => Seq[A]): Seq[A] =
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 13)) => for2_13
+      case Some((3, _))  => for3
+      case _             => Seq.empty // for sbt
+    }
+}
+
+object dev {
+
+  val props = scala.util
+    .Using(new java.io.FileInputStream("dev.properties")) { fis =>
+      val props = new java.util.Properties()
+      props.load(fis)
+      props
+    }
+    .get
+
+  // Which version should be used in IntelliJ
+  val ideScala = props.getProperty("ide.scala") match {
+    case "2.13" => versions.scala213
+    case "3"    => versions.scala3
+  }
+  val idePlatform = props.getProperty("ide.platform") match {
+    case "jvm"    => VirtualAxis.jvm
+    case "js"     => VirtualAxis.js
+    case "native" => VirtualAxis.native
+  }
+
+  def isIdeScala(scalaVersion: String): Boolean =
+    CrossVersion.partialVersion(scalaVersion) == CrossVersion.partialVersion(ideScala)
+  def isIdePlatform(platform: VirtualAxis): Boolean = platform == idePlatform
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=2.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,8 @@ addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 // cross-compile
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")
+// sbt-projectmatrix was in-sourced into sbt 2 core (the standalone plugin has no sbt 2 build), so the
+// `projectMatrix`/`VirtualAxis`/`MatrixAction` API now comes from sbt itself - no addSbtPlugin needed.
 addSbtPlugin("com.indoorvivants" % "sbt-commandmatrix" % "0.1.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
@@ -15,10 +16,15 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 // benchmarks
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
 // disabling projects in IDE
-addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.4")
 // testing protobufs
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.8")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"
+// NOTE: sbt-protoc has no stable sbt 2 release yet - 1.1.0-RC2 is the only sbt 2 build. It pulls
+// protoc-bridge_3, which on the scalapb side only lines up with the 1.0.0-alpha line: stable scalapb
+// (0.11.20) still resolves the protoc-gen_2.13/protoc-bridge_2.13 chain, and mixing that with sbt-protoc's
+// protoc-bridge_3 fails sbt's cross-version-suffix check. So the sbt 2 migration forces scalapb 1.0.0-alpha.6
+// for BOTH the codegen (here) and the runtime (versions.scalapbRuntime derives from it). See build.sbt.
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.1.0-RC2")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.6"
 // documentation
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.6.0")
 

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -100,8 +100,12 @@ class ChimneyExtendedRunner(runner: Runner)(
   *
   * on CI:
   * {{{
-  * # run all tests, use artifacts published locally from current tag
-  * scala-cli run scripts/test-snippets.scala -- --extra "chimney-version=$(sbt -batch -error 'print chimney/version')" "$PWD/docs/docs"
+  * # run all tests, use artifacts published locally from current tag (see docs/Justfile `test-snippets`)
+  * # NB: under sbt 2.x `print chimney/version` leaks ANSI + a `[success]` line, so strip/grep the version out:
+  * sbt --client "publish-local-for-tests"
+  * raw="$(sbt -batch -error 'print chimney/version' 2>&1 || true)"
+  * chimney_version="$(printf '%s\n' "$raw" | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*' | head -1)"
+  * scala-cli run scripts/test-snippets.scala -- --extra "chimney-version=$chimney_version" "$PWD/docs/docs"
   * }}}
   *
   * during development:


### PR DESCRIPTION
Migrates the build from **sbt 1.12.13 to sbt 2.0.2**.

sbt 2.x compiles the build definition with Scala 3 (not 2.12), runs on JDK 17+, in-sources projectMatrix, caches settings/tasks, and hardens several policies — each of which needed adjustments here.

## Plugins (`project/plugins.sbt`)
All plugins now resolve their sbt-2 (`_sbt2_3`) builds; `addSbtPlugin` syntax is unchanged.
- **sbt-projectmatrix dropped** — `projectMatrix`/`VirtualAxis`/`MatrixAction` are in sbt 2 core (the standalone plugin has no sbt-2 build and is archived).
- **sbt-ide-settings** `org.jetbrains % 1.1.0` → `org.jetbrains.scala % 1.1.4` (only the new coordinate publishes for sbt 2).
- **sbt-protoc** `1.0.8` → `1.1.0-RC2` (only sbt-2 build; no stable release yet) and the scalapb **compilerplugin `0.11.20` → `1.0.0-alpha.6`**. Required: sbt-protoc RC2 pulls `protoc-bridge_3`, which on the scalapb side only lines up with the 1.0.0-alpha line; stable scalapb (0.11.20) still resolves `protoc-gen_2.13`/`protoc-bridge_2.13` and fails sbt's cross-version-suffix check. ⚠️ **This bumps the `chimney-protobufs` runtime (`scalapbRuntime` derives from compilerplugin) onto scalapb `1.0.0-alpha.6`** — see "Needs a decision" below.

## `build.sbt` DSL
- `versions`/`dev` moved from build.sbt-local `val ... = new { ... }` into objects in **`project/BuildVersions.scala`**. Scala 3 widens an anonymous object to `Object` and hides its members, and sbt does not lift build.sbt-local objects into the settings scope; as `project/*.scala` objects they stay referenceable unqualified.
- `%%%` → `%%` (sbt 2.x `%%` is platform-aware for projectMatrix JS/Native cells; `%%%` no longer exists).
- Task caching: `scalacOptions --=` on a both-empty `fold` inferred `Seq[Nothing]` (no `JsonFormat`); typed the empties as `Seq.empty[String]`.
- `x cross y` infix → `x.cross(y)` (Scala 3 infix rule).
- CI command builders (`ciCommand`/`publishLocalForTests`), console tasks and logo updated for sbt 2.x's **flipped projectMatrix cell-id suffixes**: Scala 3 is now unsuffixed and Scala 2.13 is `2_13` (was: 2.13 unsuffixed, Scala 3 `3`).
- `allowMismatchScala := true` on `chimneySandwichTests`: sbt 2.x rejects a cross-Scala `projectDependency` by default, but that 2.13×3 dependency is the whole point of the sandwich tests.
- `evictionErrorLevel := Level.Warn`: sbt 2.x promotes eviction conflicts to hard errors; on Scala Native, `cats-laws` (Test) → `scalacheck` pulls scala-native `test-interface` 0.5.8 vs chimney's 0.5.12 (a benign 0.5.x upgrade). Restore warn.

## `.jvmopts`
`-Xmx2g` → `-Xmx6g`. Scala 3 Scala-Native codegen (in-process LLVM IR for the whole macro-generated codebase) OOMs at 2g under sbt 2.x; 4g already clears it with no GC pressure, 6g leaves headroom (fine on 16 GB CI runners).

## Workflows (`.github/workflows/ci.yml`)
Scala 2.13 build jobs moved from `temurin:11` to `temurin:17` — sbt 2.x requires JDK 17+ to run, so the old 2.13-on-JDK-11 job is no longer possible. Emitted bytecode stays JDK 11/17 compatible via the `-release` flags. (`release.yml` and the snippets job already run on 17; `benchmark.yml` on 21.)

## Validation
Ran the **full test matrix locally on sbt 2.0.2 (JDK 24) — all green**:

| Cell | Result |
|---|---|
| Scala 2.13 / JVM | ✅ |
| Scala 3 / JVM | ✅ |
| Scala 2.13 / JS | ✅ |
| Scala 3 / JS | ✅ |
| Scala 2.13 / Native | ✅ |
| Scala 3 / Native | ✅ (needs the 6g heap) |

Every module (chimney, cats, protobufs, java-collections, sandwich on JVM; chimney/cats/protobufs on JS + Native) with **zero test failures**. Hearth resolves to `0.4.1`; `hearth_sjs1`/`hearth_native0.5` resolve via the platform-aware `%%`.

**Not re-verified**: MiMa (intentionally dormant pre-2.0.0) and the coverage/doc report tasks (the `ci-*` aliases include them; the matrix above ran the `test` tasks directly).

## Needs a decision
The **`chimney-protobufs` runtime now depends on scalapb `1.0.0-alpha.6`** — forced by sbt-protoc's RC-only sbt-2 build (no stable sbt-2 sbt-protoc, and the RC only lines up with scalapb's alpha protocbridge chain). Protobufs compiled and its tests passed on all platforms, but this ships a scalapb **alpha** in a published artifact. Alternatives if that's unacceptable: stay on sbt 1.x for the protobufs module, or wait for a stable sbt-2 sbt-protoc / scalapb 1.0.0 final.
