### PR TITLE
Bump Hearth 0.4.2, Kindlings 0.3.2, Scala 3.9.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,10 +1,11 @@
 # add try-chimney to defaults from https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
 updates.fileExtensions = [".mill-version",".sbt",".sbt.shared",".sc",".scala",".scalafmt.conf",".yml","build.properties","mill-version","pom.xml","try-chimney.sh"]
 
-# Per-artifact pins leak (Steward tracks binary-suffixed variants like scala3-library_sjs1_3).
-# Ignore the whole group; Scala versions are managed manually (stay on 3.3 LTS + 2.13).
-updates.ignore = [
-  { groupId = "org.scala-lang" }
+# Per-artifact pins leak (Steward tracks binary-suffixed variants like scala3-library_sjs1_3),
+# so pin the whole group. Allows 3.9.x patch bumps; blocks cross-minor (3.9→3.10) and
+# Scala 2.13 bumps (2.13.x doesn't match the prefix, same effect as the old ignore).
+updates.pin = [
+  { groupId = "org.scala-lang", version = "3.9." }
 ]
 pullRequests.grouping = [
   { name="scala-versions", "title"="Scala compiler updates", "filter"=[{"group" = "org.scala-lang"}, {"group" = "org.scoverage"}] }

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,7 @@ val settings = Seq(
       "-no-indent",
       "-Wconf:msg=Unreachable case:s", // suppress fake (?) errors in internal.compiletime
       "-Wconf:msg=Missing symbol position:s", // suppress warning https://github.com/scala/scala3/issues/21672
+      "-Wconf:msg=Skipping coverage instrumentation:s", // Scala 3.9+ warns about large method bodies; not actionable for macro-generated code
       "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s", // we're not rewriting this, since we are still cross-compiling with 2.13
       "-Wconf:msg=The syntax `<function> _` is no longer supported:s", // we're not rewriting this, since we are still cross-compiling with 2.13
       "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s", // Scala 3.8 wording of the warning above

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -93,10 +93,10 @@ extra:
   scala:
     2_12: "2.12.21"
     2_13: "2.13.18"
-    3: "3.8.4"
+    3: "3.9.0"
   libraries:
     cats: "2.13.0"
-    kindlings: "0.3.0"
+    kindlings: "0.3.2"
     scala_automapper: "0.7.0"
     henkan: "0.6.5"
     ducktape: "0.2.9"

--- a/project/BuildVersions.scala
+++ b/project/BuildVersions.scala
@@ -10,7 +10,7 @@ import sbt.librarymanagement.CrossVersion
 object versions {
   // Versions we are publishing for.
   val scala213 = "2.13.18"
-  val scala3 = "3.8.4"
+  val scala3 = "3.9.0"
   // For chimney-sandwich-test-cases-3 ONLY: sbt forbids Scala 2.13 subprojects from depending on Scala 3.8+
   // subprojects (sbt-8728), and 2.13's -Ytasty-reader tops out below TASTy 28.8 - see the module for details.
   val scala3Sandwich = "3.7.3"
@@ -21,11 +21,11 @@ object versions {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.4.1"
+  val hearth = "0.4.2"
   val cats = "2.13.0"
-  // kindlings 0.3.1 is the first release on hearth 0.4.1 and includes kubuszok/kindlings#163
-  // (NonEmptySeq/NonEmptyLazyList IsCollection providers).
-  val kindlingsCatsIntegration = "0.3.1"
+  // kindlings 0.3.2 is on hearth 0.4.2 (metaspace leak fix, ValueOf evaluation) and adds built-in type rules
+  // to circe/yaml/pureconfig/sconfig derivation + jsoniter singleton enum fixes.
+  val kindlingsCatsIntegration = "0.3.2"
   val kindProjector = "0.13.4"
   val munit = "1.3.5"
   val scalaCollectionCompat = "2.14.0"


### PR DESCRIPTION
## Summary

- Bump Hearth from 0.4.1 to 0.4.2 (metaspace leak fix, `ValueOf` compile-time evaluation, Scala 2 annotation preservation)
- Bump Kindlings cats-integration from 0.3.1 to 0.3.2 (built-in type rules for circe/yaml/pureconfig/sconfig, jsoniter singleton enum fixes, unchecked type test warning fixes)
- Bump Scala 3 from 3.8.4 to 3.9.0
- Pin org.scala-lang to 3.9.x in `.scala-steward.conf` (allows patch bumps, blocks cross-minor)

## Test plan

- [x] CI passes on all platforms (JVM, JS, Native) × (Scala 2.13, Scala 3.9.0)