### PR TITLE
Fix .scala-steward.conf: ignore whole org.scala-lang group

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,10 +1,10 @@
 # add try-chimney to defaults from https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
 updates.fileExtensions = [".mill-version",".sbt",".sbt.shared",".sc",".scala",".scalafmt.conf",".yml","build.properties","mill-version","pom.xml","try-chimney.sh"]
 
-updates.pin = [
-  # Use Scala 3 LTS, ignore Scala 3 Next releases
-  { groupId="org.scala-lang", artifactId="scala3-library", version="3.3." },
-  { groupId="org.scala-lang", artifactId="scala3-library_sjs1", version="3.3." }
+# Per-artifact pins leak (Steward tracks binary-suffixed variants like scala3-library_sjs1_3).
+# Ignore the whole group; Scala versions are managed manually (stay on 3.3 LTS + 2.13).
+updates.ignore = [
+  { groupId = "org.scala-lang" }
 ]
 pullRequests.grouping = [
   { name="scala-versions", "title"="Scala compiler updates", "filter"=[{"group" = "org.scala-lang"}, {"group" = "org.scoverage"}] }


### PR DESCRIPTION
## Summary
- Replace per-artifact `updates.pin` with whole-group `updates.ignore` for `org.scala-lang`
- Per-artifact pins leak because Steward tracks binary-suffixed variants (e.g. `scala3-library_sjs1_3`) that bypass rules targeting `scala3-library_sjs1`
- Scala versions (3.3 LTS + 2.13) are managed manually — same approach proven in kubuszok org repos

This prevents unwanted cross-major bumps like #942 (2.13.18 → 3.8.4).

## Test plan
- [ ] Verify Scala Steward no longer opens "Scala compiler updates" PRs
- [ ] Verify other dependency updates (non-org.scala-lang) still come through