### PR TITLE
Fix #935 + implement #770: context-function-scoped path selectors

### DIFF
--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/CodecDefinition.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.Codec
 import io.scalaland.chimney.internal.compiletime.derivation.codec.CodecMacros
 import io.scalaland.chimney.internal.compiletime.dsl.CodecDefinitionMacros
-import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.{ChimneySelector, TransformerFlags, TransformerOverrides}
 import scala.annotation.nowarn
 
 /** Allows customization of [[io.scalaland.chimney.Codec]] derivation.
@@ -36,6 +36,8 @@ final class CodecDefinition[
       Flags
     ] {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use `selectorDomain` field in `Domain` to obtain the value of `selectorDto` field in `Dto`.
     *
     * By default, if `Domain` is missing field picked by `selectorDto` (or reverse) the compilation fails.
@@ -58,8 +60,8 @@ final class CodecDefinition[
     * @since 1.2.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorDomain: Domain => T,
-      inline selectorDto: Dto => U
+      inline selectorDomain: ChimneySelector ?=> Domain => T,
+      inline selectorDto: ChimneySelector ?=> Dto => U
   ): CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
     ${ CodecDefinitionMacros.withFieldRenamedImpl('this, 'selectorDomain, 'selectorDto) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/IsoDefinition.scala
@@ -3,7 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.Iso
 import io.scalaland.chimney.internal.compiletime.derivation.iso.IsoMacros
 import io.scalaland.chimney.internal.compiletime.dsl.IsoDefinitionMacros
-import io.scalaland.chimney.internal.runtime.{TransformerFlags, TransformerOverrides}
+import io.scalaland.chimney.internal.runtime.{ChimneySelector, TransformerFlags, TransformerOverrides}
 import scala.annotation.nowarn
 
 /** Allows customization of [[io.scalaland.chimney.Iso]] derivation.
@@ -36,6 +36,8 @@ final class IsoDefinition[
       Flags
     ] {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use `selectorFirst` field in `First` to obtain the value of `selectorSecond` field in `Second`.
     *
     * By default, if `First` is missing field picked by `selectorSecond` (or reverse) the compilation fails.
@@ -58,8 +60,8 @@ final class IsoDefinition[
     * @since 1.2.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFirst: First => T,
-      inline selectorSecond: Second => U
+      inline selectorFirst: ChimneySelector ?=> First => T,
+      inline selectorSecond: ChimneySelector ?=> Second => U
   ): IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags] =
     ${ IsoDefinitionMacros.withFieldRenamedImpl('this, 'selectorFirst, 'selectorSecond) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.internal.compiletime.derivation.transformer.Transfor
 import io.scalaland.chimney.{partial, PartialTransformer}
 import io.scalaland.chimney.internal.compiletime.dsl.*
 import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
   IsFunction,
   Path,
   TransformerFlags,
@@ -37,6 +38,8 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     ]
     with WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use provided `value` for field picked using `selector`.
     *
     * By default, if `From` is missing field picked by `selector`, compilation fails.
@@ -59,7 +62,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 0.7.0
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline value: U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldConstImpl('this, 'selector, 'value) }
@@ -86,7 +89,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 0.7.0
     */
   transparent inline def withFieldConstPartial[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline value: partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldConstPartialImpl('this, 'selector, 'value) }
@@ -113,7 +116,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 0.7.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: From => U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
@@ -144,8 +147,8 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.6.0
     */
-  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: ChimneySelector ?=> From => S)(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: S => U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
@@ -172,7 +175,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 0.7.0
     */
   transparent inline def withFieldComputedPartial[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: From => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
@@ -201,7 +204,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 1.10.0
     */
   transparent inline def withFieldComputedPartialFailFast[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: (From, Boolean) => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialFailFastImpl('this, 'selector, 'f) }
@@ -232,8 +235,8 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.6.0
     */
-  transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: ChimneySelector ?=> From => S)(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
@@ -266,8 +269,10 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.10.0
     */
-  transparent inline def withFieldComputedPartialFromFailFast[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedPartialFromFailFast[S, T, U](
+      inline selectorFrom: ChimneySelector ?=> From => S
+  )(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: (S, Boolean) => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -301,8 +306,8 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 0.7.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: From => T,
-      inline selectorTo: To => U
+      inline selectorFrom: ChimneySelector ?=> From => T,
+      inline selectorTo: ChimneySelector ?=> To => U
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldRenamedImpl('this, 'selectorFrom, 'selectorTo) }
 
@@ -322,7 +327,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 1.7.0
     */
   transparent inline def withFieldUnused[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFieldUnusedImpl('this, 'selectorFrom) }
 
@@ -494,7 +499,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 1.7.0
     */
   transparent inline def withSealedSubtypeUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
       PartialTransformerDefinitionMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T](
@@ -508,7 +513,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 1.7.0
     */
   transparent inline def withEnumCaseUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
       PartialTransformerDefinitionMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T](
@@ -560,7 +565,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.7.0
     */
-  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: From => T)(
+  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: ChimneySelector ?=> From => T)(
       inline fallback: FromFallback
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withFallbackFromImpl('this, 'selectorFrom, 'fallback) }
@@ -612,7 +617,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, T]): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerDefinitionMacros.withConstructorToImpl('this, 'selector, 'f) }
@@ -666,7 +671,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorPartialTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorPartialTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using
       IsFunction.Of[Ctor, partial.Result[T]]
@@ -726,7 +731,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.10.0
     */
-  transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using
       IsFunction.Of[Ctor, Boolean => partial.Result[T]]
@@ -783,7 +788,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorEitherTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorEitherTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using
       IsFunction.Of[Ctor, Either[String, T]]
@@ -805,7 +810,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 1.6.0
     */
   transparent inline def withSourceFlag[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): TransformerSourceFlagsDsl.OfPartialTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     ${ PartialTransformerDefinitionMacros.withSourceFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorFrom) }
 
@@ -824,7 +829,7 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     * @since 1.6.0
     */
   transparent inline def withTargetFlag[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerTargetFlagsDsl.OfPartialTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     ${ PartialTransformerDefinitionMacros.withTargetFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerDefinitionForAllMacros
 import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
   IsFunction,
   Path,
   TransformerFlags,
@@ -38,13 +39,15 @@ final class PartialTransformerDefinitionForAll[
     val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
     * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: FromMatch => T,
-      inline selectorTo: ToMatch => U
+      inline selectorFrom: ChimneySelector ?=> FromMatch => T,
+      inline selectorTo: ChimneySelector ?=> ToMatch => U
   ): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
       PartialTransformerDefinitionForAllMacros
@@ -56,7 +59,7 @@ final class PartialTransformerDefinitionForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline value: U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -72,7 +75,7 @@ final class PartialTransformerDefinitionForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -85,7 +88,7 @@ final class PartialTransformerDefinitionForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldComputedPartial[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline f: FromMatch => partial.Result[U]
   )(using U <:< T): PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerInto.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.internal.compiletime.derivation.transformer.Transfor
 import io.scalaland.chimney.partial
 import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoMacros
 import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
   IsFunction,
   Path,
   TransformerFlags,
@@ -40,6 +41,8 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     ]
     with WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use provided `value` for field picked using `selector`.
     *
     * By default, if `From` is missing field picked by `selector`, compilation fails.
@@ -62,7 +65,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 0.7.0
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline value: U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldConstImpl('this, 'selector, 'value) }
@@ -89,7 +92,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 0.7.0
     */
   transparent inline def withFieldConstPartial[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline value: partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldConstPartialImpl('this, 'selector, 'value) }
@@ -116,7 +119,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 0.7.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: From => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
@@ -147,8 +150,8 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.6.0
     */
-  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: ChimneySelector ?=> From => S)(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: S => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
@@ -175,7 +178,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 0.7.0
     */
   transparent inline def withFieldComputedPartial[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: From => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialImpl('this, 'selector, 'f) }
@@ -204,7 +207,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 1.10.0
     */
   transparent inline def withFieldComputedPartialFailFast[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: (From, Boolean) => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialFailFastImpl('this, 'selector, 'f) }
@@ -235,8 +238,8 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.6.0
     */
-  transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedPartialFrom[S, T, U](inline selectorFrom: ChimneySelector ?=> From => S)(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: S => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
@@ -269,8 +272,10 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.10.0
     */
-  transparent inline def withFieldComputedPartialFromFailFast[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedPartialFromFailFast[S, T, U](
+      inline selectorFrom: ChimneySelector ?=> From => S
+  )(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: (S, Boolean) => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldComputedPartialFromFailFastImpl('this, 'selectorFrom, 'selectorTo, 'f) }
@@ -297,8 +302,8 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 0.7.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: From => T,
-      inline selectorTo: To => U
+      inline selectorFrom: ChimneySelector ?=> From => T,
+      inline selectorTo: ChimneySelector ?=> To => U
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldRenamedImpl('this, 'selectorFrom, 'selectorTo) }
 
@@ -318,7 +323,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 1.7.0
     */
   transparent inline def withFieldUnused[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFieldUnusedImpl('this, 'selectorFrom) }
 
@@ -492,7 +497,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 1.7.0
     */
   transparent inline def withSealedSubtypeUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
@@ -501,7 +506,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 1.7.0
     */
   transparent inline def withEnumCaseUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
@@ -548,7 +553,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.7.0
     */
-  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: From => T)(
+  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: ChimneySelector ?=> From => T)(
       inline fallback: FromFallback
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withFallbackFromImpl('this, 'selectorFrom, 'fallback) }
@@ -600,7 +605,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, T]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorToImpl('this, 'selector, 'f) }
@@ -652,7 +657,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorPartialTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorPartialTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, partial.Result[T]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorPartialToImpl('this, 'selector, 'f) }
@@ -710,7 +715,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.10.0
     */
-  transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorPartialToFailFast[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using
       IsFunction.Of[Ctor, Boolean => partial.Result[T]]
@@ -765,7 +770,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorEitherTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorEitherTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, Either[String, T]]): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ PartialTransformerIntoMacros.withConstructorEitherToImpl('this, 'selector, 'f) }
@@ -785,7 +790,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 1.6.0
     */
   transparent inline def withSourceFlag[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): TransformerSourceFlagsDsl.OfPartialTransformerInto[From, To, Overrides, Flags, ? <: Path] =
     ${ PartialTransformerIntoMacros.withSourceFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorFrom) }
 
@@ -804,7 +809,7 @@ final class PartialTransformerInto[From, To, Overrides <: TransformerOverrides, 
     * @since 1.6.0
     */
   transparent inline def withTargetFlag[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerTargetFlagsDsl.OfPartialTransformerInto[From, To, Overrides, Flags, ? <: Path] =
     ${ PartialTransformerIntoMacros.withTargetFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerIntoForAll.scala
@@ -1,7 +1,13 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.dsl.PartialTransformerIntoForAllMacros
-import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
+  Path,
+  TransformerFlags,
+  TransformerOverrides,
+  WithRuntimeDataStore
+}
 import io.scalaland.chimney.partial
 
 /** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations, used with
@@ -21,13 +27,15 @@ final class PartialTransformerIntoForAll[
     val td: PartialTransformerDefinition[From, To, Overrides, Flags]
 ) extends WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
     * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: FromMatch => T,
-      inline selectorTo: ToMatch => U
+      inline selectorFrom: ChimneySelector ?=> FromMatch => T,
+      inline selectorTo: ChimneySelector ?=> ToMatch => U
   ): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${
       PartialTransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
@@ -42,7 +50,7 @@ final class PartialTransformerIntoForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline value: U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -58,7 +66,7 @@ final class PartialTransformerIntoForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -74,7 +82,7 @@ final class PartialTransformerIntoForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldComputedPartial[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline f: FromMatch => partial.Result[U]
   )(using U <:< T): PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherDefinition.scala
@@ -3,7 +3,13 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.Patcher
 import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacros
 import io.scalaland.chimney.internal.compiletime.dsl.PatcherDefinitionMacros
-import io.scalaland.chimney.internal.runtime.{PatcherFlags, PatcherOverrides, Path, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
+  PatcherFlags,
+  PatcherOverrides,
+  Path,
+  WithRuntimeDataStore
+}
 import scala.annotation.nowarn
 
 /** Allows customization of [[io.scalaland.chimney.Patcher]] derivation.
@@ -28,6 +34,8 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     ]
     with WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use the `value` provided here for the field picked using the `selectorObj`.
     *
     * By default, if `Patch` is missing a field, the original `A`'s field value is taken.
@@ -40,7 +48,7 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     *
     * @since 1.7.0
     */
-  transparent inline def withFieldConst[T, U](inline selectorObj: A => T, inline value: U)(using
+  transparent inline def withFieldConst[T, U](inline selectorObj: ChimneySelector ?=> A => T, inline value: U)(using
       U <:< T
   ): PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherDefinitionMacros.withFieldConstImpl('this, 'selectorObj, 'value) }
@@ -66,7 +74,7 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     * @since 1.7.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selectorObj: A => T,
+      inline selectorObj: ChimneySelector ?=> A => T,
       inline f: Patch => U
   )(using U <:< T): PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherDefinitionMacros.withFieldComputedImpl('this, 'selectorObj, 'f) }
@@ -96,8 +104,8 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     *
     * @since 1.7.0
     */
-  transparent inline def withFieldComputedFrom[S, T, U](inline selectorPatch: Patch => S)(
-      inline selectorObj: A => T,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorPatch: ChimneySelector ?=> Patch => S)(
+      inline selectorObj: ChimneySelector ?=> A => T,
       inline f: S => U
   )(using U <:< T): PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherDefinitionMacros.withFieldComputedFromImpl('this, 'selectorPatch, 'selectorObj, 'f) }
@@ -117,7 +125,7 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     * @since 1.7.0
     */
   transparent inline def withFieldIgnored[T](
-      inline selectorPatch: Patch => T
+      inline selectorPatch: ChimneySelector ?=> Patch => T
   ): PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherDefinitionMacros.withFieldIgnoredImpl('this, 'selectorPatch) }
 
@@ -136,7 +144,7 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     * @since 1.7.0
     */
   transparent inline def withPatchedValueFlag[T](
-      inline selectorObj: A => T
+      inline selectorObj: ChimneySelector ?=> A => T
   ): PatcherPatchedValueFlagsDsl.OfPatcherDefinition[A, Patch, Overrides, Flags, ? <: Path] =
     ${ PatcherDefinitionMacros.withPatchedValueFlagImpl('this, 'selectorObj) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherUsing.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherUsing.scala
@@ -2,7 +2,13 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.derivation.patcher.PatcherMacros
 import io.scalaland.chimney.internal.compiletime.dsl.PatcherUsingMacros
-import io.scalaland.chimney.internal.runtime.{PatcherFlags, PatcherOverrides, Path, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
+  PatcherFlags,
+  PatcherOverrides,
+  Path,
+  WithRuntimeDataStore
+}
 import scala.annotation.nowarn
 
 /** Provides operations to customize [[io.scalaland.chimney.Patcher]] logic for specific object value and patch value.
@@ -32,6 +38,8 @@ final class PatcherUsing[A, Patch, Overrides <: PatcherOverrides, Flags <: Patch
 ) extends PatcherFlagsDsl[[Flags1 <: PatcherFlags] =>> PatcherUsing[A, Patch, Overrides, Flags1], Flags]
     with WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use the `value` provided here for the field picked using the `selectorObj`.
     *
     * By default, if `Patch` is missing a field, the original `A`'s field value is taken.
@@ -44,7 +52,7 @@ final class PatcherUsing[A, Patch, Overrides <: PatcherOverrides, Flags <: Patch
     *
     * @since 1.7.0
     */
-  transparent inline def withFieldConst[T, U](inline selectorObj: A => T, value: U)(using
+  transparent inline def withFieldConst[T, U](inline selectorObj: ChimneySelector ?=> A => T, value: U)(using
       U <:< T
   ): PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherUsingMacros.withFieldConstImpl('this, 'selectorObj, 'value) }
@@ -70,7 +78,7 @@ final class PatcherUsing[A, Patch, Overrides <: PatcherOverrides, Flags <: Patch
     * @since 1.7.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selectorObj: A => T,
+      inline selectorObj: ChimneySelector ?=> A => T,
       inline f: Patch => U
   )(using U <:< T): PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherUsingMacros.withFieldComputedImpl('this, 'selectorObj, 'f) }
@@ -100,8 +108,8 @@ final class PatcherUsing[A, Patch, Overrides <: PatcherOverrides, Flags <: Patch
     *
     * @since 1.7.0
     */
-  transparent inline def withFieldComputedFrom[S, T, U](inline selectorPatch: Patch => S)(
-      inline selectorObj: A => T,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorPatch: ChimneySelector ?=> Patch => S)(
+      inline selectorObj: ChimneySelector ?=> A => T,
       inline f: S => U
   )(using U <:< T): PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherUsingMacros.withFieldComputedFromImpl('this, 'selectorPatch, 'selectorObj, 'f) }
@@ -121,7 +129,7 @@ final class PatcherUsing[A, Patch, Overrides <: PatcherOverrides, Flags <: Patch
     * @since 1.7.0
     */
   transparent inline def withFieldIgnored[T](
-      inline selectorPatch: Patch => T
+      inline selectorPatch: ChimneySelector ?=> Patch => T
   ): PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags] =
     ${ PatcherUsingMacros.withFieldIgnoredImpl('this, 'selectorPatch) }
 
@@ -140,7 +148,7 @@ final class PatcherUsing[A, Patch, Overrides <: PatcherOverrides, Flags <: Patch
     * @since 1.7.0
     */
   transparent inline def withPatchedValueFlag[T](
-      inline selectorObj: A => T
+      inline selectorObj: ChimneySelector ?=> A => T
   ): PatcherPatchedValueFlagsDsl.OfPatcherUsing[A, Patch, Overrides, Flags, ? <: Path] =
     ${ PatcherUsingMacros.withPatchedValueFlagImpl('this, 'selectorObj) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -4,6 +4,7 @@ import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.*
 import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
   IsFunction,
   Path,
   TransformerFlags,
@@ -39,6 +40,8 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     ]
     with WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Lifts current transformer definition as `PartialTransformer` definition
     *
     * It keeps all the configuration, provided missing values, renames, coproduct instances etc.
@@ -71,7 +74,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 0.4.0
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline value: U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldConstImpl('this, 'selector, 'value) }
@@ -98,7 +101,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 0.4.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: From => U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldComputedImpl('this, 'selector, 'f) }
@@ -129,8 +132,8 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     *
     * @since 1.6.0
     */
-  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: ChimneySelector ?=> From => S)(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: S => U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
@@ -157,8 +160,8 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 0.4.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: From => T,
-      inline selectorTo: To => U
+      inline selectorFrom: ChimneySelector ?=> From => T,
+      inline selectorTo: ChimneySelector ?=> To => U
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldRenamedImpl('this, 'selectorFrom, 'selectorTo) }
 
@@ -178,7 +181,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 1.7.0
     */
   transparent inline def withFieldUnused[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFieldUnusedImpl('this, 'selectorFrom) }
 
@@ -271,7 +274,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 1.7.0
     */
   transparent inline def withSealedSubtypeUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
@@ -280,7 +283,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 1.7.0
     */
   transparent inline def withEnumCaseUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
@@ -326,7 +329,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     *
     * @since 1.7.0
     */
-  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: From => T)(
+  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: ChimneySelector ?=> From => T)(
       inline fallback: FromFallback
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withFallbackFromImpl('this, 'selectorFrom, 'fallback) }
@@ -378,7 +381,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, T]): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerDefinitionMacros.withConstructorToImpl('this, 'selector, 'f) }
@@ -398,7 +401,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 1.6.0
     */
   transparent inline def withSourceFlag[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): TransformerSourceFlagsDsl.OfTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     ${ TransformerDefinitionMacros.withSourceFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorFrom) }
 
@@ -417,7 +420,7 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     * @since 1.6.0
     */
   transparent inline def withTargetFlag[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerTargetFlagsDsl.OfTransformerDefinition[From, To, Overrides, Flags, ? <: Path] =
     ${ TransformerDefinitionMacros.withTargetFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.dsl.TransformerDefinitionForAllMacros
 import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
   IsFunction,
   Path,
   TransformerFlags,
@@ -38,13 +39,15 @@ final class TransformerDefinitionForAll[
     val runtimeData: TransformerDefinitionCommons.RuntimeDataStore
 ) extends WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
     * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: FromMatch => T,
-      inline selectorTo: ToMatch => U
+      inline selectorFrom: ChimneySelector ?=> FromMatch => T,
+      inline selectorTo: ChimneySelector ?=> ToMatch => U
   ): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
       TransformerDefinitionForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
@@ -59,7 +62,7 @@ final class TransformerDefinitionForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline value: U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -75,7 +78,7 @@ final class TransformerDefinitionForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -91,7 +94,7 @@ final class TransformerDefinitionForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldComputedPartial[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline f: FromMatch => partial.Result[U]
   )(using U <:< T): TransformerDefinition[From, To, ? <: TransformerOverrides, Flags] =
     ${

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -3,6 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.TransformerMacros
 import io.scalaland.chimney.internal.compiletime.dsl.TransformerIntoMacros
 import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
   IsFunction,
   Path,
   TransformerFlags,
@@ -36,6 +37,8 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
 ) extends TransformerFlagsDsl[[Flags1 <: TransformerFlags] =>> TransformerInto[From, To, Overrides, Flags1], Flags]
     with WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Lifts the current transformation to the partial transformation.
     *
     * It keeps all the configuration, provided missing values, renames, coproduct instances etc.
@@ -60,7 +63,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 0.1.5
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline value: U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldConstImpl('this, 'selector, 'value) }
@@ -87,7 +90,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 0.1.5
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: To => T,
+      inline selector: ChimneySelector ?=> To => T,
       inline f: From => U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldComputedImpl('this, 'selector, 'f) }
@@ -118,8 +121,8 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     *
     * @since 1.6.0
     */
-  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: From => S)(
-      inline selectorTo: To => T,
+  transparent inline def withFieldComputedFrom[S, T, U](inline selectorFrom: ChimneySelector ?=> From => S)(
+      inline selectorTo: ChimneySelector ?=> To => T,
       inline f: S => U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldComputedFromImpl('this, 'selectorFrom, 'selectorTo, 'f) }
@@ -146,8 +149,8 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 0.1.5
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: From => T,
-      inline selectorTo: To => U
+      inline selectorFrom: ChimneySelector ?=> From => T,
+      inline selectorTo: ChimneySelector ?=> To => U
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldRenamedImpl('this, 'selectorFrom, 'selectorTo) }
 
@@ -167,7 +170,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 1.7.0
     */
   transparent inline def withFieldUnused[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFieldUnusedImpl('this, 'selectorFrom) }
 
@@ -252,7 +255,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 1.7.0
     */
   transparent inline def withSealedSubtypeUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
@@ -261,7 +264,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 1.7.0
     */
   transparent inline def withEnumCaseUnmatched[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withSealedSubtypeUnmatchedImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 
@@ -308,7 +311,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     *
     * @since 1.7.0
     */
-  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: From => T)(
+  transparent inline def withFallbackFrom[T, FromFallback](inline selectorFrom: ChimneySelector ?=> From => T)(
       inline fallback: FromFallback
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withFallbackFromImpl('this, 'selectorFrom, 'fallback) }
@@ -360,7 +363,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     *
     * @since 1.6.0
     */
-  transparent inline def withConstructorTo[T, Ctor](inline selector: To => T)(
+  transparent inline def withConstructorTo[T, Ctor](inline selector: ChimneySelector ?=> To => T)(
       inline f: Ctor
   )(using IsFunction.Of[Ctor, T]): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${ TransformerIntoMacros.withConstructorToImpl('this, 'selector, 'f) }
@@ -380,7 +383,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 1.6.0
     */
   transparent inline def withSourceFlag[T](
-      inline selectorFrom: From => T
+      inline selectorFrom: ChimneySelector ?=> From => T
   ): TransformerSourceFlagsDsl.OfTransformerInto[From, To, Overrides, Flags, ? <: Path] =
     ${ TransformerIntoMacros.withSourceFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorFrom) }
 
@@ -399,7 +402,7 @@ final class TransformerInto[From, To, Overrides <: TransformerOverrides, Flags <
     * @since 1.6.0
     */
   transparent inline def withTargetFlag[T](
-      inline selectorTo: To => T
+      inline selectorTo: ChimneySelector ?=> To => T
   ): TransformerTargetFlagsDsl.OfTransformerInto[From, To, Overrides, Flags, ? <: Path] =
     ${ TransformerIntoMacros.withTargetFlagImpl[From, To, Overrides, Flags, T]('this, 'selectorTo) }
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerIntoForAll.scala
@@ -1,7 +1,13 @@
 package io.scalaland.chimney.dsl
 
 import io.scalaland.chimney.internal.compiletime.dsl.TransformerIntoForAllMacros
-import io.scalaland.chimney.internal.runtime.{Path, TransformerFlags, TransformerOverrides, WithRuntimeDataStore}
+import io.scalaland.chimney.internal.runtime.{
+  ChimneySelector,
+  Path,
+  TransformerFlags,
+  TransformerOverrides,
+  WithRuntimeDataStore
+}
 import io.scalaland.chimney.partial
 
 /** Scoped builder for defining overrides that apply to all matching `[FromMatch, ToMatch]` derivations, used with
@@ -21,13 +27,15 @@ final class TransformerIntoForAll[
     val td: TransformerDefinition[From, To, Overrides, Flags]
 ) extends WithRuntimeDataStore {
 
+  private given ChimneySelector = null.asInstanceOf[ChimneySelector]
+
   /** Use the `selectorFrom` field in `FromMatch` to obtain the value of the `selectorTo` field in `ToMatch`.
     *
     * @since 1.10.0
     */
   transparent inline def withFieldRenamed[T, U](
-      inline selectorFrom: FromMatch => T,
-      inline selectorTo: ToMatch => U
+      inline selectorFrom: ChimneySelector ?=> FromMatch => T,
+      inline selectorTo: ChimneySelector ?=> ToMatch => U
   ): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${
       TransformerIntoForAllMacros.withFieldRenamedImpl[From, To, Overrides, Flags, FromMatch, ToMatch, T, U](
@@ -42,7 +50,7 @@ final class TransformerIntoForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldConst[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline value: U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${
@@ -58,7 +66,7 @@ final class TransformerIntoForAll[
     * @since 1.10.0
     */
   transparent inline def withFieldComputed[T, U](
-      inline selector: ToMatch => T,
+      inline selector: ChimneySelector ?=> ToMatch => T,
       inline f: FromMatch => U
   )(using U <:< T): TransformerInto[From, To, ? <: TransformerOverrides, Flags] =
     ${

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/dsl.scala
@@ -3,6 +3,7 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.{partial, PartialTransformer, Patcher, Transformer}
 
 export io.scalaland.chimney.inlined.{into, intoPartial, using}
+export io.scalaland.chimney.internal.runtime.ChimneySelector
 export io.scalaland.chimney.syntax.{
   everyItem,
   everyMapKey,

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/CodecDefinitionMacros.scala
@@ -20,8 +20,8 @@ object CodecDefinitionMacros {
       U: Type
   ](
       cd: Expr[CodecDefinition[Domain, Dto, EncodeOverrides, DecodeOverrides, Flags]],
-      selectorDomain: Expr[Domain => T],
-      selectorDto: Expr[Dto => U]
+      selectorDomain: Expr[Any],
+      selectorDto: Expr[Any]
   )(using Quotes): Expr[CodecDefinition[Domain, Dto, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags]] = {
     val m = new CodecDefinitionMacros(quotes)
     m.CodecDefinitionDsl

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/IsoDefinitionMacros.scala
@@ -20,8 +20,8 @@ object IsoDefinitionMacros {
       U: Type
   ](
       id: Expr[IsoDefinition[First, Second, FirstOverrides, SecondOverrides, Flags]],
-      selectorFirst: Expr[First => T],
-      selectorSecond: Expr[Second => U]
+      selectorFirst: Expr[Any],
+      selectorSecond: Expr[Any]
   )(using Quotes): Expr[IsoDefinition[First, Second, ? <: TransformerOverrides, ? <: TransformerOverrides, Flags]] = {
     val m = new IsoDefinitionMacros(quotes)
     m.IsoDefinitionDsl

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionForAllMacros.scala
@@ -22,8 +22,8 @@ object PartialTransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selectorFrom: Expr[FromMatch => T],
-      selectorTo: Expr[ToMatch => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionForAllMacros(quotes)
     m.PartialTransformerDefinitionForAllDsl
@@ -43,7 +43,7 @@ object PartialTransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionForAllMacros(quotes)
@@ -64,7 +64,7 @@ object PartialTransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       f: Expr[FromMatch => U]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionForAllMacros(quotes)
@@ -85,7 +85,7 @@ object PartialTransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       f: Expr[FromMatch => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionForAllMacros(quotes)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerDefinitionMacros.scala
@@ -20,7 +20,7 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -39,7 +39,7 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       value: Expr[partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -58,7 +58,7 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[From => U]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -78,8 +78,8 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[S => U]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -98,7 +98,7 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[From => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -118,8 +118,8 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[S => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -138,7 +138,7 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[(From, Boolean) => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -158,8 +158,8 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[(S, Boolean) => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -178,8 +178,8 @@ object PartialTransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
-      selectorTo: Expr[To => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
     m.PartialTransformerDefinitionDsl
@@ -196,7 +196,7 @@ object PartialTransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
     m.PartialTransformerDefinitionDsl
@@ -281,7 +281,7 @@ object PartialTransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
     m.PartialTransformerDefinitionDsl
@@ -316,7 +316,7 @@ object PartialTransformerDefinitionMacros {
       FromFallback: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
+      selectorFrom: Expr[Any],
       fallback: Expr[FromFallback]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -352,7 +352,7 @@ object PartialTransformerDefinitionMacros {
       Ctor: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -388,7 +388,7 @@ object PartialTransformerDefinitionMacros {
       Ctor: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -424,7 +424,7 @@ object PartialTransformerDefinitionMacros {
       Ctor: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -460,7 +460,7 @@ object PartialTransformerDefinitionMacros {
       Ctor: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerDefinitionMacros(quotes)
@@ -478,7 +478,7 @@ object PartialTransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using
       Quotes
   ): Expr[TransformerSourceFlagsDsl.OfPartialTransformerDefinition[From, To, Overrides, Flags, ? <: Path]] = {
@@ -498,7 +498,7 @@ object PartialTransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using
       Quotes
   ): Expr[TransformerTargetFlagsDsl.OfPartialTransformerDefinition[From, To, Overrides, Flags, ? <: Path]] = {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoForAllMacros.scala
@@ -22,8 +22,8 @@ object PartialTransformerIntoForAllMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selectorFrom: Expr[FromMatch => T],
-      selectorTo: Expr[ToMatch => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoForAllMacros(quotes)
     m.PartialTransformerIntoForAllDsl
@@ -43,7 +43,7 @@ object PartialTransformerIntoForAllMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoForAllMacros(quotes)
@@ -64,7 +64,7 @@ object PartialTransformerIntoForAllMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       f: Expr[FromMatch => U]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoForAllMacros(quotes)
@@ -85,7 +85,7 @@ object PartialTransformerIntoForAllMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       f: Expr[FromMatch => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoForAllMacros(quotes)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PartialTransformerIntoMacros.scala
@@ -20,7 +20,7 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -39,7 +39,7 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       value: Expr[partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -58,7 +58,7 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[From => U]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -78,8 +78,8 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[S => U]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -98,7 +98,7 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[From => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -118,8 +118,8 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[S => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -138,7 +138,7 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[(From, Boolean) => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -158,8 +158,8 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[(S, Boolean) => partial.Result[U]]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -178,8 +178,8 @@ object PartialTransformerIntoMacros {
       U: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
-      selectorTo: Expr[To => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
     m.PartialTransformerIntoDsl
@@ -196,7 +196,7 @@ object PartialTransformerIntoMacros {
       T: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
     m.PartialTransformerIntoDsl
@@ -281,7 +281,7 @@ object PartialTransformerIntoMacros {
       T: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
     m.PartialTransformerIntoDsl
@@ -316,7 +316,7 @@ object PartialTransformerIntoMacros {
       FromFallback: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
+      selectorFrom: Expr[Any],
       fallback: Expr[FromFallback]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -352,7 +352,7 @@ object PartialTransformerIntoMacros {
       Ctor: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -388,7 +388,7 @@ object PartialTransformerIntoMacros {
       Ctor: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -424,7 +424,7 @@ object PartialTransformerIntoMacros {
       Ctor: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -460,7 +460,7 @@ object PartialTransformerIntoMacros {
       Ctor: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[PartialTransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new PartialTransformerIntoMacros(quotes)
@@ -478,7 +478,7 @@ object PartialTransformerIntoMacros {
       T: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using Quotes): Expr[TransformerSourceFlagsDsl.OfPartialTransformerInto[From, To, Overrides, Flags, ? <: Path]] = {
     val m = new PartialTransformerIntoMacros(quotes)
     m.partialTransformerIntoWithSourceFlag[From, To, Overrides, Flags](ti, selectorFrom)
@@ -494,7 +494,7 @@ object PartialTransformerIntoMacros {
       T: Type
   ](
       ti: Expr[PartialTransformerInto[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerTargetFlagsDsl.OfPartialTransformerInto[From, To, Overrides, Flags, ? <: Path]] = {
     val m = new PartialTransformerIntoMacros(quotes)
     m.partialTransformerIntoWithTargetFlag[From, To, Overrides, Flags](ti, selectorTo)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PatcherDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PatcherDefinitionMacros.scala
@@ -19,7 +19,7 @@ object PatcherDefinitionMacros {
       U: Type
   ](
       pd: Expr[PatcherDefinition[A, Patch, Overrides, Flags]],
-      selectorObj: Expr[A => T],
+      selectorObj: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherDefinitionMacros(quotes)
@@ -38,7 +38,7 @@ object PatcherDefinitionMacros {
       U: Type
   ](
       pd: Expr[PatcherDefinition[A, Patch, Overrides, Flags]],
-      selectorObj: Expr[A => T],
+      selectorObj: Expr[Any],
       f: Expr[Patch => U]
   )(using Quotes): Expr[PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherDefinitionMacros(quotes)
@@ -58,8 +58,8 @@ object PatcherDefinitionMacros {
       U: Type
   ](
       pd: Expr[PatcherDefinition[A, Patch, Overrides, Flags]],
-      selectorPatch: Expr[Patch => S],
-      selectorObj: Expr[A => T],
+      selectorPatch: Expr[Any],
+      selectorObj: Expr[Any],
       f: Expr[S => U]
   )(using Quotes): Expr[PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherDefinitionMacros(quotes)
@@ -77,7 +77,7 @@ object PatcherDefinitionMacros {
       T: Type
   ](
       pd: Expr[PatcherDefinition[A, Patch, Overrides, Flags]],
-      selectorPatch: Expr[Patch => T]
+      selectorPatch: Expr[Any]
   )(using Quotes): Expr[PatcherDefinition[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherDefinitionMacros(quotes)
     m.PatcherDefinitionDsl
@@ -94,7 +94,7 @@ object PatcherDefinitionMacros {
       T: Type
   ](
       pd: Expr[PatcherDefinition[A, Patch, Overrides, Flags]],
-      selectorObj: Expr[A => T]
+      selectorObj: Expr[Any]
   )(using Quotes): Expr[PatcherPatchedValueFlagsDsl.OfPatcherDefinition[A, Patch, Overrides, Flags, ? <: Path]] = {
     val m = new PatcherDefinitionMacros(quotes)
     m.patcherDefinitionWithPatchedValueFlag[A, Patch, Overrides, Flags](pd, selectorObj)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PatcherUsingMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/PatcherUsingMacros.scala
@@ -19,7 +19,7 @@ object PatcherUsingMacros {
       U: Type
   ](
       pu: Expr[PatcherUsing[A, Patch, Overrides, Flags]],
-      selectorObj: Expr[A => T],
+      selectorObj: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherUsingMacros(quotes)
@@ -38,7 +38,7 @@ object PatcherUsingMacros {
       U: Type
   ](
       pu: Expr[PatcherUsing[A, Patch, Overrides, Flags]],
-      selectorObj: Expr[A => T],
+      selectorObj: Expr[Any],
       f: Expr[Patch => U]
   )(using Quotes): Expr[PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherUsingMacros(quotes)
@@ -58,8 +58,8 @@ object PatcherUsingMacros {
       U: Type
   ](
       pu: Expr[PatcherUsing[A, Patch, Overrides, Flags]],
-      selectorPatch: Expr[Patch => S],
-      selectorObj: Expr[A => T],
+      selectorPatch: Expr[Any],
+      selectorObj: Expr[Any],
       f: Expr[S => U]
   )(using Quotes): Expr[PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherUsingMacros(quotes)
@@ -77,7 +77,7 @@ object PatcherUsingMacros {
       T: Type
   ](
       pu: Expr[PatcherUsing[A, Patch, Overrides, Flags]],
-      selectorPatch: Expr[Patch => T]
+      selectorPatch: Expr[Any]
   )(using Quotes): Expr[PatcherUsing[A, Patch, ? <: PatcherOverrides, Flags]] = {
     val m = new PatcherUsingMacros(quotes)
     m.PatcherUsingDsl
@@ -94,7 +94,7 @@ object PatcherUsingMacros {
       T: Type
   ](
       pu: Expr[PatcherUsing[A, Patch, Overrides, Flags]],
-      selectorObj: Expr[A => T]
+      selectorObj: Expr[Any]
   )(using Quotes): Expr[PatcherPatchedValueFlagsDsl.OfPatcherUsing[A, Patch, Overrides, Flags, ? <: Path]] = {
     val m = new PatcherUsingMacros(quotes)
     m.patcherUsingWithPatchedValueFlag[A, Patch, Overrides, Flags](pu, selectorObj)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionForAllMacros.scala
@@ -22,8 +22,8 @@ object TransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selectorFrom: Expr[FromMatch => T],
-      selectorTo: Expr[ToMatch => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionForAllMacros(quotes)
     m.TransformerDefinitionForAllDsl
@@ -43,7 +43,7 @@ object TransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionForAllMacros(quotes)
@@ -64,7 +64,7 @@ object TransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       f: Expr[FromMatch => U]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionForAllMacros(quotes)
@@ -85,7 +85,7 @@ object TransformerDefinitionForAllMacros {
       U: Type
   ](
       td: Expr[TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       f: Expr[FromMatch => partial.Result[U]]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionForAllMacros(quotes)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerDefinitionMacros.scala
@@ -19,7 +19,7 @@ object TransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
@@ -38,7 +38,7 @@ object TransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[From => U]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
@@ -58,8 +58,8 @@ object TransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[S => U]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
@@ -78,8 +78,8 @@ object TransformerDefinitionMacros {
       U: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
-      selectorTo: Expr[To => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
     m.TransformerDefinitionDsl
@@ -96,7 +96,7 @@ object TransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
     m.TransformerDefinitionDsl
@@ -147,7 +147,7 @@ object TransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
     m.TransformerDefinitionDsl
@@ -182,7 +182,7 @@ object TransformerDefinitionMacros {
       FromFallback: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
+      selectorFrom: Expr[Any],
       fallback: Expr[FromFallback]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
@@ -218,7 +218,7 @@ object TransformerDefinitionMacros {
       Ctor: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[TransformerDefinition[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerDefinitionMacros(quotes)
@@ -236,7 +236,7 @@ object TransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using Quotes): Expr[TransformerSourceFlagsDsl.OfTransformerDefinition[From, To, Overrides, Flags, ? <: Path]] = {
     val m = new TransformerDefinitionMacros(quotes)
     m.transformerDefinitionWithSourceFlag[From, To, Overrides, Flags](td, selectorFrom)
@@ -252,7 +252,7 @@ object TransformerDefinitionMacros {
       T: Type
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerTargetFlagsDsl.OfTransformerDefinition[From, To, Overrides, Flags, ? <: Path]] = {
     val m = new TransformerDefinitionMacros(quotes)
     m.transformerDefinitionWithTargetFlag[From, To, Overrides, Flags](td, selectorTo)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoForAllMacros.scala
@@ -21,8 +21,8 @@ object TransformerIntoForAllMacros {
       U: Type
   ](
       ti: Expr[TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selectorFrom: Expr[FromMatch => T],
-      selectorTo: Expr[ToMatch => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoForAllMacros(quotes)
     m.TransformerIntoForAllDsl
@@ -42,7 +42,7 @@ object TransformerIntoForAllMacros {
       U: Type
   ](
       ti: Expr[TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoForAllMacros(quotes)
@@ -63,7 +63,7 @@ object TransformerIntoForAllMacros {
       U: Type
   ](
       ti: Expr[TransformerIntoForAll[From, To, Overrides, Flags, FromMatch, ToMatch]],
-      selector: Expr[ToMatch => T],
+      selector: Expr[Any],
       f: Expr[FromMatch => U]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoForAllMacros(quotes)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/dsl/TransformerIntoMacros.scala
@@ -19,7 +19,7 @@ object TransformerIntoMacros {
       U: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       value: Expr[U]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
@@ -38,7 +38,7 @@ object TransformerIntoMacros {
       U: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[From => U]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
@@ -58,8 +58,8 @@ object TransformerIntoMacros {
       U: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => S],
-      selectorTo: Expr[To => T],
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any],
       f: Expr[S => U]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
@@ -78,8 +78,8 @@ object TransformerIntoMacros {
       U: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
-      selectorTo: Expr[To => U]
+      selectorFrom: Expr[Any],
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
     m.TransformerIntoDsl
@@ -96,7 +96,7 @@ object TransformerIntoMacros {
       T: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
     m.TransformerIntoDsl
@@ -147,7 +147,7 @@ object TransformerIntoMacros {
       T: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
     m.TransformerIntoDsl
@@ -182,7 +182,7 @@ object TransformerIntoMacros {
       FromFallback: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T],
+      selectorFrom: Expr[Any],
       fallback: Expr[FromFallback]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
@@ -218,7 +218,7 @@ object TransformerIntoMacros {
       Ctor: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selector: Expr[To => T],
+      selector: Expr[Any],
       f: Expr[Ctor]
   )(using Quotes): Expr[TransformerInto[From, To, ? <: TransformerOverrides, Flags]] = {
     val m = new TransformerIntoMacros(quotes)
@@ -236,7 +236,7 @@ object TransformerIntoMacros {
       T: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selectorFrom: Expr[From => T]
+      selectorFrom: Expr[Any]
   )(using Quotes): Expr[TransformerSourceFlagsDsl.OfTransformerInto[From, To, Overrides, Flags, ? <: Path]] = {
     val m = new TransformerIntoMacros(quotes)
     m.transformerIntoWithSourceFlag[From, To, Overrides, Flags](ti, selectorFrom)
@@ -252,7 +252,7 @@ object TransformerIntoMacros {
       T: Type
   ](
       ti: Expr[TransformerInto[From, To, Overrides, Flags]],
-      selectorTo: Expr[To => T]
+      selectorTo: Expr[Any]
   )(using Quotes): Expr[TransformerTargetFlagsDsl.OfTransformerInto[From, To, Overrides, Flags, ? <: Path]] = {
     val m = new TransformerIntoMacros(quotes)
     m.transformerIntoWithTargetFlag[From, To, Overrides, Flags](ti, selectorTo)

--- a/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/syntax/syntax.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney.syntax
 
 import io.scalaland.chimney.{partial, PartialTransformer, Patcher, Transformer}
-import io.scalaland.chimney.internal.runtime.{IsCollection, IsEither, IsMap, IsOption}
+import io.scalaland.chimney.internal.runtime.{ChimneySelector, IsCollection, IsEither, IsMap, IsOption}
 
 import scala.annotation.unused
 
@@ -140,7 +140,7 @@ extension [A](obj: A) {
   *
   * @since 1.0.0
   */
-extension [A](@unused a: A) {
+extension [A](@unused a: A)(using ChimneySelector) {
 
   /** Allows paths like `_.adt.matching[Subtype].field` when selecting the target fields to override in Chimney DSL.
     *
@@ -201,7 +201,7 @@ extension [A](@unused a: A) {
   *
   * @since 1.0.0
   */
-extension [C[_], I](@unused cc: C[I]) {
+extension [C[_], I](@unused cc: C[I])(using ChimneySelector) {
 
   /** Allows paths like `_.collection.everyItem.field` when selecting the target fields to override in Chimney DSL.
     *
@@ -227,7 +227,7 @@ extension [C[_], I](@unused cc: C[I]) {
   *
   * @since 1.0.0
   */
-extension [M[_, _], K, V](@unused cc: M[K, V]) {
+extension [M[_, _], K, V](@unused cc: M[K, V])(using ChimneySelector) {
 
   /** Allows paths like `_.map.everyMapKey.field` when selecting the target fields to override in Chimney DSL.
     *

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformToOptionRuleModule.scala
@@ -64,8 +64,6 @@ private[compiletime] trait TransformToOptionRuleModule {
   private def wrapInOptionAndTransform[From, To](implicit
       ctx: TransformationContext[From, To]
   ): MIO[Rule.ExpansionResult[To]] = {
-    implicit val OptionFromType: Type[Option[From]] = optionTypeCompat[From]
-
     // Source-side subtype overrides (from withEnumCaseHandled / withSealedSubtypeHandled) return the
     // full target type (e.g. Option[Bar]).  The standard path wraps From into Option[From] and
     // delegates to OptionToOption, which recurses into From → InnerTo — but the override's path

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformToOptionRuleModule.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/derivation/transformer/rules/TransformToOptionRuleModule.scala
@@ -1,10 +1,16 @@
 package io.scalaland.chimney.internal.compiletime.derivation.transformer.rules
 
+import hearth.fp.data.NonEmptyVector
 import hearth.fp.effect.{Log, MIO}
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import io.scalaland.chimney.internal.compiletime.derivation.transformer.Derivation
+import io.scalaland.chimney.partial
 
 private[compiletime] trait TransformToOptionRuleModule {
   this: Derivation & TransformOptionToOptionRuleModule & hearth.MacroCommons =>
+
+  import ChimneyType.Implicits.*
 
   // Cross-quotes helpers in methods with regular type parameters (the cross-quotes helper-def pattern).
 
@@ -17,6 +23,18 @@ private[compiletime] trait TransformToOptionRuleModule {
   private def wrapFallbackOptionCompat[A: Type](value: Expr[A]): ExistentialExpr = {
     implicit val OptionAType: Type[Option[A]] = optionTypeCompat[A]
     optionExprCompat(value).as_??
+  }
+
+  private def fn1TypeCompat[A: Type, B: Type]: Type[A => B] = Type.of[A => B]
+
+  private def applyFnCompat[A: Type, B: Type](fn: Expr[A => B], a: Expr[A]): Expr[B] = Expr.quote {
+    Expr.splice(fn).apply(Expr.splice(a))
+  }
+
+  private def fnFromBooleanTypeCompat[A: Type]: Type[Boolean => A] = Type.of[Boolean => A]
+
+  private def applyFailFastCompat[A: Type](fn: Expr[Boolean => A], failFast: Expr[Boolean]): Expr[A] = Expr.quote {
+    Expr.splice(fn).apply(Expr.splice(failFast))
   }
 
   protected object TransformToOptionRule extends Rule("ToOption") {
@@ -47,12 +65,171 @@ private[compiletime] trait TransformToOptionRuleModule {
       ctx: TransformationContext[From, To]
   ): MIO[Rule.ExpansionResult[To]] = {
     implicit val OptionFromType: Type[Option[From]] = optionTypeCompat[From]
+
+    // Source-side subtype overrides (from withEnumCaseHandled / withSealedSubtypeHandled) return the
+    // full target type (e.g. Option[Bar]).  The standard path wraps From into Option[From] and
+    // delegates to OptionToOption, which recurses into From → InnerTo — but the override's path
+    // gets dropped during that recursion (its SourcePath doesn't start with matching[Some[From]].value)
+    // and its result type (Option[Bar]) doesn't match the inner target (Bar).
+    // Fix: when such overrides exist and From is a sealed hierarchy, generate the match directly
+    // at the From → Option[Bar] level, consuming the overrides here.
+    val subtypeOverrides = ctx.config
+      .filterCurrentOverridesForSubtype { (someFrom: ??) =>
+        import someFrom.Underlying as SomeFrom
+        Type[SomeFrom] <:< Type[From]
+      }
+      .filter {
+        case (_, TransformerOverride.Computed(_, targetPath, _))           => targetPath == ctx.currentTgt
+        case (_, TransformerOverride.ComputedPartial(_, targetPath, _, _)) => targetPath == ctx.currentTgt
+        case _                                                             => false
+      }
+
+    if (subtypeOverrides.nonEmpty) {
+      Type[From] match {
+        case SealedHierarchy(SealedEnum(fromElements)) =>
+          // $COVERAGE-OFF$
+          Log.info(
+            s"Found ${subtypeOverrides.size} subtype override(s) for sealed ${Type.prettyPrint[From]}; generating match before Option wrapping"
+          ) >>
+            // $COVERAGE-ON$
+            mapSealedSubtypesToOption[From, To](fromElements, subtypeOverrides)
+        case _ =>
+          // From is not a sealed hierarchy — fall back to default wrapping (overrides will be lost,
+          // but withEnumCaseHandled on a non-sealed type is not meaningful)
+          wrapAndDelegateToOptionToOption[From, To]
+      }
+    } else {
+      wrapAndDelegateToOptionToOption[From, To]
+    }
+  }
+
+  private def wrapAndDelegateToOptionToOption[From, To](implicit
+      ctx: TransformationContext[From, To]
+  ): MIO[Rule.ExpansionResult[To]] = {
+    implicit val OptionFromType: Type[Option[From]] = optionTypeCompat[From]
     // We're constructing:
     // '{ ${ derivedTo2 } /* created from Option(src) */  }
     TransformOptionToOptionRule.expand(
       ctx.updateFromTo[Option[From], To](optionExprCompat(ctx.src), updateFallbacks = wrapFallbacks)
     )
   }
+
+  private def mapSealedSubtypesToOption[From, To](
+      fromElements: SealedEnum.Elements[From],
+      subtypeOverrides: Map[??, TransformerOverride.ForSubtype]
+  )(implicit ctx: TransformationContext[From, To]): MIO[Rule.ExpansionResult[To]] =
+    Type[To] match {
+      case OptionalValue(to2) =>
+        import to2.{Underlying as InnerTo, value as optionalTo}
+        implicit val SomeInnerToType: Type[Some[InnerTo]] = Type.of[Some[InnerTo]]
+        implicit val FnFromTo: Type[From => To] = fn1TypeCompat[From, To]
+        implicit val FnFromPartialTo: Type[From => partial.Result[To]] = fn1TypeCompat[From, partial.Result[To]]
+        implicit val FnBoolPartialTo: Type[Boolean => partial.Result[To]] = fnFromBooleanTypeCompat[partial.Result[To]]
+        implicit val FnFromBoolPartialTo: Type[From => Boolean => partial.Result[To]] =
+          fn1TypeCompat[From, Boolean => partial.Result[To]]
+
+        // For non-overridden subtypes, match by name against InnerTo's sealed subtypes
+        val maybeToElements: Option[SealedEnum.Elements[InnerTo]] = Type[InnerTo] match {
+          case SealedHierarchy(SealedEnum(elems)) => Some(elems)
+          case _                                  => None
+        }
+
+        val elements: List[Existential.UpperBounded[From, SealedEnum.Element[From, *]]] = fromElements
+        elements
+          .parTraverse[MIO, MatchCase[TransformationExpr[To]]] {
+            (fromSubtype: Existential.UpperBounded[From, SealedEnum.Element[From, *]]) =>
+              import fromSubtype.Underlying as FromSubtype
+
+              subtypeOverrides.find { case (tpe, _) =>
+                fromSubtype.Underlying <:< tpe.Underlying || tpe.Underlying <:< fromSubtype.Underlying
+              } match {
+                case Some((_, runtimeOverride)) =>
+                  // Overridden subtype: apply the override function (returns To = Option[Bar])
+                  MatchCase
+                    .typeMatch[FromSubtype](FreshName.FromType)
+                    .traverse[MIO, TransformationExpr[To]] { (fromExpr: Expr[FromSubtype]) =>
+                      lazy val fromUpcast: Expr[From] = fromExpr.upcast[From]
+                      runtimeOverride match {
+                        case TransformerOverride.Computed(_, _, runtimeData) =>
+                          MIO.pure(
+                            TransformationExpr.fromTotal(
+                              applyFnCompat(runtimeData.asInstanceOfExpr[From => To], fromUpcast)
+                            )
+                          )
+                        case TransformerOverride.ComputedPartial(_, _, runtimeData, failFastAware) =>
+                          val partialResult = if (failFastAware) {
+                            val failFastExpr = ctx match {
+                              case TransformationContext.ForPartial(_, failFast) => failFast
+                              case _                                             => Expr(false)
+                            }
+                            applyFailFastCompat(
+                              applyFnCompat(
+                                runtimeData.asInstanceOfExpr[From => Boolean => partial.Result[To]],
+                                fromUpcast
+                              ),
+                              failFastExpr
+                            )
+                          } else {
+                            applyFnCompat(runtimeData.asInstanceOfExpr[From => partial.Result[To]], fromUpcast)
+                          }
+                          MIO.pure(TransformationExpr.fromPartial(partialResult))
+                        case _ =>
+                          MIO.fail(
+                            new AssertionError("Unexpected override type in ToOption subtype handling")
+                          )
+                      }
+                    }
+
+                case None =>
+                  // Non-overridden subtype: match by name against InnerTo's subtypes, derive, wrap in Some
+                  val nameMatch = maybeToElements.flatMap { toElems =>
+                    toElems.filter(toSub => areSubtypeNamesMatching(fromSubtype.value.name, toSub.value.name)) match {
+                      case toSub :: Nil => Some(toSub)
+                      case _            => None
+                    }
+                  }
+                  nameMatch match {
+                    case Some(toSubtype) =>
+                      import toSubtype.Underlying as ToSubtype, toSubtype.value.upcast as toUpcast
+                      MatchCase
+                        .typeMatch[FromSubtype](FreshName.FromPrefix(fromSubtype.value.name.toLowerCase))
+                        .traverse[MIO, TransformationExpr[To]] { (fromExpr: Expr[FromSubtype]) =>
+                          deriveRecursiveTransformationExpr[FromSubtype, ToSubtype](
+                            fromExpr,
+                            followFrom = Path(_.matching[FromSubtype]),
+                            followTo = Path(_.matching[Some[InnerTo]].select("value").matching[ToSubtype])
+                          ).map(_.map(toUpcast)).map(_.map(optionalTo.of))
+                        }
+                    case None =>
+                      // No unique name match — try deriving FromSubtype → InnerTo directly
+                      MatchCase
+                        .typeMatch[FromSubtype](FreshName.FromPrefix(fromSubtype.value.name.toLowerCase))
+                        .traverse[MIO, TransformationExpr[To]] { (fromExpr: Expr[FromSubtype]) =>
+                          deriveRecursiveTransformationExpr[FromSubtype, InnerTo](
+                            fromExpr,
+                            followFrom = Path(_.matching[FromSubtype]),
+                            followTo = Path(_.matching[Some[InnerTo]].select("value"))
+                          ).map(_.map(optionalTo.of))
+                        }
+                  }
+              }
+          }
+          .flatMap { (matchCases: List[MatchCase[TransformationExpr[To]]]) =>
+            val cases = NonEmptyVector.fromVector(matchCases.toVector).getOrElse {
+              // $COVERAGE-OFF$should never happen unless we messed up
+              assertionFailed("Expected at least one subtype pattern-match case")
+              // $COVERAGE-ON$
+            }
+            if (matchCases.exists(_.isPartial))
+              expandedPartial(ctx.src.matchOn[partial.Result[To]](cases.map(_.ensurePartial)))
+            else
+              expandedTotal(ctx.src.matchOn[To](cases.map(_.ensureTotal)))
+          }
+      case _ =>
+        // $COVERAGE-OFF$should never happen: we're in ToOption rule, To must be Optional
+        assertionFailed(s"ToOption rule matched but ${Type.prettyPrint[To]} is not an OptionalValue")
+      // $COVERAGE-ON$
+    }
 
   private val wrapFallbacks: TransformerOverride.ForFallback => Vector[TransformerOverride.ForFallback] = {
     case fb @ TransformerOverride.Fallback(fallback) =>

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/dsl/DslDefinitions.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/dsl/DslDefinitions.scala
@@ -18,12 +18,30 @@ private[compiletime] trait DslDefinitions { this: ChimneyDefinitions & hearth.Ma
   private val pathMarkers =
     Set("matching", "matchingSome", "matchingLeft", "matchingRight", "everyItem", "everyMapKey", "everyMapValue")
 
-  protected def parsePathType(selector: Expr[Any]): Either[String, ??<:[runtime.Path]] =
-    DestructuredExpr.parseUntyped(UntypedExpr.fromTyped(selector)) match {
-      case lambda: DestructuredExpr.Lambda if lambda.params.sizeIs == 1 =>
-        parsePathBody(selector, lambda.params.head, lambda.body)
+  protected def parsePathType(selector: Expr[Any]): Either[String, ??<:[runtime.Path]] = {
+    // Scala 3 context-function selectors (ChimneySelector ?=> From => T) may appear as:
+    //   1. A Block wrapping a val (resolved given) + lambda: { val contextual$N = ...; (x => x.field) }
+    //   2. A nested lambda: (cs => (x => x.field))
+    // In both cases, we need to unwrap to the actual single-param path lambda.
+    def unwrapToLambda(node: DestructuredExpr): Option[DestructuredExpr.Lambda] = node match {
+      case lambda: DestructuredExpr.Lambda => Some(lambda)
+      case block: DestructuredExpr.Block   => unwrapToLambda(block.result)
+      case _                               => None
+    }
+
+    unwrapToLambda(DestructuredExpr.parseUntyped(UntypedExpr.fromTyped(selector))) match {
+      case Some(lambda) if lambda.params.sizeIs == 1 =>
+        // If the body is another single-param lambda, this is a context function wrapper (case 2 above)
+        val (root, body) = lambda.body match {
+          case innerLambda: DestructuredExpr.Lambda if innerLambda.params.sizeIs == 1 =>
+            (innerLambda.params.head, innerLambda.body)
+          case _ =>
+            (lambda.params.head, lambda.body)
+        }
+        parsePathBody(selector, root, body)
       case _ => Left(invalidSelectorMessage(selector))
     }
+  }
 
   private def parsePathBody(
       selector: Expr[Any],

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ChimneySelector.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ChimneySelector.scala
@@ -1,0 +1,13 @@
+package io.scalaland.chimney.internal.runtime
+
+/** Phantom type used on Scala 3 to scope DSL path extension methods (`matching`, `everyItem`, `everyMapKey`,
+  * `everyMapValue`, `matchingSome`, `matchingLeft`, `matchingRight`) so they are only available inside selector lambdas
+  * passed to DSL methods like `withFieldConst`, `withFieldRenamed`, etc.
+  *
+  * On Scala 3, DSL selector parameters use context functions (`ChimneySelector ?=> From => T`) so the compiler
+  * automatically provides the `ChimneySelector` evidence within the lambda body, enabling the extension methods. Outside
+  * of DSL selectors, these extensions are not in scope.
+  *
+  * @since 1.8.0
+  */
+sealed trait ChimneySelector

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ChimneySelector.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/ChimneySelector.scala
@@ -5,8 +5,8 @@ package io.scalaland.chimney.internal.runtime
   * passed to DSL methods like `withFieldConst`, `withFieldRenamed`, etc.
   *
   * On Scala 3, DSL selector parameters use context functions (`ChimneySelector ?=> From => T`) so the compiler
-  * automatically provides the `ChimneySelector` evidence within the lambda body, enabling the extension methods. Outside
-  * of DSL selectors, these extensions are not in scope.
+  * automatically provides the `ChimneySelector` evidence within the lambda body, enabling the extension methods.
+  * Outside of DSL selectors, these extensions are not in scope.
   *
   * @since 1.8.0
   */

--- a/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/IssuesSpec.scala
@@ -993,6 +993,30 @@ class IssuesSpec extends ChimneySpec {
       Order22(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
   }
 
+  test("fix issue #935 (withEnumCaseHandled to Option target)") {
+    import Issue935.*
+
+    val transformer = Transformer
+      .define[Foo, Option[Bar]]
+      .withEnumCaseHandled[Foo.Default.type](_ => None)
+      .buildTransformer
+
+    transformer.transform(Foo.Default) ==> None
+    transformer.transform(Foo.A) ==> Some(Bar.A)
+  }
+
+  test("fix issue #935 (withSealedSubtypeHandledPartial to Option target)") {
+    import Issue935.*
+
+    val transformer = PartialTransformer
+      .define[Foo, Option[Bar]]
+      .withEnumCaseHandled[Foo.Default.type](_ => None)
+      .buildTransformer
+
+    transformer.transform(Foo.Default).asOption ==> Some(None)
+    transformer.transform(Foo.A).asOption ==> Some(Some(Bar.A))
+  }
+
   test("fix issue #899 (case class member computed as `this.transformInto[B]`)") {
     import Issue899.*
 

--- a/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/fixtures/Issues.scala
@@ -353,6 +353,19 @@ object Issue739 {
   )
 }
 
+object Issue935 {
+  sealed trait Foo
+  object Foo {
+    case object Default extends Foo
+    case object A extends Foo
+  }
+
+  sealed trait Bar
+  object Bar {
+    case object A extends Bar
+  }
+}
+
 object Issue899 {
   import io.scalaland.chimney.dsl.*
 


### PR DESCRIPTION
## Summary

- **Fix #935**: `withEnumCaseHandled` override silently dropped when target type is `Option[B]` — the override is now consumed at the correct derivation level before Option wrapping
- **Implement #770**: Scala 3 DSL path extension methods (`matching`, `everyItem`, `everyMapKey`, etc.) are now scoped to selector lambdas via context functions, no longer polluting the global scope

## Fix #935: withEnumCaseHandled with Option target

**Root cause**: `TransformToOptionRule` wraps `From` into `Option[From]` and delegates to `OptionToOption`, which recurses into `From → InnerTo`. During recursion, source-side subtype overrides are dropped because:
1. Their paths don't start with `matching[Some[From]].value` (the recursion prefix)
2. Their return type (`Option[To]`) doesn't match the inner target (`InnerTo`)

**Fix**: When source-side subtype overrides exist and `From` is a sealed hierarchy, `TransformToOptionRule` now generates the pattern match directly at the `From → Option[To]` level — consuming overrides there (where the return type matches) and deriving non-overridden subtypes by name-matching against `InnerTo`'s subtypes.

## Implement #770: context-function-scoped path extensions

Path extension methods were available on every value once `dsl.*` or `syntax.*` was imported. Now they require `using ChimneySelector`, which is only provided inside DSL selector lambdas via context functions (`ChimneySelector ?=> From => T`).

Changes:
- New `ChimneySelector` sealed trait phantom type in `internal.runtime`
- `using ChimneySelector` constraint on path extension blocks in `syntax.scala`
- Selector params in all Scala 3 DSL classes changed to context functions
- `DslDefinitions` parser updated to unwrap Block/nested-lambda wrapping from context function resolution
- Macro adapter selector params widened to `Expr[Any]`

Not a breaking change: selector functions are `inline` macro parameters, so the context function wrapper is invisible to existing user code.

## Test plan

- [x] New test cases for #935 (total and partial transformer with `withEnumCaseHandled` to `Option` target)
- [x] All 1153 core tests pass
- [x] All 312 cats integration tests pass
- [x] All modules compile (chimney, chimney-cats, chimney-java-collections, chimney-protobufs)