### PR TITLE
Prototype #602: replace Vector[Any] with cons-cell RuntimeDataStore

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,7 +44,7 @@ The simplified version of how the code above works:
    }
    ```
 4. since there might be many overrides in `td.runtimeDataStore(0)` and the macro needs to know which field override is on
-   which position, **DSL needs to remember somehow what each index in the vector overrides**. For that purpose there
+   which position, **DSL needs to remember somehow what each index in the store overrides**. For that purpose there
    exist `TransformerCfg`, a phantom type (a type used only in compile time) which acts as a type-level list where each
    such information could be prepended. (You can think of it as of a tuple, which never get instantiated and only exist
    as expandable list of types). Each time user adds some override code is generated which would append a value in

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,8 +29,8 @@ The simplified version of how the code above works:
 
 1. `.into[Bar]` wraps `Foo(1, "test")` value. The wrapper (here: `TransformerInto`) would store
    **both the transformed value and possible field/coproduct value overrides**
-2. these overrides are stored in `RuntimeDataStore` (currently implemented as `Vector[Any]`) -
-   `.withFieldConst(_.c, 3.0)` adds `3.0` as a value to this vector.
+2. these overrides are stored in `RuntimeDataStore` (a cons-cell linked list materialized into an array on first access) -
+   `.withFieldConst(_.c, 3.0)` adds `3.0` as a value to this store.
    **Both wrapping and override appending would happen during runtime**, so this DSL imposes some overhead
 3. the final `.transform` would generate a code similar to:
    ```scala

--- a/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/DSLOverhead.scala
+++ b/benchmarks/src/main/scala/io/scalaland/chimney/benchmarks/DSLOverhead.scala
@@ -109,6 +109,71 @@ class DSLOverhead extends CommonBenchmarkSettings {
   @Benchmark
   def largeConstByHand: LargeOutput = doLargeByHandConst(samples.largeSample)
 
+  // --- partial chain: val captures the first half, continuation adds the second half ---
+
+  // format: off
+  @Benchmark
+  def largeConstChimneyIntoSplit: LargeOutput = {
+    val builder = samples.largeSample
+      .into[LargeOutput]
+      .withFieldConst(_.a, 834)
+      .withFieldConst(_.b, 834)
+      .withFieldConst(_.c, 834)
+      .withFieldConst(_.d, 834)
+      .withFieldConst(_.e, 834)
+      .withFieldConst(_.f, 834)
+      .withFieldConst(_.g, 834)
+      .withFieldConst(_.h, 834)
+      .withFieldConst(_.i, 834)
+      .withFieldConst(_.j, 834)
+      .withFieldConst(_.k, 834)
+    builder
+      .withFieldConst(_.l, 834)
+      .withFieldConst(_.m, 834)
+      .withFieldConst(_.n, 834)
+      .withFieldConst(_.o, 834)
+      .withFieldConst(_.p, 834)
+      .withFieldConst(_.q, 834)
+      .withFieldConst(_.r, 834)
+      .withFieldConst(_.s, 834)
+      .withFieldConst(_.t, 834)
+      .withFieldConst(_.u, 834)
+      .withFieldConst(_.v, 834)
+      .transform
+  }
+
+  @Benchmark
+  def largeConstChimneyDefinedSplit: LargeOutput = {
+    val builder = Transformer
+      .define[Large, LargeOutput]
+      .withFieldConst(_.a, 834)
+      .withFieldConst(_.b, 834)
+      .withFieldConst(_.c, 834)
+      .withFieldConst(_.d, 834)
+      .withFieldConst(_.e, 834)
+      .withFieldConst(_.f, 834)
+      .withFieldConst(_.g, 834)
+      .withFieldConst(_.h, 834)
+      .withFieldConst(_.i, 834)
+      .withFieldConst(_.j, 834)
+      .withFieldConst(_.k, 834)
+    builder
+      .withFieldConst(_.l, 834)
+      .withFieldConst(_.m, 834)
+      .withFieldConst(_.n, 834)
+      .withFieldConst(_.o, 834)
+      .withFieldConst(_.p, 834)
+      .withFieldConst(_.q, 834)
+      .withFieldConst(_.r, 834)
+      .withFieldConst(_.s, 834)
+      .withFieldConst(_.t, 834)
+      .withFieldConst(_.u, 834)
+      .withFieldConst(_.v, 834)
+      .buildTransformer
+      .transform(samples.largeSample)
+  }
+  // format: on
+
   final private val renameLargeTransformer: Transformer[Large, LargeRenamedOutput] =
     Transformer
       .define[Large, LargeRenamedOutput]

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -837,5 +837,5 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     macro TransformerMacros.derivePartialTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new PartialTransformerDefinition(overrideData +: runtimeData).asInstanceOf[this.type]
+    new PartialTransformerDefinition(runtimeData.prepended(overrideData)).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
@@ -76,6 +76,8 @@ final class PartialTransformerDefinitionForAll[
       .withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](
+      runtimeData.prepended(overrideData)
+    )
       .asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PatcherDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PatcherDefinition.scala
@@ -156,5 +156,5 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     macro PatcherMacros.derivePatcherWithConfig[A, Patch, Overrides, Flags, ImplicitScopeFlags]
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new PatcherDefinition(overrideData +: runtimeData).asInstanceOf[this.type]
+    new PatcherDefinition(runtimeData.prepended(overrideData)).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PatcherDefinitionCommons.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/PatcherDefinitionCommons.scala
@@ -3,8 +3,8 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.internal.runtime.PatcherOverrides
 
 object PatcherDefinitionCommons {
-  type RuntimeDataStore = Vector[Any]
-  def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
+  type RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore
+  def emptyRuntimeDataStore: RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty
 }
 
 private[chimney] trait PatcherDefinitionCommons[UpdateOverrides[_ <: PatcherOverrides]] {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -438,5 +438,5 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     macro TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new TransformerDefinition(overrideData +: runtimeData).asInstanceOf[this.type]
+    new TransformerDefinition(runtimeData.prepended(overrideData)).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -3,8 +3,8 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.internal.runtime.TransformerOverrides
 
 object TransformerDefinitionCommons {
-  type RuntimeDataStore = Vector[Any]
-  def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
+  type RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore
+  def emptyRuntimeDataStore: RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty
 }
 
 private[chimney] trait TransformerDefinitionCommons[UpdateOverrides[_ <: TransformerOverrides]] {

--- a/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
@@ -75,6 +75,6 @@ final class TransformerDefinitionForAll[
     macro TransformerDefinitionForAllMacros.withFieldComputedPartialImpl[From, To, Overrides, Flags, FromMatch, ToMatch]
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData.prepended(overrideData))
       .asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
@@ -1,0 +1,97 @@
+package io.scalaland.chimney.internal.compiletime.derivation
+
+import io.scalaland.chimney.dsl.TransformerDefinitionCommons
+import io.scalaland.chimney.internal.runtime
+
+import scala.reflect.macros.blackbox
+
+private[derivation] object RuntimeDataStoreFlattening {
+
+  /** Analyze the prefix tree for a linear DSL chain and, if found, emit a flat `RuntimeDataStore.wrap(Array(...))`.
+    * Returns `None` when the chain cannot be recognized (e.g. it contains a `val` reference).
+    */
+  def flattenedRuntimeDataStore(
+      prefixTree: blackbox.Context#Tree
+  )(c: blackbox.Context): Option[c.Expr[TransformerDefinitionCommons.RuntimeDataStore]] = {
+    import c.universe.*
+
+    val updateSymbol = typeOf[runtime.WithRuntimeDataStore.type].decl(TermName("update"))
+    val emptySymbol = typeOf[runtime.RuntimeDataStore.type].decl(TermName("empty"))
+
+    val acc = collection.mutable.ListBuffer.empty[Tree]
+
+    def stripCasts(t: Tree): Tree = t match {
+      case TypeApply(Select(inner, TermName("asInstanceOf")), _) => stripCasts(inner)
+      case Typed(inner, _)                                       => stripCasts(inner)
+      case _                                                     => t
+    }
+
+    def hasEmptyRDS(args: List[Tree]): Boolean = args match {
+      case List(arg) => arg.symbol == emptySymbol
+      case _         => args.exists(a => stripCasts(a).symbol == emptySymbol)
+    }
+
+    def walk(t: Tree): Boolean = {
+      val core = stripCasts(t)
+      core match {
+        case Apply(fn, List(inner, data)) if fn.symbol == updateSymbol =>
+          acc += data
+          walk(inner)
+        case Apply(TypeApply(fn, _), List(inner, data)) if fn.symbol == updateSymbol =>
+          acc += data
+          walk(inner)
+        case Apply(Select(New(_), _), args) => hasEmptyRDS(args)
+        case _                              => false
+      }
+    }
+
+    val tree = prefixTree.asInstanceOf[Tree]
+    if (walk(tree)) {
+      val dataTerms = acc.toList
+      if (dataTerms.nonEmpty) {
+        Some(
+          c.Expr[TransformerDefinitionCommons.RuntimeDataStore](
+            q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.wrap(_root_.scala.Array[Any](..$dataTerms))"
+          )
+        )
+      } else {
+        Some(
+          c.Expr[TransformerDefinitionCommons.RuntimeDataStore](
+            q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty"
+          )
+        )
+      }
+    } else None
+  }
+
+  /** For DSL wrappers that carry a source (e.g. TransformerInto, PatcherUsing), extract the constructor arguments from
+    * the base of a linear chain. Returns the base constructor argument trees if the chain is linear, `None` otherwise.
+    */
+  def extractBaseConstructorArgs(
+      prefixTree: blackbox.Context#Tree
+  )(c: blackbox.Context): Option[List[c.universe.Tree]] = {
+    import c.universe.*
+
+    val updateSymbol = typeOf[runtime.WithRuntimeDataStore.type].decl(TermName("update"))
+
+    def stripCasts(t: Tree): Tree = t match {
+      case TypeApply(Select(inner, TermName("asInstanceOf")), _) => stripCasts(inner)
+      case Typed(inner, _)                                       => stripCasts(inner)
+      case _                                                     => t
+    }
+
+    def walk(t: Tree): Option[List[Tree]] = {
+      val core = stripCasts(t)
+      core match {
+        case Apply(fn, List(inner, _)) if fn.symbol == updateSymbol =>
+          walk(inner)
+        case Apply(TypeApply(fn, _), List(inner, _)) if fn.symbol == updateSymbol =>
+          walk(inner)
+        case Apply(Select(New(_), _), args) => Some(args)
+        case _                                               => None
+      }
+    }
+
+    walk(prefixTree.asInstanceOf[Tree]).map(_.asInstanceOf[List[c.universe.Tree]])
+  }
+}

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
@@ -1,22 +1,32 @@
 package io.scalaland.chimney.internal.compiletime.derivation
 
-import io.scalaland.chimney.dsl.TransformerDefinitionCommons
 import io.scalaland.chimney.internal.runtime
 
 import scala.reflect.macros.blackbox
 
 private[derivation] object RuntimeDataStoreFlattening {
 
-  /** Analyze the prefix tree for a linear DSL chain and, if found, emit a flat `RuntimeDataStore.wrap(Array(...))`.
-    * Returns `None` when the chain cannot be recognized (e.g. it contains a `val` reference).
+  sealed trait ChainBase
+  case object EmptyBase extends ChainBase
+  case class OpaqueBase(tree: Any) extends ChainBase
+
+  /** Analyze the prefix tree and return the chain base (empty or opaque) together with the accumulated data terms.
+    *
+    * The walk always succeeds:
+    *   - `EmptyBase` + data → `RuntimeDataStore.wrap(Array(data))`
+    *   - `EmptyBase` + no data → `RuntimeDataStore.empty`
+    *   - `OpaqueBase(tree)` + data → `tree.runtimeData.prependedAll(Array(data))`
+    *   - `OpaqueBase(tree)` + no data → `tree.runtimeData` (no optimization possible)
     */
-  def flattenedRuntimeDataStore(
+  def analyzeChain(
       prefixTree: blackbox.Context#Tree
-  )(c: blackbox.Context): Option[c.Expr[TransformerDefinitionCommons.RuntimeDataStore]] = {
+  )(c: blackbox.Context): (ChainBase, List[c.universe.Tree]) = {
     import c.universe.*
 
     val updateSymbol = typeOf[runtime.WithRuntimeDataStore.type].decl(TermName("update"))
-    val emptySymbol = typeOf[runtime.RuntimeDataStore.type].decl(TermName("empty"))
+    val emptyRDSSymbol = typeOf[runtime.RuntimeDataStore.type].decl(TermName("empty"))
+    val emptyTransformerOverrides = typeOf[runtime.TransformerOverrides.Empty]
+    val emptyPatcherOverrides = typeOf[runtime.PatcherOverrides.Empty]
 
     val acc = collection.mutable.ListBuffer.empty[Tree]
 
@@ -26,46 +36,57 @@ private[derivation] object RuntimeDataStoreFlattening {
       case _                                                     => t
     }
 
-    def hasEmptyRDS(args: List[Tree]): Boolean = args match {
-      case List(arg) => arg.symbol == emptySymbol
-      case _         => args.exists(a => stripCasts(a).symbol == emptySymbol)
+    def hasEmptyRDS(args: List[Tree]): Boolean =
+      args.exists(a => stripCasts(a).symbol == emptyRDSSymbol)
+
+    def hasEmptyOverrides(t: Tree): Boolean = {
+      val tpe = t.tpe
+      tpe != null && tpe != NoType && tpe.typeArgs.exists(arg =>
+        arg =:= emptyTransformerOverrides || arg =:= emptyPatcherOverrides
+      )
     }
 
-    def walk(t: Tree): Boolean = {
+    def walk(t: Tree): ChainBase = {
       val core = stripCasts(t)
       core match {
+        // WithRuntimeDataStore.update(inner, data) — collect data and recurse
         case Apply(fn, List(inner, data)) if fn.symbol == updateSymbol =>
-          acc += data
-          walk(inner)
+          acc += data; walk(inner)
         case Apply(TypeApply(fn, _), List(inner, data)) if fn.symbol == updateSymbol =>
-          acc += data
-          walk(inner)
-        case Apply(Select(New(_), _), args) => hasEmptyRDS(args)
-        case _                              => false
+          acc += data; walk(inner)
+
+        // Method on New(single arg): flag wrappers (new OfPTI(inner).enableX) or
+        // extension methods (new TransformerOps(source).into[To]).
+        // If the expression itself has Empty overrides, it's a valid chain base (stop).
+        // Otherwise recurse through the wrapper to look for data deeper in the chain.
+        case expr @ Select(Apply(Select(New(_), _), List(inner)), _) =>
+          if (hasEmptyOverrides(expr)) EmptyBase else walk(inner)
+        case expr @ TypeApply(Select(Apply(Select(New(_), _), List(inner)), _), _) =>
+          if (hasEmptyOverrides(expr)) EmptyBase else walk(inner)
+        case expr @ Apply(TypeApply(Select(Apply(Select(New(_), _), List(inner)), _), _), _) =>
+          if (hasEmptyOverrides(expr)) EmptyBase else walk(inner)
+        case expr @ Apply(Select(Apply(Select(New(_), _), List(inner)), _), _) =>
+          if (hasEmptyOverrides(expr)) EmptyBase else walk(inner)
+
+        // Direct constructor (e.g. new TransformerInto(source, td))
+        case Apply(Select(New(_), _), args) =>
+          if (hasEmptyRDS(args)) EmptyBase else OpaqueBase(core)
+
+        // Catch-all: factory methods, val references, etc.
+        case other =>
+          if (hasEmptyOverrides(other)) EmptyBase else OpaqueBase(other)
       }
     }
 
     val tree = prefixTree.asInstanceOf[Tree]
-    if (walk(tree)) {
-      val dataTerms = acc.toList
-      if (dataTerms.nonEmpty) {
-        Some(
-          c.Expr[TransformerDefinitionCommons.RuntimeDataStore](
-            q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.wrap(_root_.scala.Array[Any](..$dataTerms))"
-          )
-        )
-      } else {
-        Some(
-          c.Expr[TransformerDefinitionCommons.RuntimeDataStore](
-            q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty"
-          )
-        )
-      }
-    } else None
+    val base = walk(tree)
+    (base, acc.toList.asInstanceOf[List[c.universe.Tree]])
   }
 
   /** For DSL wrappers that carry a source (e.g. TransformerInto, PatcherUsing), extract the constructor arguments from
-    * the base of a linear chain. Returns the base constructor argument trees if the chain is linear, `None` otherwise.
+    * the base of a linear chain. Recurses through `WithRuntimeDataStore.update` calls and intermediate wrappers (flag
+    * DSL classes like `OfPartialTransformerInto`, value-class extension methods) to find the direct `New` constructor.
+    * Returns `None` when the chain base is not a recognizable constructor.
     */
   def extractBaseConstructorArgs(
       prefixTree: blackbox.Context#Tree
@@ -87,8 +108,20 @@ private[derivation] object RuntimeDataStoreFlattening {
           walk(inner)
         case Apply(TypeApply(fn, _), List(inner, _)) if fn.symbol == updateSymbol =>
           walk(inner)
-        case Apply(Select(New(_), _), args) => Some(args)
-        case _                                               => None
+        // Method on New(single arg) — recurse through wrappers
+        case Select(Apply(Select(New(_), _), List(inner)), _) =>
+          walk(inner)
+        case TypeApply(Select(Apply(Select(New(_), _), List(inner)), _), _) =>
+          walk(inner)
+        case Apply(TypeApply(Select(Apply(Select(New(_), _), List(inner)), _), _), _) =>
+          walk(inner)
+        case Apply(Select(Apply(Select(New(_), _), List(inner)), _), _) =>
+          walk(inner)
+        // Direct constructor
+        case Apply(Select(New(_), _), args) =>
+          Some(args)
+        case _ =>
+          None
       }
     }
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -2,6 +2,7 @@ package io.scalaland.chimney.internal.compiletime.derivation.patcher
 
 import io.scalaland.chimney.{dsl, Patcher}
 import io.scalaland.chimney.internal.compiletime.PlatformBridge
+import io.scalaland.chimney.internal.compiletime.derivation.RuntimeDataStoreFlattening
 import io.scalaland.chimney.internal.runtime
 
 import scala.reflect.macros.blackbox
@@ -19,15 +20,28 @@ final class PatcherMacros(ctx: blackbox.Context) extends PlatformBridge(ctx) wit
   ](
       pc: Expr[io.scalaland.chimney.dsl.PatcherConfiguration[ImplicitScopeFlags]]
   ): c.Expr[A] = retypecheck(
-    // Called by PatcherUsing => prefix is PatcherUsing
-    cacheDefinition(c.Expr[dsl.PatcherUsing[A, Patch, Overrides, Flags]](c.prefix.tree)) { pu =>
+    // Called by PatcherUsing => prefix is PatcherUsing (constructor args: obj, objPatch, pd)
+    (for {
+      rds <- RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
+      args <- RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c)
+      if args.sizeIs >= 2
+    } yield {
       val body = derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
-        obj = c.Expr[A](q"$pu.obj"),
-        patch = c.Expr[Patch](q"$pu.objPatch"),
-        runtimeDataStore = c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](q"$pu.pd.runtimeData")
+        obj = c.Expr[A](args(0)),
+        patch = c.Expr[Patch](args(1)),
+        runtimeDataStore = rds
       )
       c.Expr[A](q"{ ${Expr.suppressUnused(pc)}; $body }")
-    }
+    }).getOrElse(
+      cacheDefinition(c.Expr[dsl.PatcherUsing[A, Patch, Overrides, Flags]](c.prefix.tree)) { pu =>
+        val body = derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
+          obj = c.Expr[A](q"$pu.obj"),
+          patch = c.Expr[Patch](q"$pu.objPatch"),
+          runtimeDataStore = c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](q"$pu.pd.runtimeData")
+        )
+        c.Expr[A](q"{ ${Expr.suppressUnused(pc)}; $body }")
+      }
+    )
   )
 
   def derivePatcherWithConfig[
@@ -39,10 +53,11 @@ final class PatcherMacros(ctx: blackbox.Context) extends PlatformBridge(ctx) wit
   ](
       pc: Expr[io.scalaland.chimney.dsl.PatcherConfiguration[ImplicitScopeFlags]]
   ): Expr[Patcher[A, Patch]] = retypecheck {
-    val body = derivePatcher[A, Patch, Overrides, InstanceFlags, ImplicitScopeFlags](
-      // Called by PatcherDefinition => prefix is PatcherDefinition
-      c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
-    )
+    // Called by PatcherDefinition => prefix is PatcherDefinition
+    val rds = RuntimeDataStoreFlattening
+      .flattenedRuntimeDataStore(c.prefix.tree)(c)
+      .getOrElse(c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData"))
+    val body = derivePatcher[A, Patch, Overrides, InstanceFlags, ImplicitScopeFlags](rds)
     c.Expr[Patcher[A, Patch]](q"{ ${Expr.suppressUnused(pc)}; $body }")
   }
 

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -19,20 +19,48 @@ final class PatcherMacros(ctx: blackbox.Context) extends PlatformBridge(ctx) wit
       ImplicitScopeFlags <: runtime.PatcherFlags: WeakTypeTag
   ](
       pc: Expr[io.scalaland.chimney.dsl.PatcherConfiguration[ImplicitScopeFlags]]
-  ): c.Expr[A] = retypecheck(
+  ): c.Expr[A] = retypecheck {
+    import RuntimeDataStoreFlattening.{EmptyBase, OpaqueBase}
     // Called by PatcherUsing => prefix is PatcherUsing (constructor args: obj, objPatch, pd)
-    (for {
-      rds <- RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
-      args <- RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c)
-      if args.sizeIs >= 2
-    } yield {
-      val body = derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
-        obj = c.Expr[A](args(0)),
-        patch = c.Expr[Patch](args(1)),
-        runtimeDataStore = rds
-      )
-      c.Expr[A](q"{ ${Expr.suppressUnused(pc)}; $body }")
-    }).getOrElse(
+    val (base, data) = RuntimeDataStoreFlattening.analyzeChain(c.prefix.tree)(c)
+    val result: Option[c.Expr[A]] = base match {
+      case EmptyBase =>
+        RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c).collect {
+          case args if args.sizeIs >= 2 =>
+            val rds =
+              if (data.nonEmpty)
+                c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](
+                  q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.wrap(_root_.scala.Array[Any](..$data))"
+                )
+              else
+                c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](
+                  q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty"
+                )
+            val body = derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
+              obj = c.Expr[A](args(0)),
+              patch = c.Expr[Patch](args(1)),
+              runtimeDataStore = rds
+            )
+            c.Expr[A](q"{ ${Expr.suppressUnused(pc)}; $body }")
+        }
+      case OpaqueBase(baseTree) =>
+        val bt = baseTree.asInstanceOf[c.universe.Tree]
+        val baseName = TermName(c.freshName("chainBase"))
+        val rds =
+          if (data.nonEmpty)
+            c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](
+              q"$baseName.pd.runtimeData.prependedAll(_root_.scala.Array[Any](..$data))"
+            )
+          else
+            c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](q"$baseName.pd.runtimeData")
+        val body = derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
+          obj = c.Expr[A](q"$baseName.obj"),
+          patch = c.Expr[Patch](q"$baseName.objPatch"),
+          runtimeDataStore = rds
+        )
+        Some(c.Expr[A](q"{ val $baseName = $bt; ${Expr.suppressUnused(pc)}; $body }"))
+    }
+    result.getOrElse(
       cacheDefinition(c.Expr[dsl.PatcherUsing[A, Patch, Overrides, Flags]](c.prefix.tree)) { pu =>
         val body = derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
           obj = c.Expr[A](q"$pu.obj"),
@@ -42,7 +70,7 @@ final class PatcherMacros(ctx: blackbox.Context) extends PlatformBridge(ctx) wit
         c.Expr[A](q"{ ${Expr.suppressUnused(pc)}; $body }")
       }
     )
-  )
+  }
 
   def derivePatcherWithConfig[
       A: WeakTypeTag,
@@ -53,10 +81,26 @@ final class PatcherMacros(ctx: blackbox.Context) extends PlatformBridge(ctx) wit
   ](
       pc: Expr[io.scalaland.chimney.dsl.PatcherConfiguration[ImplicitScopeFlags]]
   ): Expr[Patcher[A, Patch]] = retypecheck {
+    import RuntimeDataStoreFlattening.{EmptyBase, OpaqueBase}
     // Called by PatcherDefinition => prefix is PatcherDefinition
-    val rds = RuntimeDataStoreFlattening
-      .flattenedRuntimeDataStore(c.prefix.tree)(c)
-      .getOrElse(c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData"))
+    val (base, data) = RuntimeDataStoreFlattening.analyzeChain(c.prefix.tree)(c)
+    val rds: c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore] = base match {
+      case EmptyBase if data.nonEmpty =>
+        c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](
+          q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.wrap(_root_.scala.Array[Any](..$data))"
+        )
+      case EmptyBase =>
+        c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](
+          q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty"
+        )
+      case OpaqueBase(baseTree) if data.nonEmpty =>
+        val bt = baseTree.asInstanceOf[c.universe.Tree]
+        c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](
+          q"$bt.runtimeData.prependedAll(_root_.scala.Array[Any](..$data))"
+        )
+      case _ =>
+        c.Expr[dsl.PatcherDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
+    }
     val body = derivePatcher[A, Patch, Overrides, InstanceFlags, ImplicitScopeFlags](rds)
     c.Expr[Patcher[A, Patch]](q"{ ${Expr.suppressUnused(pc)}; $body }")
   }

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -3,6 +3,7 @@ package io.scalaland.chimney.internal.compiletime.derivation.transformer
 import io.scalaland.chimney.dsl
 import io.scalaland.chimney.{PartialTransformer, Transformer}
 import io.scalaland.chimney.internal.compiletime.PlatformBridge
+import io.scalaland.chimney.internal.compiletime.derivation.RuntimeDataStoreFlattening
 import io.scalaland.chimney.internal.runtime
 import io.scalaland.chimney.partial
 
@@ -28,14 +29,17 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[To] = retypecheck(
     // Called by TransformerInto => prefix is TransformerInto
-    // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-    cacheDefinition(c.Expr[dsl.TransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { ti =>
-      val body = deriveTotalTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-        src = c.Expr[From](q"$ti.source"),
-        runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$ti.td.runtimeData")
-      )
-      c.Expr[To](q"{ ${Expr.suppressUnused(tc)}; $body }")
-    }
+    flattenedTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](tc)(
+      deriveTotalTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](_, _)
+    ).getOrElse(
+      cacheDefinition(c.Expr[dsl.TransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { ti =>
+        val body = deriveTotalTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+          src = c.Expr[From](q"$ti.source"),
+          runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$ti.td.runtimeData")
+        )
+        c.Expr[To](q"{ ${Expr.suppressUnused(tc)}; $body }")
+      }
+    )
   )
 
   def deriveTotalTransformerWithDefaults[
@@ -63,10 +67,10 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
   ](
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[Transformer[From, To]] = retypecheck {
-    val body = deriveTotalTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-      // Called by TransformerDefinition => prefix is TransformerDefinition
-      c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
-    )
+    // Called by TransformerDefinition => prefix is TransformerDefinition
+    val rds = flattenedDefinitionRuntimeDataStore()
+      .getOrElse(c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData"))
+    val body = deriveTotalTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](rds)
     c.Expr[Transformer[From, To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
   }
 
@@ -80,15 +84,21 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[partial.Result[To]] = retypecheck(
     // Called by PartialTransformerInto => prefix is PartialTransformerInto
-    // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-    cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
-      val body = derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-        src = c.Expr[From](q"$pti.source"),
-        failFast = c.Expr[Boolean](q"false"),
-        runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
-      )
-      c.Expr[partial.Result[To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
-    }
+    flattenedPartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+      tc,
+      failFast = c.Expr[Boolean](q"false")
+    )(
+      derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](_, _, _)
+    ).getOrElse(
+      cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
+        val body = derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+          src = c.Expr[From](q"$pti.source"),
+          failFast = c.Expr[Boolean](q"false"),
+          runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
+        )
+        c.Expr[partial.Result[To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
+      }
+    )
   )
 
   def derivePartialTransformationWithConfigFailFast[
@@ -101,15 +111,21 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[partial.Result[To]] = retypecheck(
     // Called by PartialTransformerInto => prefix is PartialTransformerInto
-    // We're caching it because it is used twice: once for RuntimeDataStore and once for source
-    cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
-      val body = derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-        src = c.Expr[From](q"$pti.source"),
-        failFast = c.Expr[Boolean](q"true"),
-        runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
-      )
-      c.Expr[partial.Result[To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
-    }
+    flattenedPartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+      tc,
+      failFast = c.Expr[Boolean](q"true")
+    )(
+      derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](_, _, _)
+    ).getOrElse(
+      cacheDefinition(c.Expr[dsl.PartialTransformerInto[From, To, Overrides, InstanceFlags]](c.prefix.tree)) { pti =>
+        val body = derivePartialTransformationResult[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
+          src = c.Expr[From](q"$pti.source"),
+          failFast = c.Expr[Boolean](q"true"),
+          runtimeDataStore = c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$pti.td.runtimeData")
+        )
+        c.Expr[partial.Result[To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
+      }
+    )
   )
 
   def derivePartialTransformerWithDefaults[
@@ -137,10 +153,10 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
   ](
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[PartialTransformer[From, To]] = retypecheck {
-    val body = derivePartialTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](
-      // Called by PartialTransformerDefinition => prefix is PartialTransformerDefinition
-      c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData")
-    )
+    // Called by PartialTransformerDefinition => prefix is PartialTransformerDefinition
+    val rds = flattenedDefinitionRuntimeDataStore()
+      .getOrElse(c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData"))
+    val body = derivePartialTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](rds)
     c.Expr[PartialTransformer[From, To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
   }
 
@@ -172,6 +188,47 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
     val body = useImplicitScopeFlags(implicitScopeFlagsType)
     c.Expr[A](q"{ ${Expr.suppressUnused(implicitScopeConfig)}; $body }")
   }
+
+  private def flattenedDefinitionRuntimeDataStore(): Option[Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore]] =
+    RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
+
+  private def flattenedTransformationResult[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: runtime.TransformerOverrides: WeakTypeTag,
+      InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
+      ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
+  ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]])(
+      derive: (Expr[From], Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore]) => Expr[To]
+  ): Option[Expr[To]] =
+    for {
+      rds <- RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
+      args <- RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c)
+      sourceTree <- args.headOption
+    } yield {
+      val body = derive(c.Expr[From](sourceTree), rds)
+      c.Expr[To](q"{ ${Expr.suppressUnused(tc)}; $body }")
+    }
+
+  private def flattenedPartialTransformationResult[
+      From: WeakTypeTag,
+      To: WeakTypeTag,
+      Overrides <: runtime.TransformerOverrides: WeakTypeTag,
+      InstanceFlags <: runtime.TransformerFlags: WeakTypeTag,
+      ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
+  ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]], failFast: Expr[Boolean])(
+      derive: (Expr[From], Expr[Boolean], Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore]) => Expr[
+        partial.Result[To]
+      ]
+  ): Option[Expr[partial.Result[To]]] =
+    for {
+      rds <- RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
+      args <- RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c)
+      sourceTree <- args.headOption
+    } yield {
+      val body = derive(c.Expr[From](sourceTree), failFast, rds)
+      c.Expr[partial.Result[To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
+    }
 
   private def retypecheck[A: Type](expr: c.Expr[A]): c.Expr[A] = try {
     val res = c.typecheck(tree = c.untypecheck(expr.tree))

--- a/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-2/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -68,8 +68,7 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[Transformer[From, To]] = retypecheck {
     // Called by TransformerDefinition => prefix is TransformerDefinition
-    val rds = flattenedDefinitionRuntimeDataStore()
-      .getOrElse(c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData"))
+    val rds = flattenedDefinitionRDS(q"${c.prefix.tree}.runtimeData")
     val body = deriveTotalTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](rds)
     c.Expr[Transformer[From, To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
   }
@@ -154,8 +153,7 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
       tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]]
   ): Expr[PartialTransformer[From, To]] = retypecheck {
     // Called by PartialTransformerDefinition => prefix is PartialTransformerDefinition
-    val rds = flattenedDefinitionRuntimeDataStore()
-      .getOrElse(c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"${c.prefix.tree}.runtimeData"))
+    val rds = flattenedDefinitionRDS(q"${c.prefix.tree}.runtimeData")
     val body = derivePartialTransformer[From, To, Overrides, InstanceFlags, ImplicitScopeFlags](rds)
     c.Expr[PartialTransformer[From, To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
   }
@@ -189,8 +187,29 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
     c.Expr[A](q"{ ${Expr.suppressUnused(implicitScopeConfig)}; $body }")
   }
 
-  private def flattenedDefinitionRuntimeDataStore(): Option[Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore]] =
-    RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
+  private def flattenedDefinitionRDS(
+      fallback: => c.universe.Tree
+  ): c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore] = {
+    import RuntimeDataStoreFlattening.{EmptyBase, OpaqueBase}
+    val (base, data) = RuntimeDataStoreFlattening.analyzeChain(c.prefix.tree)(c)
+    base match {
+      case EmptyBase if data.nonEmpty =>
+        c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+          q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.wrap(_root_.scala.Array[Any](..$data))"
+        )
+      case EmptyBase =>
+        c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+          q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty"
+        )
+      case OpaqueBase(baseTree) if data.nonEmpty =>
+        val bt = baseTree.asInstanceOf[c.universe.Tree]
+        c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+          q"$bt.runtimeData.prependedAll(_root_.scala.Array[Any](..$data))"
+        )
+      case _ =>
+        c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](fallback)
+    }
+  }
 
   private def flattenedTransformationResult[
       From: WeakTypeTag,
@@ -200,15 +219,39 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
       ImplicitScopeFlags <: runtime.TransformerFlags: WeakTypeTag
   ](tc: Expr[io.scalaland.chimney.dsl.TransformerConfiguration[ImplicitScopeFlags]])(
       derive: (Expr[From], Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore]) => Expr[To]
-  ): Option[Expr[To]] =
-    for {
-      rds <- RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
-      args <- RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c)
-      sourceTree <- args.headOption
-    } yield {
-      val body = derive(c.Expr[From](sourceTree), rds)
-      c.Expr[To](q"{ ${Expr.suppressUnused(tc)}; $body }")
+  ): Option[Expr[To]] = {
+    import RuntimeDataStoreFlattening.{EmptyBase, OpaqueBase}
+    val (base, data) = RuntimeDataStoreFlattening.analyzeChain(c.prefix.tree)(c)
+    base match {
+      case EmptyBase =>
+        RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c).flatMap(_.headOption).map {
+          sourceTree =>
+            val rds =
+              if (data.nonEmpty)
+                c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+                  q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.wrap(_root_.scala.Array[Any](..$data))"
+                )
+              else
+                c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+                  q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty"
+                )
+            val body = derive(c.Expr[From](sourceTree), rds)
+            c.Expr[To](q"{ ${Expr.suppressUnused(tc)}; $body }")
+        }
+      case OpaqueBase(baseTree) =>
+        val bt = baseTree.asInstanceOf[c.universe.Tree]
+        val baseName = TermName(c.freshName("chainBase"))
+        val rds =
+          if (data.nonEmpty)
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+              q"$baseName.td.runtimeData.prependedAll(_root_.scala.Array[Any](..$data))"
+            )
+          else
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$baseName.td.runtimeData")
+        val body = derive(c.Expr[From](q"$baseName.source"), rds)
+        Some(c.Expr[To](q"{ val $baseName = $bt; ${Expr.suppressUnused(tc)}; $body }"))
     }
+  }
 
   private def flattenedPartialTransformationResult[
       From: WeakTypeTag,
@@ -220,15 +263,39 @@ final class TransformerMacros(ctx: blackbox.Context) extends PlatformBridge(ctx)
       derive: (Expr[From], Expr[Boolean], Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore]) => Expr[
         partial.Result[To]
       ]
-  ): Option[Expr[partial.Result[To]]] =
-    for {
-      rds <- RuntimeDataStoreFlattening.flattenedRuntimeDataStore(c.prefix.tree)(c)
-      args <- RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c)
-      sourceTree <- args.headOption
-    } yield {
-      val body = derive(c.Expr[From](sourceTree), failFast, rds)
-      c.Expr[partial.Result[To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
+  ): Option[Expr[partial.Result[To]]] = {
+    import RuntimeDataStoreFlattening.{EmptyBase, OpaqueBase}
+    val (base, data) = RuntimeDataStoreFlattening.analyzeChain(c.prefix.tree)(c)
+    base match {
+      case EmptyBase =>
+        RuntimeDataStoreFlattening.extractBaseConstructorArgs(c.prefix.tree)(c).flatMap(_.headOption).map {
+          sourceTree =>
+            val rds =
+              if (data.nonEmpty)
+                c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+                  q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.wrap(_root_.scala.Array[Any](..$data))"
+                )
+              else
+                c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+                  q"_root_.io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty"
+                )
+            val body = derive(c.Expr[From](sourceTree), failFast, rds)
+            c.Expr[partial.Result[To]](q"{ ${Expr.suppressUnused(tc)}; $body }")
+        }
+      case OpaqueBase(baseTree) =>
+        val bt = baseTree.asInstanceOf[c.universe.Tree]
+        val baseName = TermName(c.freshName("chainBase"))
+        val rds =
+          if (data.nonEmpty)
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](
+              q"$baseName.td.runtimeData.prependedAll(_root_.scala.Array[Any](..$data))"
+            )
+          else
+            c.Expr[dsl.TransformerDefinitionCommons.RuntimeDataStore](q"$baseName.td.runtimeData")
+        val body = derive(c.Expr[From](q"$baseName.source"), failFast, rds)
+        Some(c.Expr[partial.Result[To]](q"{ val $baseName = $bt; ${Expr.suppressUnused(tc)}; $body }"))
     }
+  }
 
   private def retypecheck[A: Type](expr: c.Expr[A]): c.Expr[A] = try {
     val res = c.typecheck(tree = c.untypecheck(expr.tree))

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinition.scala
@@ -861,5 +861,5 @@ final class PartialTransformerDefinition[From, To, Overrides <: TransformerOverr
     ${ TransformerMacros.derivePartialTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]('this) }
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new PartialTransformerDefinition(overrideData +: runtimeData).asInstanceOf[this.type]
+    new PartialTransformerDefinition(runtimeData.prepended(overrideData)).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PartialTransformerDefinitionForAll.scala
@@ -94,6 +94,8 @@ final class PartialTransformerDefinitionForAll[
     }
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+    new PartialTransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](
+      runtimeData.prepended(overrideData)
+    )
       .asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherDefinition.scala
@@ -156,5 +156,5 @@ final class PatcherDefinition[A, Patch, Overrides <: PatcherOverrides, Flags <: 
     ${ PatcherMacros.derivePatcherWithConfig[A, Patch, Overrides, Flags, ImplicitScopeFlags]('this) }
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new PatcherDefinition(overrideData +: runtimeData).asInstanceOf[this.type]
+    new PatcherDefinition(runtimeData.prepended(overrideData)).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherDefinitionCommons.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/PatcherDefinitionCommons.scala
@@ -3,8 +3,8 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.internal.runtime.PatcherOverrides
 
 object PatcherDefinitionCommons {
-  type RuntimeDataStore = Vector[Any]
-  final def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
+  type RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore
+  final def emptyRuntimeDataStore: RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty
 }
 private[chimney] trait PatcherDefinitionCommons[UpdateOverrides[_ <: PatcherOverrides]] {
 

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -454,5 +454,5 @@ final class TransformerDefinition[From, To, Overrides <: TransformerOverrides, F
     ${ TransformerMacros.deriveTotalTransformerWithConfig[From, To, Overrides, Flags, ImplicitScopeFlags]('this) }
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new TransformerDefinition(overrideData +: runtimeData).asInstanceOf[this.type]
+    new TransformerDefinition(runtimeData.prepended(overrideData)).asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionCommons.scala
@@ -3,13 +3,13 @@ package io.scalaland.chimney.dsl
 import io.scalaland.chimney.internal.runtime.TransformerOverrides
 
 object TransformerDefinitionCommons {
-  type RuntimeDataStore = Vector[Any]
-  final def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
+  type RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore
+  final def emptyRuntimeDataStore: RuntimeDataStore = io.scalaland.chimney.internal.runtime.RuntimeDataStore.empty
   // @static annotation breaks Scala.js 3 with:
   // [error] ## Exception when compiling 73 sources to /Users/dev/Workspaces/GitHub/chimney/chimney/target/js-3/classes
   // [error] java.lang.AssertionError: assertion failed: Trying to access the this of another class:
   //   tree.symbol = trait TransformerDefinitionCommons, class symbol = module class extensions$package$
-  // @static final def emptyRuntimeDataStore: RuntimeDataStore = Vector.empty[Any]
+  // @static final def emptyRuntimeDataStore: RuntimeDataStore = RuntimeDataStore.empty
 }
 
 private[chimney] trait TransformerDefinitionCommons[UpdateOverrides[_ <: TransformerOverrides]] {

--- a/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/dsl/TransformerDefinitionForAll.scala
@@ -100,6 +100,6 @@ final class TransformerDefinitionForAll[
     }
 
   private[chimney] def addOverride(overrideData: Any): this.type =
-    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](overrideData +: runtimeData)
+    new TransformerDefinitionForAll[From, To, Overrides, Flags, FromMatch, ToMatch](runtimeData.prepended(overrideData))
       .asInstanceOf[this.type]
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
@@ -5,31 +5,21 @@ import io.scalaland.chimney.internal.runtime
 
 import scala.quoted.{Expr, Quotes, Type, Varargs}
 
-/** Scala 3-only optimization: detects linear DSL chains and emits a flat `RuntimeDataStore.wrap(Array(...))` instead of
-  * evaluating the cons-cell chain at runtime. Falls back to the standard `prefix.runtimeData` when the prefix contains
-  * a `val` reference or any tree shape the analysis cannot recognize.
-  */
 private[derivation] object RuntimeDataStoreFlattening {
 
-  def flattenedRuntimeDataStore[D: Type](
-      prefix: Expr[D]
-  )(runtimeDataAccess: Expr[D] => Expr[TransformerDefinitionCommons.RuntimeDataStore])(using
-      q: Quotes
-  ): Expr[TransformerDefinitionCommons.RuntimeDataStore] = {
-    import q.reflect.*
-    extractChainData(prefix.asTerm) match {
-      case Some(dataTerms) if dataTerms.nonEmpty =>
-        val dataExprs: Seq[Expr[Any]] = dataTerms.map(_.asExprOf[Any])
-        val seqExpr: Expr[Seq[Any]] = Varargs(dataExprs)
-        '{ runtime.RuntimeDataStore.wrap($seqExpr.toArray[Any]) }
-      case Some(_) =>
-        '{ runtime.RuntimeDataStore.empty }
-      case None =>
-        runtimeDataAccess(prefix)
-    }
-  }
+  sealed trait ChainBase
+  case object EmptyBase extends ChainBase
+  case class OpaqueBase(term: Any) extends ChainBase
 
-  private def extractChainData(prefixTerm: Any)(using q: Quotes): Option[List[q.reflect.Term]] = {
+  /** Analyze the prefix tree and return the chain base together with accumulated data terms.
+    *
+    * The walk always succeeds:
+    *   - `EmptyBase` + data → `RuntimeDataStore.wrap(Array(data))`
+    *   - `EmptyBase` + no data → `RuntimeDataStore.empty`
+    *   - `OpaqueBase(term)` + data → partial chain, caller uses `prependedAll`
+    *   - `OpaqueBase(term)` + no data → no optimization, use `runtimeDataAccess` on original prefix
+    */
+  def analyzeChain(prefixTerm: Any)(using q: Quotes): (ChainBase, List[q.reflect.Term]) = {
     import q.reflect.*
 
     val updateMethodSymbol: Symbol = {
@@ -39,6 +29,9 @@ private[derivation] object RuntimeDataStoreFlattening {
 
     val rdsModuleSymbol: Symbol =
       Symbol.requiredModule("io.scalaland.chimney.internal.runtime.RuntimeDataStore")
+
+    val emptyTransformerOverrides: TypeRepr = TypeRepr.of[runtime.TransformerOverrides.Empty]
+    val emptyPatcherOverrides: TypeRepr = TypeRepr.of[runtime.PatcherOverrides.Empty]
 
     val acc = collection.mutable.ListBuffer.empty[Term]
 
@@ -61,23 +54,73 @@ private[derivation] object RuntimeDataStoreFlattening {
 
     def hasEmptyRDS(args: List[Term]): Boolean = args.exists(isEmptyRDS)
 
-    def walk(t: Term): Boolean = {
+    def hasEmptyOverrides(t: Term): Boolean = {
+      val tpe = t.tpe
+      tpe != TypeRepr.of[Nothing] && tpe.typeArgs.exists(arg =>
+        arg =:= emptyTransformerOverrides || arg =:= emptyPatcherOverrides
+      )
+    }
+
+    def walk(t: Term): ChainBase = {
       val core = stripCasts(stripWrappers(t))
       core match {
+        // WithRuntimeDataStore.update(inner, data)
         case Apply(fn, List(inner, data)) if fn.symbol == updateMethodSymbol =>
-          acc += data
-          walk(inner)
+          acc += data; walk(inner)
         case Apply(TypeApply(fn, _), List(inner, data)) if fn.symbol == updateMethodSymbol =>
-          acc += data
-          walk(inner)
-        case Apply(Select(New(_), "<init>"), args)               => hasEmptyRDS(args)
-        case Apply(TypeApply(Select(New(_), "<init>"), _), args) => hasEmptyRDS(args)
-        case _                                                   => false
+          acc += data; walk(inner)
+
+        // Method on New(single arg): flag wrappers or extension methods.
+        // Check hasEmptyOverrides on the expression first — if true, it's a valid base.
+        // Otherwise recurse through the wrapper.
+        case expr @ Select(Apply(Select(New(_), "<init>"), List(inner)), _) =>
+          if hasEmptyOverrides(expr) then EmptyBase else walk(inner)
+        case expr @ TypeApply(Select(Apply(Select(New(_), "<init>"), List(inner)), _), _) =>
+          if hasEmptyOverrides(expr) then EmptyBase else walk(inner)
+        case expr @ Apply(TypeApply(Select(Apply(Select(New(_), "<init>"), List(inner)), _), _), _) =>
+          if hasEmptyOverrides(expr) then EmptyBase else walk(inner)
+        case expr @ Apply(Select(Apply(Select(New(_), "<init>"), List(inner)), _), _) =>
+          if hasEmptyOverrides(expr) then EmptyBase else walk(inner)
+
+        // Direct constructor
+        case Apply(Select(New(_), "<init>"), args) => if hasEmptyRDS(args) then EmptyBase else OpaqueBase(core)
+        case Apply(TypeApply(Select(New(_), "<init>"), _), args) =>
+          if hasEmptyRDS(args) then EmptyBase else OpaqueBase(core)
+
+        // Catch-all
+        case other => if hasEmptyOverrides(other) then EmptyBase else OpaqueBase(other)
       }
     }
 
     val term = prefixTerm.asInstanceOf[Term]
-    if walk(term) then Some(acc.toList)
-    else None
+    val base = walk(term)
+    (base, acc.toList)
+  }
+
+  def flattenedRuntimeDataStore[D: Type](
+      prefix: Expr[D]
+  )(runtimeDataAccess: Expr[D] => Expr[TransformerDefinitionCommons.RuntimeDataStore])(using
+      q: Quotes
+  ): Expr[TransformerDefinitionCommons.RuntimeDataStore] = {
+    import q.reflect.*
+
+    val (base, dataTerms) = analyzeChain(prefix.asTerm)
+
+    base match {
+      case EmptyBase if dataTerms.nonEmpty =>
+        val dataExprs: Seq[Expr[Any]] = dataTerms.map(_.asExprOf[Any])
+        val seqExpr: Expr[Seq[Any]] = Varargs(dataExprs)
+        '{ runtime.RuntimeDataStore.wrap($seqExpr.toArray[Any]) }
+      case EmptyBase =>
+        '{ runtime.RuntimeDataStore.empty }
+      case OpaqueBase(baseTerm) if dataTerms.nonEmpty =>
+        val bt = baseTerm.asInstanceOf[Term]
+        val rdsAccess = Select.unique(bt, "runtimeData").asExprOf[TransformerDefinitionCommons.RuntimeDataStore]
+        val dataExprs: Seq[Expr[Any]] = dataTerms.map(_.asExprOf[Any])
+        val seqExpr: Expr[Seq[Any]] = Varargs(dataExprs)
+        '{ $rdsAccess.prependedAll($seqExpr.toArray[Any]) }
+      case _ =>
+        runtimeDataAccess(prefix)
+    }
   }
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/RuntimeDataStoreFlattening.scala
@@ -1,0 +1,83 @@
+package io.scalaland.chimney.internal.compiletime.derivation
+
+import io.scalaland.chimney.dsl.TransformerDefinitionCommons
+import io.scalaland.chimney.internal.runtime
+
+import scala.quoted.{Expr, Quotes, Type, Varargs}
+
+/** Scala 3-only optimization: detects linear DSL chains and emits a flat `RuntimeDataStore.wrap(Array(...))` instead of
+  * evaluating the cons-cell chain at runtime. Falls back to the standard `prefix.runtimeData` when the prefix contains
+  * a `val` reference or any tree shape the analysis cannot recognize.
+  */
+private[derivation] object RuntimeDataStoreFlattening {
+
+  def flattenedRuntimeDataStore[D: Type](
+      prefix: Expr[D]
+  )(runtimeDataAccess: Expr[D] => Expr[TransformerDefinitionCommons.RuntimeDataStore])(using
+      q: Quotes
+  ): Expr[TransformerDefinitionCommons.RuntimeDataStore] = {
+    import q.reflect.*
+    extractChainData(prefix.asTerm) match {
+      case Some(dataTerms) if dataTerms.nonEmpty =>
+        val dataExprs: Seq[Expr[Any]] = dataTerms.map(_.asExprOf[Any])
+        val seqExpr: Expr[Seq[Any]] = Varargs(dataExprs)
+        '{ runtime.RuntimeDataStore.wrap($seqExpr.toArray[Any]) }
+      case Some(_) =>
+        '{ runtime.RuntimeDataStore.empty }
+      case None =>
+        runtimeDataAccess(prefix)
+    }
+  }
+
+  private def extractChainData(prefixTerm: Any)(using q: Quotes): Option[List[q.reflect.Term]] = {
+    import q.reflect.*
+
+    val updateMethodSymbol: Symbol = {
+      val wrdsModule = Symbol.requiredModule("io.scalaland.chimney.internal.runtime.WithRuntimeDataStore")
+      wrdsModule.methodMember("update").head
+    }
+
+    val rdsModuleSymbol: Symbol =
+      Symbol.requiredModule("io.scalaland.chimney.internal.runtime.RuntimeDataStore")
+
+    val acc = collection.mutable.ListBuffer.empty[Term]
+
+    def stripWrappers(t: Term): Term = t match {
+      case Inlined(_, _, body) => stripWrappers(body)
+      case Block(Nil, expr)    => stripWrappers(expr)
+      case Typed(expr, _)      => stripWrappers(expr)
+      case _                   => t
+    }
+
+    def stripCasts(t: Term): Term = stripWrappers(t) match {
+      case TypeApply(Select(inner, "asInstanceOf"), _) => stripCasts(stripWrappers(inner))
+      case other                                       => other
+    }
+
+    def isEmptyRDS(t: Term): Boolean = stripWrappers(t) match {
+      case Select(qualifier, "empty") => qualifier.symbol == rdsModuleSymbol
+      case _                          => false
+    }
+
+    def hasEmptyRDS(args: List[Term]): Boolean = args.exists(isEmptyRDS)
+
+    def walk(t: Term): Boolean = {
+      val core = stripCasts(stripWrappers(t))
+      core match {
+        case Apply(fn, List(inner, data)) if fn.symbol == updateMethodSymbol =>
+          acc += data
+          walk(inner)
+        case Apply(TypeApply(fn, _), List(inner, data)) if fn.symbol == updateMethodSymbol =>
+          acc += data
+          walk(inner)
+        case Apply(Select(New(_), "<init>"), args)               => hasEmptyRDS(args)
+        case Apply(TypeApply(Select(New(_), "<init>"), _), args) => hasEmptyRDS(args)
+        case _                                                   => false
+      }
+    }
+
+    val term = prefixTerm.asInstanceOf[Term]
+    if walk(term) then Some(acc.toList)
+    else None
+  }
+}

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/patcher/PatcherMacros.scala
@@ -3,6 +3,7 @@ package io.scalaland.chimney.internal.compiletime.derivation.patcher
 import io.scalaland.chimney.dsl.PatcherDefinition
 import io.scalaland.chimney.Patcher
 import io.scalaland.chimney.internal.compiletime.PlatformBridge
+import io.scalaland.chimney.internal.compiletime.derivation.RuntimeDataStoreFlattening
 import io.scalaland.chimney.internal.runtime
 
 import scala.quoted.{Expr, Quotes, Type}
@@ -20,7 +21,9 @@ final class PatcherMacros(q: Quotes) extends PlatformBridge(q) with Derivation w
   ](
       pc: Expr[PatcherDefinition[A, Patch, Overrides, Flags]]
   ): Expr[Patcher[A, Patch]] =
-    derivePatcher[A, Patch, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{ $pc.runtimeData })
+    derivePatcher[A, Patch, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore =
+      RuntimeDataStoreFlattening.flattenedRuntimeDataStore(pc)(pc => '{ $pc.runtimeData })
+    )
 
   def derivePatcherWithDefaults[
       A: Type,
@@ -80,6 +83,6 @@ object PatcherMacros {
     new PatcherMacros(q).derivePatcherResult[A, Patch, Overrides, Flags, ImplicitScopeFlags](
       obj,
       patch,
-      '{ $pd.runtimeData }
+      RuntimeDataStoreFlattening.flattenedRuntimeDataStore(pd)(pd => '{ $pd.runtimeData })
     )
 }

--- a/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
+++ b/chimney/src/main/scala-3/io/scalaland/chimney/internal/compiletime/derivation/transformer/TransformerMacros.scala
@@ -6,6 +6,8 @@ import io.scalaland.chimney.internal.compiletime.PlatformBridge
 import io.scalaland.chimney.internal.runtime
 import io.scalaland.chimney.partial
 
+import io.scalaland.chimney.internal.compiletime.derivation.RuntimeDataStoreFlattening
+
 import scala.quoted.{Expr, Quotes, Type}
 
 final class TransformerMacros(q: Quotes) extends PlatformBridge(q) with Derivation with Gateway {
@@ -21,7 +23,9 @@ final class TransformerMacros(q: Quotes) extends PlatformBridge(q) with Derivati
   ](
       td: Expr[TransformerDefinition[From, To, Overrides, Flags]]
   ): Expr[Transformer[From, To]] =
-    deriveTotalTransformer[From, To, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{ $td.runtimeData })
+    deriveTotalTransformer[From, To, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore =
+      RuntimeDataStoreFlattening.flattenedRuntimeDataStore(td)(td => '{ $td.runtimeData })
+    )
 
   def deriveTotalTransformerWithDefaults[
       From: Type,
@@ -60,9 +64,9 @@ final class TransformerMacros(q: Quotes) extends PlatformBridge(q) with Derivati
   ](
       td: Expr[PartialTransformerDefinition[From, To, Overrides, Flags]]
   ): Expr[PartialTransformer[From, To]] =
-    derivePartialTransformer[From, To, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore = '{
-      $td.runtimeData
-    })
+    derivePartialTransformer[From, To, Overrides, Flags, ImplicitScopeFlags](runtimeDataStore =
+      RuntimeDataStoreFlattening.flattenedRuntimeDataStore(td)(td => '{ $td.runtimeData })
+    )
 
   private def resolveImplicitScopeConfigAndMuteUnusedWarnings[A: Type](
       useImplicitScopeFlags: ??<:[runtime.TransformerFlags] => Expr[A]
@@ -140,7 +144,7 @@ object TransformerMacros {
           ImplicitScopeFlags
         ](
           source,
-          '{ $typedTd.runtimeData }
+          RuntimeDataStoreFlattening.flattenedRuntimeDataStore(typedTd)(td => '{ $td.runtimeData })
         )
     }
   }
@@ -202,7 +206,7 @@ object TransformerMacros {
         ](
           source,
           Expr(failFast),
-          '{ $typedTd.runtimeData }
+          RuntimeDataStoreFlattening.flattenedRuntimeDataStore(typedTd)(td => '{ $td.runtimeData })
         )
     }
   }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/dsl/DslMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/compiletime/dsl/DslMacros.scala
@@ -871,7 +871,7 @@ private[compiletime] trait DslMacros extends DslDefinitions { this: ChimneyDefin
         )(d =>
           Expr.quote {
             new io.scalaland.chimney.dsl.TransformerDefinition[From, To, O2, Flags](
-              Expr.splice(d) +: Expr.splice(prefix).runtimeData
+              Expr.splice(prefix).runtimeData.prepended(Expr.splice(d))
             )
           }
         )
@@ -987,7 +987,7 @@ private[compiletime] trait DslMacros extends DslDefinitions { this: ChimneyDefin
         )(d =>
           Expr.quote {
             new io.scalaland.chimney.dsl.PartialTransformerDefinition[From, To, O2, Flags](
-              Expr.splice(d) +: Expr.splice(prefix).runtimeData
+              Expr.splice(prefix).runtimeData.prepended(Expr.splice(d))
             )
           }
         )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
@@ -2,16 +2,15 @@ package io.scalaland.chimney.internal.runtime
 
 /** Efficient prepend-oriented store for DSL override data.
   *
-  * During DSL chain construction (`.withFieldConst`, `.withFieldComputed`, etc.) values are accumulated via [[prepend]],
-  * which builds a cons-cell linked list in O(1) per step. On the first indexed [[apply]] call (emitted by the macro
-  * into the derived transformer body), the list is materialized into an `Array` for O(1) random access. This replaces
-  * the previous `Vector[Any]` backing, which copied the entire underlying array on every prepend -- O(n) per step and
-  * O(n^2) total for a chain of n overrides.
+  * During DSL chain construction (`.withFieldConst`, `.withFieldComputed`, etc.) values are accumulated via
+  * [[prepended]], which builds a cons-cell linked list in O(1) per step. On the first indexed [[apply]] call (emitted
+  * by the macro into the derived transformer body), the list is materialized into an `Array` for O(1) random access.
+  * This replaces the previous `Vector[Any]` backing which allocated a new collection on every prepend.
   *
   * Thread safety: materialization uses a benign race -- two threads may both materialize, but the result is identical
-  * and the write to `materialized` is to a volatile field, so subsequent reads on any thread see a consistent array.
+  * and the write to `materialized` is to a `@volatile` field, so subsequent reads on any thread see a consistent array.
   *
-  * @since 1.7.0
+  * @since 2.0.0
   */
 final class RuntimeDataStore private (
     // --- cons-cell build phase ---
@@ -44,6 +43,19 @@ final class RuntimeDataStore private (
   /** O(1) prepend -- allocates a single cons-cell object. */
   def prepended(value: Any): RuntimeDataStore =
     new RuntimeDataStore(value, this, size + 1, null)
+
+  override def toString: String = {
+    val sb = new java.lang.StringBuilder("RuntimeDataStore(")
+    var current = this
+    var i = 0
+    while (i < size) {
+      if (i > 0) { val _ = sb.append(", ") }
+      val _ = sb.append(current.head)
+      current = current.tail
+      i += 1
+    }
+    sb.append(")").toString
+  }
 }
 
 object RuntimeDataStore {

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
@@ -7,8 +7,13 @@ package io.scalaland.chimney.internal.runtime
   * by the macro into the derived transformer body), the list is materialized into an `Array` for O(1) random access.
   * This replaces the previous `Vector[Any]` backing which allocated a new collection on every prepend.
   *
-  * Thread safety: materialization uses a benign race -- two threads may both materialize, but the result is identical
-  * and the write to `materialized` is to a `@volatile` field, so subsequent reads on any thread see a consistent array.
+  * When the terminal macro (e.g. `buildTransformer`) can prove that the DSL chain is a linear expression (no `val`
+  * captures), it emits [[RuntimeDataStore.wrap]] to construct a pre-materialized store in a single allocation, skipping
+  * the cons-cell chain entirely.
+  *
+  * Thread safety: materialization uses a benign race -- two threads may both materialize, but the result is identical.
+  * The `materialized` field is intentionally non-volatile: a thread that does not see a prior write simply
+  * re-materializes (producing the same array contents), avoiding the overhead of a volatile read on every `apply()`.
   *
   * @since 2.0.0
   */
@@ -18,11 +23,12 @@ final class RuntimeDataStore private (
     private val tail: RuntimeDataStore,
     val size: Int,
     // --- materialized read phase ---
-    @volatile private var materialized: Array[Any]
+    private var materialized: Array[Any]
 ) {
 
   /** Retrieve the value at logical index `index` (0 = most recently prepended). On the first call the cons-cell chain
-    * is materialized into a flat array; subsequent calls are O(1).
+    * is materialized into a flat array; subsequent calls are O(1). If the tail (or any node in the chain) is already
+    * materialized (e.g. created via [[RuntimeDataStore.wrap]]), its array is bulk-copied via `System.arraycopy`.
     */
   def apply(index: Int): Any = {
     var arr = materialized
@@ -31,9 +37,15 @@ final class RuntimeDataStore private (
       var current = this
       var i = 0
       while (i < size) {
-        arr(i) = current.head
-        current = current.tail
-        i += 1
+        val currentMat = current.materialized
+        if (currentMat ne null) {
+          System.arraycopy(currentMat, 0, arr, i, current.size)
+          i = size
+        } else {
+          arr(i) = current.head
+          current = current.tail
+          i += 1
+        }
       }
       materialized = arr
     }
@@ -46,13 +58,22 @@ final class RuntimeDataStore private (
 
   override def toString: String = {
     val sb = new java.lang.StringBuilder("RuntimeDataStore(")
-    var current = this
+    val arr = materialized
     var i = 0
-    while (i < size) {
-      if (i > 0) { val _ = sb.append(", ") }
-      val _ = sb.append(current.head)
-      current = current.tail
-      i += 1
+    if (arr ne null) {
+      while (i < size) {
+        if (i > 0) { val _ = sb.append(", ") }
+        val _ = sb.append(arr(i))
+        i += 1
+      }
+    } else {
+      var current = this
+      while (i < size) {
+        if (i > 0) { val _ = sb.append(", ") }
+        val _ = sb.append(current.head)
+        current = current.tail
+        i += 1
+      }
     }
     sb.append(")").toString
   }
@@ -60,4 +81,17 @@ final class RuntimeDataStore private (
 
 object RuntimeDataStore {
   val empty: RuntimeDataStore = new RuntimeDataStore(null, null, 0, new Array[Any](0))
+
+  /** Create a pre-materialized store from the given array. Index 0 in the array corresponds to logical index 0 (the
+    * most recently prepended value). The caller must not mutate `values` after this call -- no defensive copy is made.
+    * This is safe when the array is freshly constructed by macro-generated code.
+    *
+    * A store created via `wrap` supports [[prepended]]: the child node's materialization loop detects the
+    * pre-materialized tail and bulk-copies via `System.arraycopy` instead of walking a cons-cell chain.
+    */
+  def wrap(values: Array[Any]): RuntimeDataStore = {
+    val n = values.length
+    if (n == 0) empty
+    else new RuntimeDataStore(values(0), null, n, values)
+  }
 }

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
@@ -56,6 +56,26 @@ final class RuntimeDataStore private (
   def prepended(value: Any): RuntimeDataStore =
     new RuntimeDataStore(value, this, size + 1, null)
 
+  /** Bulk-prepend: creates a single pre-materialized store containing `values` followed by this store's data. Used by
+    * macro-generated code for partial chain optimization -- when the DSL chain is split by a `val`, the continuation's
+    * data is grouped into one `prependedAll` call instead of N individual [[prepended]] calls.
+    *
+    * The caller must not mutate `values` after this call.
+    */
+  def prependedAll(values: Array[Any]): RuntimeDataStore = {
+    val n = values.length
+    if (n == 0) this
+    else if (size == 0) RuntimeDataStore.wrap(values)
+    else {
+      val total = n + size
+      val arr = new Array[Any](total)
+      System.arraycopy(values, 0, arr, 0, n)
+      apply(0)
+      System.arraycopy(materialized, 0, arr, n, size)
+      new RuntimeDataStore(arr(0), null, total, arr)
+    }
+  }
+
   override def toString: String = {
     val sb = new java.lang.StringBuilder("RuntimeDataStore(")
     val arr = materialized

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/runtime/RuntimeDataStore.scala
@@ -1,0 +1,51 @@
+package io.scalaland.chimney.internal.runtime
+
+/** Efficient prepend-oriented store for DSL override data.
+  *
+  * During DSL chain construction (`.withFieldConst`, `.withFieldComputed`, etc.) values are accumulated via [[prepend]],
+  * which builds a cons-cell linked list in O(1) per step. On the first indexed [[apply]] call (emitted by the macro
+  * into the derived transformer body), the list is materialized into an `Array` for O(1) random access. This replaces
+  * the previous `Vector[Any]` backing, which copied the entire underlying array on every prepend -- O(n) per step and
+  * O(n^2) total for a chain of n overrides.
+  *
+  * Thread safety: materialization uses a benign race -- two threads may both materialize, but the result is identical
+  * and the write to `materialized` is to a volatile field, so subsequent reads on any thread see a consistent array.
+  *
+  * @since 1.7.0
+  */
+final class RuntimeDataStore private (
+    // --- cons-cell build phase ---
+    private val head: Any,
+    private val tail: RuntimeDataStore,
+    val size: Int,
+    // --- materialized read phase ---
+    @volatile private var materialized: Array[Any]
+) {
+
+  /** Retrieve the value at logical index `index` (0 = most recently prepended). On the first call the cons-cell chain
+    * is materialized into a flat array; subsequent calls are O(1).
+    */
+  def apply(index: Int): Any = {
+    var arr = materialized
+    if (arr eq null) {
+      arr = new Array[Any](size)
+      var current = this
+      var i = 0
+      while (i < size) {
+        arr(i) = current.head
+        current = current.tail
+        i += 1
+      }
+      materialized = arr
+    }
+    arr(index)
+  }
+
+  /** O(1) prepend -- allocates a single cons-cell object. */
+  def prepended(value: Any): RuntimeDataStore =
+    new RuntimeDataStore(value, this, size + 1, null)
+}
+
+object RuntimeDataStore {
+  val empty: RuntimeDataStore = new RuntimeDataStore(null, null, 0, new Array[Any](0))
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerAllocationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerAllocationsSpec.scala
@@ -1,0 +1,129 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+
+import scala.annotation.nowarn
+
+/** Verifies that [[dsl.PartialTransformerInto]] (.intoPartial.withX.transform) chains with various combinations of
+  * data-carrying and type-only modifiers produce correct transformations — both from fresh expressions and from `val`
+  * references.
+  */
+@nowarn("msg=unused import")
+class PartialTransformerAllocationsSpec extends ChimneySpec {
+
+  case class Source(a: Int, b: String, c: Double)
+  case class Target(a: Int, b: String, c: Double)
+  case class TargetExtra(a: Int, b: String, c: Double, d: Long)
+  case class TargetFewer(a: Int, c: Double)
+
+  val src = Source(1, "hello", 3.14)
+
+  group("fresh expression chains (.intoPartial)") {
+
+    test("0 data-carrying modifiers") {
+      src.intoPartial[Target].transform.asOption ==> Some(Target(1, "hello", 3.14))
+    }
+
+    test("1 data-carrying modifier (withFieldConst)") {
+      src.intoPartial[TargetExtra].withFieldConst(_.d, 42L).transform.asOption ==>
+        Some(TargetExtra(1, "hello", 3.14, 42L))
+    }
+
+    test("1 data-carrying modifier (withFieldConstPartial)") {
+      src
+        .intoPartial[TargetExtra]
+        .withFieldConstPartial(_.d, partial.Result.fromValue(42L))
+        .transform
+        .asOption ==>
+        Some(TargetExtra(1, "hello", 3.14, 42L))
+    }
+
+    test("multiple data-carrying modifiers") {
+      src
+        .intoPartial[TargetExtra]
+        .withFieldConst(_.d, 100L)
+        .withFieldComputed(_.a, s => s.a + 10)
+        .transform
+        .asOption ==> Some(TargetExtra(11, "hello", 3.14, 100L))
+    }
+
+    test("data-carrying + type-only interleaved") {
+      src
+        .intoPartial[TargetExtra]
+        .withFieldConst(_.d, 99L)
+        .enableMethodAccessors
+        .withFieldComputed(_.c, s => s.c * 2)
+        .transform
+        .asOption ==> Some(TargetExtra(1, "hello", 6.28, 99L))
+    }
+
+    test("multiple type-only modifiers between data modifiers") {
+      src
+        .intoPartial[TargetExtra]
+        .withFieldConst(_.d, 1L)
+        .enableMethodAccessors
+        .disableMethodAccessors
+        .withFieldConst(_.a, 999)
+        .transform
+        .asOption ==> Some(TargetExtra(999, "hello", 3.14, 1L))
+    }
+
+    test("three consecutive data-carrying modifiers") {
+      src
+        .intoPartial[TargetExtra]
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "world")
+        .withFieldConst(_.d, 7L)
+        .transform
+        .asOption ==> Some(TargetExtra(10, "world", 3.14, 7L))
+    }
+
+    test("withFieldComputedPartial") {
+      src
+        .intoPartial[TargetExtra]
+        .withFieldComputedPartial(_.d, s => partial.Result.fromValue(s.a.toLong))
+        .transform
+        .asOption ==> Some(TargetExtra(1, "hello", 3.14, 1L))
+    }
+
+    test("withFieldUnused + withFieldConst") {
+      src
+        .intoPartial[TargetFewer]
+        .withFieldUnused(_.b)
+        .withFieldConst(_.c, 0.0)
+        .transform
+        .asOption ==> Some(TargetFewer(1, 0.0))
+    }
+  }
+
+  group("val reference chains (.intoPartial then val)") {
+
+    test("shared base with 0 data modifiers, then branching") {
+      val base = src.intoPartial[TargetExtra]
+      val r1 = base.withFieldConst(_.d, 10L).transform.asOption
+      val r2 = base.withFieldConst(_.d, 20L).transform.asOption
+      r1 ==> Some(TargetExtra(1, "hello", 3.14, 10L))
+      r2 ==> Some(TargetExtra(1, "hello", 3.14, 20L))
+    }
+
+    test("shared base with data, then branching") {
+      val base = src.intoPartial[TargetExtra].withFieldConst(_.d, 0L)
+      val r1 = base.withFieldComputed(_.a, _.a + 1).transform.asOption
+      val r2 = base.withFieldComputed(_.a, _.a + 2).transform.asOption
+      r1 ==> Some(TargetExtra(2, "hello", 3.14, 0L))
+      r2 ==> Some(TargetExtra(3, "hello", 3.14, 0L))
+    }
+
+    test("deep chain from val after branching") {
+      val base = src.intoPartial[TargetExtra].withFieldConst(_.d, 1L)
+      val r = base
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "x")
+        .transform
+        .asOption
+      r ==> Some(TargetExtra(10, "x", 3.14, 1L))
+      val r2 = base.transform.asOption
+      r2 ==> Some(TargetExtra(1, "hello", 3.14, 1L))
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerDefinitionAllocationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PartialTransformerDefinitionAllocationsSpec.scala
@@ -1,0 +1,122 @@
+package io.scalaland.chimney
+
+/** Verifies that [[dsl.PartialTransformerDefinition]] chains with various combinations of data-carrying and type-only
+  * modifiers produce correct transformations — both from fresh expressions and from `val` references (branching).
+  */
+class PartialTransformerDefinitionAllocationsSpec extends ChimneySpec {
+
+  case class Source(a: Int, b: String, c: Double)
+  case class Target(a: Int, b: String, c: Double)
+  case class TargetExtra(a: Int, b: String, c: Double, d: Long)
+  case class TargetFewer(a: Int, c: Double)
+
+  val src = Source(1, "hello", 3.14)
+
+  group("fresh expression chains") {
+
+    test("0 data-carrying modifiers (empty chain)") {
+      val t = PartialTransformer.define[Source, Target].buildTransformer
+      t.transform(src).asOption ==> Some(Target(1, "hello", 3.14))
+    }
+
+    test("1 data-carrying modifier (withFieldConst)") {
+      val t = PartialTransformer.define[Source, TargetExtra].withFieldConst(_.d, 42L).buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(1, "hello", 3.14, 42L))
+    }
+
+    test("1 data-carrying modifier (withFieldConstPartial)") {
+      val t = PartialTransformer
+        .define[Source, TargetExtra]
+        .withFieldConstPartial(_.d, partial.Result.fromValue(42L))
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(1, "hello", 3.14, 42L))
+    }
+
+    test("multiple data-carrying modifiers") {
+      val t = PartialTransformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 100L)
+        .withFieldComputed(_.a, s => s.a + 10)
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(11, "hello", 3.14, 100L))
+    }
+
+    test("data-carrying + type-only interleaved") {
+      val t = PartialTransformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 99L)
+        .enableMethodAccessors
+        .withFieldComputed(_.c, s => s.c * 2)
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(1, "hello", 6.28, 99L))
+    }
+
+    test("multiple type-only modifiers between data modifiers") {
+      val t = PartialTransformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 1L)
+        .enableMethodAccessors
+        .disableMethodAccessors
+        .withFieldConst(_.a, 999)
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(999, "hello", 3.14, 1L))
+    }
+
+    test("three consecutive data-carrying modifiers") {
+      val t = PartialTransformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "world")
+        .withFieldConst(_.d, 7L)
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(10, "world", 3.14, 7L))
+    }
+
+    test("withFieldComputedPartial") {
+      val t = PartialTransformer
+        .define[Source, TargetExtra]
+        .withFieldComputedPartial(_.d, s => partial.Result.fromValue(s.a.toLong))
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(1, "hello", 3.14, 1L))
+    }
+
+    test("withFieldUnused + withFieldConst") {
+      val t = PartialTransformer
+        .define[Source, TargetFewer]
+        .withFieldUnused(_.b)
+        .withFieldConst(_.c, 0.0)
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetFewer(1, 0.0))
+    }
+  }
+
+  group("val reference chains (branching)") {
+
+    test("shared base with 0 data modifiers, then branching") {
+      val base = PartialTransformer.define[Source, TargetExtra]
+      val t1 = base.withFieldConst(_.d, 10L).buildTransformer
+      val t2 = base.withFieldConst(_.d, 20L).buildTransformer
+      t1.transform(src).asOption ==> Some(TargetExtra(1, "hello", 3.14, 10L))
+      t2.transform(src).asOption ==> Some(TargetExtra(1, "hello", 3.14, 20L))
+    }
+
+    test("shared base with data, then branching with more data") {
+      val base = PartialTransformer.define[Source, TargetExtra].withFieldConst(_.d, 0L)
+      val t1 = base.withFieldComputed(_.a, _.a + 1).buildTransformer
+      val t2 = base.withFieldComputed(_.a, _.a + 2).buildTransformer
+      t1.transform(src).asOption ==> Some(TargetExtra(2, "hello", 3.14, 0L))
+      t2.transform(src).asOption ==> Some(TargetExtra(3, "hello", 3.14, 0L))
+    }
+
+    test("deep chain from val after branching") {
+      val base = PartialTransformer.define[Source, TargetExtra].withFieldConst(_.d, 1L)
+      val t = base
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "x")
+        .buildTransformer
+      t.transform(src).asOption ==> Some(TargetExtra(10, "x", 3.14, 1L))
+      val t2 = base.buildTransformer
+      t2.transform(src).asOption ==> Some(TargetExtra(1, "hello", 3.14, 1L))
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherAllocationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherAllocationsSpec.scala
@@ -6,8 +6,8 @@ import io.scalaland.chimney.fixtures.PatchDomain.*
 import scala.annotation.nowarn
 
 /** Verifies that patcher DSL chains ([[dsl.PatcherDefinition]] / [[dsl.PatcherUsing]]) with various combinations of
-  * data-carrying and type-only modifiers produce correct results — both from fresh expressions and from `val` references
-  * (branching).
+  * data-carrying and type-only modifiers produce correct results — both from fresh expressions and from `val`
+  * references (branching).
   */
 @nowarn("msg=unused import")
 class PatcherAllocationsSpec extends ChimneySpec {

--- a/chimney/src/test/scala/io/scalaland/chimney/PatcherAllocationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/PatcherAllocationsSpec.scala
@@ -1,0 +1,144 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+import io.scalaland.chimney.fixtures.PatchDomain.*
+
+import scala.annotation.nowarn
+
+/** Verifies that patcher DSL chains ([[dsl.PatcherDefinition]] / [[dsl.PatcherUsing]]) with various combinations of
+  * data-carrying and type-only modifiers produce correct results — both from fresh expressions and from `val` references
+  * (branching).
+  */
+@nowarn("msg=unused import")
+class PatcherAllocationsSpec extends ChimneySpec {
+
+  group("PatcherDefinition fresh expression chains") {
+
+    test("0 data-carrying modifiers (empty chain)") {
+      val p = Patcher.define[User, UpdateDetails].buildPatcher
+      p.patch(exampleUser, UpdateDetails("new@email.com", 9876543210L)) ==>
+        User(10, Email("new@email.com"), Phone(9876543210L))
+    }
+
+    test("1 data-carrying modifier (withFieldConst)") {
+      val p = Patcher
+        .define[User, UpdateDetails]
+        .withFieldConst(_.id, 99)
+        .buildPatcher
+      p.patch(exampleUser, UpdateDetails("new@email.com", 9876543210L)) ==>
+        User(99, Email("new@email.com"), Phone(9876543210L))
+    }
+
+    test("multiple data-carrying modifiers (withFieldConst + withFieldComputed)") {
+      val p = Patcher
+        .define[User, UpdateDetails]
+        .withFieldConst(_.id, 99)
+        .withFieldComputed(_.id, _ => 77)
+        .buildPatcher
+      p.patch(exampleUser, UpdateDetails("new@email.com", 9876543210L)) ==>
+        User(77, Email("new@email.com"), Phone(9876543210L))
+    }
+
+    test("data-carrying + type-only interleaved") {
+      val p = Patcher
+        .define[User, UpdateDetails]
+        .withFieldConst(_.id, 42)
+        .enableMacrosLogging
+        .disableMacrosLogging
+        .withFieldComputed(_.id, _ => 55)
+        .buildPatcher
+      p.patch(exampleUser, UpdateDetails("x@y.com", 100L)) ==>
+        User(55, Email("x@y.com"), Phone(100L))
+    }
+
+    test("only type-only modifiers") {
+      val p = Patcher
+        .define[User, UpdateDetails]
+        .enableMacrosLogging
+        .disableMacrosLogging
+        .buildPatcher
+      p.patch(exampleUser, UpdateDetails("new@email.com", 5555L)) ==>
+        User(10, Email("new@email.com"), Phone(5555L))
+    }
+
+    test("three consecutive data-carrying modifiers") {
+      val p = Patcher
+        .define[User, UpdateDetails]
+        .withFieldConst(_.id, 1)
+        .withFieldComputed(_.id, _ => 2)
+        .withFieldConst(_.id, 3)
+        .buildPatcher
+      p.patch(exampleUser, UpdateDetails("ignored", 999L)) ==>
+        User(3, Email("ignored"), Phone(999L))
+    }
+  }
+
+  group("PatcherDefinition val reference chains (branching)") {
+
+    test("shared base with 0 data modifiers, then branching") {
+      val base = Patcher.define[User, UpdateDetails]
+      val p1 = base.withFieldConst(_.id, 1).buildPatcher
+      val p2 = base.withFieldConst(_.id, 2).buildPatcher
+      p1.patch(exampleUser, UpdateDetails("a@b.com", 111L)) ==> User(1, Email("a@b.com"), Phone(111L))
+      p2.patch(exampleUser, UpdateDetails("a@b.com", 111L)) ==> User(2, Email("a@b.com"), Phone(111L))
+    }
+
+    test("shared base with data, then branching with more data") {
+      val base = Patcher.define[User, UpdateDetails].withFieldConst(_.id, 0)
+      val p1 = base.withFieldComputed(_.id, _ => 1).buildPatcher
+      val p2 = base.withFieldComputed(_.id, _ => 2).buildPatcher
+      p1.patch(exampleUser, UpdateDetails("x", 1L)) ==> User(1, Email("x"), Phone(1L))
+      p2.patch(exampleUser, UpdateDetails("x", 1L)) ==> User(2, Email("x"), Phone(1L))
+    }
+  }
+
+  group("PatcherUsing (.using) fresh expression chains") {
+
+    test("0 data-carrying modifiers") {
+      exampleUser.using(UpdateDetails("new@email.com", 9876543210L)).patch ==>
+        User(10, Email("new@email.com"), Phone(9876543210L))
+    }
+
+    test("1 data-carrying modifier (withFieldConst)") {
+      exampleUser.using(UpdateDetails("x@y.com", 111L)).withFieldConst(_.id, 99).patch ==>
+        User(99, Email("x@y.com"), Phone(111L))
+    }
+
+    test("multiple data-carrying modifiers") {
+      exampleUser
+        .using(UpdateDetails("x@y.com", 111L))
+        .withFieldConst(_.id, 99)
+        .withFieldComputed(_.id, _ => 77)
+        .patch ==> User(77, Email("x@y.com"), Phone(111L))
+    }
+
+    test("data-carrying + type-only interleaved") {
+      exampleUser
+        .using(UpdateDetails("x@y.com", 111L))
+        .withFieldConst(_.id, 42)
+        .enableMacrosLogging
+        .disableMacrosLogging
+        .withFieldComputed(_.id, _ => 55)
+        .patch ==> User(55, Email("x@y.com"), Phone(111L))
+    }
+  }
+
+  group("PatcherUsing val reference chains (branching)") {
+
+    test("shared base, then branching") {
+      val base = exampleUser.using(UpdateDetails("x@y.com", 111L))
+      val r1 = base.withFieldConst(_.id, 1).patch
+      val r2 = base.withFieldConst(_.id, 2).patch
+      r1 ==> User(1, Email("x@y.com"), Phone(111L))
+      r2 ==> User(2, Email("x@y.com"), Phone(111L))
+    }
+
+    test("shared base with data, then branching") {
+      val base = exampleUser.using(UpdateDetails("x@y.com", 111L)).withFieldConst(_.id, 0)
+      val r1 = base.withFieldComputed(_.id, _ => 1).patch
+      val r2 = base.withFieldComputed(_.id, _ => 2).patch
+      r1 ==> User(1, Email("x@y.com"), Phone(111L))
+      r2 ==> User(2, Email("x@y.com"), Phone(111L))
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerAllocationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerAllocationsSpec.scala
@@ -1,0 +1,123 @@
+package io.scalaland.chimney
+
+import io.scalaland.chimney.dsl.*
+
+import scala.annotation.nowarn
+
+/** Verifies that [[dsl.TransformerInto]] (.into.withX.transform) chains with various combinations of data-carrying and
+  * type-only modifiers produce correct transformations — both from fresh expressions and from `val` references.
+  */
+@nowarn("msg=unused import")
+class TotalTransformerAllocationsSpec extends ChimneySpec {
+
+  case class Source(a: Int, b: String, c: Double)
+  case class Target(a: Int, b: String, c: Double)
+  case class TargetRenamed(a: Int, bb: String, c: Double)
+  case class TargetExtra(a: Int, b: String, c: Double, d: Long)
+  case class TargetFewer(a: Int, c: Double)
+
+  val src = Source(1, "hello", 3.14)
+
+  group("fresh expression chains (.into)") {
+
+    test("0 data-carrying modifiers") {
+      src.into[Target].transform ==> Target(1, "hello", 3.14)
+    }
+
+    test("1 data-carrying modifier (withFieldConst)") {
+      src.into[TargetExtra].withFieldConst(_.d, 42L).transform ==> TargetExtra(1, "hello", 3.14, 42L)
+    }
+
+    test("multiple data-carrying modifiers") {
+      src
+        .into[TargetExtra]
+        .withFieldConst(_.d, 100L)
+        .withFieldComputed(_.a, s => s.a + 10)
+        .transform ==> TargetExtra(11, "hello", 3.14, 100L)
+    }
+
+    test("type-only modifier (withFieldRenamed)") {
+      src.into[TargetRenamed].withFieldRenamed(_.b, _.bb).transform ==> TargetRenamed(1, "hello", 3.14)
+    }
+
+    test("data-carrying + type-only interleaved") {
+      src
+        .into[TargetExtra]
+        .withFieldConst(_.d, 99L)
+        .withFieldRenamed(_.b, _.b)
+        .withFieldComputed(_.c, s => s.c * 2)
+        .transform ==> TargetExtra(1, "hello", 6.28, 99L)
+    }
+
+    test("multiple type-only modifiers between data modifiers") {
+      src
+        .into[TargetExtra]
+        .withFieldConst(_.d, 1L)
+        .enableMethodAccessors
+        .disableMethodAccessors
+        .withFieldConst(_.a, 999)
+        .transform ==> TargetExtra(999, "hello", 3.14, 1L)
+    }
+
+    test("only type-only modifiers") {
+      src.into[Target].enableMethodAccessors.disableMethodAccessors.transform ==> Target(1, "hello", 3.14)
+    }
+
+    test("three consecutive data-carrying modifiers") {
+      src
+        .into[TargetExtra]
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "world")
+        .withFieldConst(_.d, 7L)
+        .transform ==> TargetExtra(10, "world", 3.14, 7L)
+    }
+
+    test("withFieldUnused (type-only) + withFieldConst (data)") {
+      src
+        .into[TargetFewer]
+        .withFieldUnused(_.b)
+        .withFieldConst(_.c, 0.0)
+        .transform ==> TargetFewer(1, 0.0)
+    }
+  }
+
+  group("val reference chains (.into then val)") {
+
+    test("shared base with 0 data modifiers, then branching") {
+      val base = src.into[TargetExtra]
+      val r1 = base.withFieldConst(_.d, 10L).transform
+      val r2 = base.withFieldConst(_.d, 20L).transform
+      r1 ==> TargetExtra(1, "hello", 3.14, 10L)
+      r2 ==> TargetExtra(1, "hello", 3.14, 20L)
+    }
+
+    test("shared base with 1 data modifier, then branching with more data") {
+      val base = src.into[TargetExtra].withFieldConst(_.d, 0L)
+      val r1 = base.withFieldComputed(_.a, _.a + 1).transform
+      val r2 = base.withFieldComputed(_.a, _.a + 2).transform
+      r1 ==> TargetExtra(2, "hello", 3.14, 0L)
+      r2 ==> TargetExtra(3, "hello", 3.14, 0L)
+    }
+
+    test("shared base with data, then one branch adds data and other adds type-only") {
+      val base = src.into[TargetExtra].withFieldConst(_.d, 5L)
+      val r1 = base.withFieldComputed(_.a, _ => 100).transform
+      val r2 = base.enableMethodAccessors.transform
+      r1 ==> TargetExtra(100, "hello", 3.14, 5L)
+      r2 ==> TargetExtra(1, "hello", 3.14, 5L)
+    }
+
+    test("deep chain from val: 3+ data modifiers after branching") {
+      val base = src.into[TargetExtra].withFieldConst(_.d, 1L)
+      val r = base
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "x")
+        .withFieldComputed(_.c, _ => 0.0)
+        .transform
+      r ==> TargetExtra(10, "x", 0.0, 1L)
+      // original base still works independently
+      val r2 = base.transform
+      r2 ==> TargetExtra(1, "hello", 3.14, 1L)
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerDefinitionAllocationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerDefinitionAllocationsSpec.scala
@@ -1,7 +1,7 @@
 package io.scalaland.chimney
 
-/** Verifies that [[dsl.TransformerDefinition]] chains with various combinations of data-carrying and type-only modifiers
-  * produce correct transformations — both from fresh expressions and from `val` references (branching).
+/** Verifies that [[dsl.TransformerDefinition]] chains with various combinations of data-carrying and type-only
+  * modifiers produce correct transformations — both from fresh expressions and from `val` references (branching).
   */
 class TotalTransformerDefinitionAllocationsSpec extends ChimneySpec {
 
@@ -138,6 +138,17 @@ class TotalTransformerDefinitionAllocationsSpec extends ChimneySpec {
       // original base still works independently
       val t2 = base.buildTransformer
       t2.transform(src) ==> TargetExtra(1, "hello", 3.14, 1L)
+    }
+
+    test("built transformer used multiple times (exercises materialized fast path)") {
+      val t = Transformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 42L)
+        .withFieldComputed(_.a, _.a * 10)
+        .buildTransformer
+      t.transform(src) ==> TargetExtra(10, "hello", 3.14, 42L)
+      t.transform(Source(2, "world", 2.72)) ==> TargetExtra(20, "world", 2.72, 42L)
+      t.transform(src) ==> TargetExtra(10, "hello", 3.14, 42L)
     }
   }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerDefinitionAllocationsSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/TotalTransformerDefinitionAllocationsSpec.scala
@@ -1,0 +1,143 @@
+package io.scalaland.chimney
+
+/** Verifies that [[dsl.TransformerDefinition]] chains with various combinations of data-carrying and type-only modifiers
+  * produce correct transformations — both from fresh expressions and from `val` references (branching).
+  */
+class TotalTransformerDefinitionAllocationsSpec extends ChimneySpec {
+
+  case class Source(a: Int, b: String, c: Double)
+  case class Target(a: Int, b: String, c: Double)
+  case class TargetRenamed(a: Int, bb: String, c: Double)
+  case class TargetExtra(a: Int, b: String, c: Double, d: Long)
+  case class TargetFewer(a: Int, c: Double)
+
+  val src = Source(1, "hello", 3.14)
+
+  group("fresh expression chains") {
+
+    test("0 data-carrying modifiers (empty chain)") {
+      val t = Transformer.define[Source, Target].buildTransformer
+      t.transform(src) ==> Target(1, "hello", 3.14)
+    }
+
+    test("1 data-carrying modifier (withFieldConst)") {
+      val t = Transformer.define[Source, TargetExtra].withFieldConst(_.d, 42L).buildTransformer
+      t.transform(src) ==> TargetExtra(1, "hello", 3.14, 42L)
+    }
+
+    test("multiple data-carrying modifiers (withFieldConst + withFieldComputed)") {
+      val t = Transformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 100L)
+        .withFieldComputed(_.a, s => s.a + 10)
+        .buildTransformer
+      t.transform(src) ==> TargetExtra(11, "hello", 3.14, 100L)
+    }
+
+    test("data-carrying modifier interleaved with type-only modifier (withFieldRenamed)") {
+      val t = Transformer
+        .define[Source, TargetRenamed]
+        .withFieldRenamed(_.b, _.bb)
+        .buildTransformer
+      t.transform(src) ==> TargetRenamed(1, "hello", 3.14)
+    }
+
+    test("data-carrying + type-only interleaved") {
+      val t = Transformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 99L)
+        .withFieldRenamed(_.b, _.b) // identity rename, just a type-only modifier in the chain
+        .withFieldComputed(_.c, s => s.c * 2)
+        .buildTransformer
+      t.transform(src) ==> TargetExtra(1, "hello", 6.28, 99L)
+    }
+
+    test("multiple type-only modifiers between data modifiers") {
+      val t = Transformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 1L)
+        .enableMethodAccessors
+        .disableMethodAccessors
+        .withFieldConst(_.a, 999)
+        .buildTransformer
+      t.transform(src) ==> TargetExtra(999, "hello", 3.14, 1L)
+    }
+
+    test("only type-only modifiers (enableMethodAccessors etc.)") {
+      val t = Transformer
+        .define[Source, Target]
+        .enableMethodAccessors
+        .disableMethodAccessors
+        .buildTransformer
+      t.transform(src) ==> Target(1, "hello", 3.14)
+    }
+
+    test("three consecutive data-carrying modifiers") {
+      val t = Transformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "world")
+        .withFieldConst(_.d, 7L)
+        .buildTransformer
+      t.transform(src) ==> TargetExtra(10, "world", 3.14, 7L)
+    }
+
+    test("withFieldConst overriding a previous withFieldConst for same field") {
+      val t = Transformer
+        .define[Source, TargetExtra]
+        .withFieldConst(_.d, 1L)
+        .withFieldConst(_.d, 2L)
+        .buildTransformer
+      t.transform(src) ==> TargetExtra(1, "hello", 3.14, 2L)
+    }
+
+    test("withFieldUnused (type-only) + withFieldConst (data)") {
+      val t = Transformer
+        .define[Source, TargetFewer]
+        .withFieldUnused(_.b)
+        .withFieldConst(_.c, 0.0)
+        .buildTransformer
+      t.transform(src) ==> TargetFewer(1, 0.0)
+    }
+  }
+
+  group("val reference chains (branching)") {
+
+    test("shared base with 0 data modifiers, then branching") {
+      val base = Transformer.define[Source, TargetExtra]
+      val t1 = base.withFieldConst(_.d, 10L).buildTransformer
+      val t2 = base.withFieldConst(_.d, 20L).buildTransformer
+      t1.transform(src) ==> TargetExtra(1, "hello", 3.14, 10L)
+      t2.transform(src) ==> TargetExtra(1, "hello", 3.14, 20L)
+    }
+
+    test("shared base with 1 data modifier, then branching with more data") {
+      val base = Transformer.define[Source, TargetExtra].withFieldConst(_.d, 0L)
+      val t1 = base.withFieldComputed(_.a, _.a + 1).buildTransformer
+      val t2 = base.withFieldComputed(_.a, _.a + 2).buildTransformer
+      t1.transform(src) ==> TargetExtra(2, "hello", 3.14, 0L)
+      t2.transform(src) ==> TargetExtra(3, "hello", 3.14, 0L)
+    }
+
+    test("shared base with data, then one branch adds data and other adds type-only") {
+      val base = Transformer.define[Source, TargetExtra].withFieldConst(_.d, 5L)
+      val t1 = base.withFieldComputed(_.a, _ => 100).buildTransformer
+      val t2 = base.enableMethodAccessors.buildTransformer
+      t1.transform(src) ==> TargetExtra(100, "hello", 3.14, 5L)
+      t2.transform(src) ==> TargetExtra(1, "hello", 3.14, 5L)
+    }
+
+    test("deep chain from val: 3+ data modifiers after branching") {
+      val base = Transformer.define[Source, TargetExtra].withFieldConst(_.d, 1L)
+      val t = base
+        .withFieldConst(_.a, 10)
+        .withFieldConst(_.b, "x")
+        .withFieldComputed(_.c, _ => 0.0)
+        .buildTransformer
+      t.transform(src) ==> TargetExtra(10, "x", 0.0, 1L)
+      // original base still works independently
+      val t2 = base.buildTransformer
+      t2.transform(src) ==> TargetExtra(1, "hello", 3.14, 1L)
+    }
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
@@ -1,0 +1,83 @@
+package io.scalaland.chimney.internal
+
+import io.scalaland.chimney.internal.runtime.RuntimeDataStore
+import io.scalaland.chimney.ChimneySpec
+
+class RuntimeDataStoreSpec extends ChimneySpec {
+
+  test("RuntimeDataStore.empty has size 0") {
+    RuntimeDataStore.empty.size ==> 0
+  }
+
+  test("RuntimeDataStore.prepended increments size") {
+    val store0 = RuntimeDataStore.empty
+    val store1 = store0.prepended("a")
+    val store2 = store1.prepended("b")
+    val store3 = store2.prepended("c")
+
+    store0.size ==> 0
+    store1.size ==> 1
+    store2.size ==> 2
+    store3.size ==> 3
+  }
+
+  test("RuntimeDataStore.apply returns values in prepend order (index 0 = most recent)") {
+    val store = RuntimeDataStore.empty
+      .prepended("first")
+      .prepended("second")
+      .prepended("third")
+
+    store(0) ==> "third"
+    store(1) ==> "second"
+    store(2) ==> "first"
+  }
+
+  test("RuntimeDataStore preserves old snapshots after prepend") {
+    val store1 = RuntimeDataStore.empty.prepended("a")
+    val store2 = store1.prepended("b")
+
+    // old snapshot is unchanged
+    store1.size ==> 1
+    store1(0) ==> "a"
+
+    // new snapshot has both
+    store2.size ==> 2
+    store2(0) ==> "b"
+    store2(1) ==> "a"
+  }
+
+  test("RuntimeDataStore handles branching (same parent, two children)") {
+    val parent = RuntimeDataStore.empty.prepended("x")
+    val childA = parent.prepended("a")
+    val childB = parent.prepended("b")
+
+    childA(0) ==> "a"
+    childA(1) ==> "x"
+    childB(0) ==> "b"
+    childB(1) ==> "x"
+  }
+
+  test("RuntimeDataStore works with heterogeneous types") {
+    val store = RuntimeDataStore.empty
+      .prepended(42)
+      .prepended("hello")
+      .prepended(3.14)
+      .prepended(List(1, 2, 3))
+
+    store(0) ==> List(1, 2, 3)
+    store(1) ==> 3.14
+    store(2) ==> "hello"
+    store(3) ==> 42
+  }
+
+  test("RuntimeDataStore works with null values") {
+    val store = RuntimeDataStore.empty
+      .prepended(null)
+      .prepended("not null")
+      .prepended(null)
+
+    store(0) ==> null
+    store(1) ==> "not null"
+    store(2) ==> null
+  }
+}

--- a/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
@@ -80,4 +80,41 @@ class RuntimeDataStoreSpec extends ChimneySpec {
     store(1) ==> "not null"
     store(2) ==> null
   }
+
+  test("repeated apply reuses materialized array (fast path)") {
+    val store = RuntimeDataStore.empty
+      .prepended("a")
+      .prepended("b")
+      .prepended("c")
+
+    store(0) ==> "c"
+    store(1) ==> "b"
+    store(2) ==> "a"
+    // second round of reads exercises the cached array
+    store(0) ==> "c"
+    store(1) ==> "b"
+    store(2) ==> "a"
+  }
+
+  test("materialize parent, then branch — children produce correct arrays") {
+    val parent = RuntimeDataStore.empty.prepended("x")
+    // force parent materialization
+    parent(0) ==> "x"
+
+    val childA = parent.prepended("a")
+    val childB = parent.prepended("b")
+
+    childA(0) ==> "a"
+    childA(1) ==> "x"
+    childB(0) ==> "b"
+    childB(1) ==> "x"
+    // parent still correct
+    parent(0) ==> "x"
+  }
+
+  test("toString shows contents") {
+    RuntimeDataStore.empty.toString ==> "RuntimeDataStore()"
+    RuntimeDataStore.empty.prepended("a").toString ==> "RuntimeDataStore(a)"
+    RuntimeDataStore.empty.prepended(1).prepended(2).toString ==> "RuntimeDataStore(2, 1)"
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
@@ -117,4 +117,39 @@ class RuntimeDataStoreSpec extends ChimneySpec {
     RuntimeDataStore.empty.prepended("a").toString ==> "RuntimeDataStore(a)"
     RuntimeDataStore.empty.prepended(1).prepended(2).toString ==> "RuntimeDataStore(2, 1)"
   }
+
+  test("wrap creates a pre-materialized store with correct indexing") {
+    val store = RuntimeDataStore.wrap(Array[Any]("c", "b", "a"))
+    store.size ==> 3
+    store(0) ==> "c"
+    store(1) ==> "b"
+    store(2) ==> "a"
+  }
+
+  test("wrap with empty array returns empty") {
+    val store = RuntimeDataStore.wrap(Array.empty[Any])
+    store.size ==> 0
+  }
+
+  test("wrap store supports prepended (branching from flat base)") {
+    val base = RuntimeDataStore.wrap(Array[Any]("b", "a"))
+    val child1 = base.prepended("c1")
+    val child2 = base.prepended("c2")
+
+    child1(0) ==> "c1"
+    child1(1) ==> "b"
+    child1(2) ==> "a"
+
+    child2(0) ==> "c2"
+    child2(1) ==> "b"
+    child2(2) ==> "a"
+
+    base(0) ==> "b"
+    base(1) ==> "a"
+  }
+
+  test("wrap store toString uses materialized array") {
+    val store = RuntimeDataStore.wrap(Array[Any](1, 2, 3))
+    store.toString ==> "RuntimeDataStore(1, 2, 3)"
+  }
 }

--- a/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/internal/RuntimeDataStoreSpec.scala
@@ -152,4 +152,51 @@ class RuntimeDataStoreSpec extends ChimneySpec {
     val store = RuntimeDataStore.wrap(Array[Any](1, 2, 3))
     store.toString ==> "RuntimeDataStore(1, 2, 3)"
   }
+
+  test("prependedAll combines values with existing store") {
+    val base = RuntimeDataStore.empty.prepended("a").prepended("b")
+    val result = base.prependedAll(Array[Any]("d", "c"))
+    result.size ==> 4
+    result(0) ==> "d"
+    result(1) ==> "c"
+    result(2) ==> "b"
+    result(3) ==> "a"
+  }
+
+  test("prependedAll with empty array returns this") {
+    val base = RuntimeDataStore.empty.prepended("a")
+    val result = base.prependedAll(Array.empty[Any])
+    result.size ==> 1
+    result(0) ==> "a"
+  }
+
+  test("prependedAll on empty store returns wrap of values") {
+    val result = RuntimeDataStore.empty.prependedAll(Array[Any]("c", "b", "a"))
+    result.size ==> 3
+    result(0) ==> "c"
+    result(1) ==> "b"
+    result(2) ==> "a"
+  }
+
+  test("prependedAll on wrapped store combines correctly") {
+    val base = RuntimeDataStore.wrap(Array[Any]("b", "a"))
+    val result = base.prependedAll(Array[Any]("d", "c"))
+    result.size ==> 4
+    result(0) ==> "d"
+    result(1) ==> "c"
+    result(2) ==> "b"
+    result(3) ==> "a"
+  }
+
+  test("prependedAll preserves original store") {
+    val base = RuntimeDataStore.wrap(Array[Any]("b", "a"))
+    val result = base.prependedAll(Array[Any]("c"))
+    base.size ==> 2
+    base(0) ==> "b"
+    base(1) ==> "a"
+    result.size ==> 3
+    result(0) ==> "c"
+    result(1) ==> "b"
+    result(2) ==> "a"
+  }
 }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -245,8 +245,8 @@ You can also merge values!
       def transform(src: UserData): User = {
         val userData: UserData = src
         new User(
-          vector(0).asInstanceOf[UserMeta].id,
-          vector(0).asInstanceOf[UserMeta].isDeleted,
+          runtimeDataStore(0).asInstanceOf[UserMeta].id,
+          runtimeDataStore(0).asInstanceOf[UserMeta].isDeleted,
           userdata.name,
           userdata.surname
         )

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -239,7 +239,7 @@ You can also merge values!
     ```scala
     // macro outputs code like this (reformatted a bit for readability):
 
-    val vector = ... // overrides stored by DSL in Vector[Any], here UserMeta fallback
+    val runtimeDataStore = ... // overrides stored by DSL in RuntimeDataStore, here UserMeta fallback
 
     final class $anon() extends Transformer[UserData, User] {
       def transform(src: UserData): User = {

--- a/docs/docs/under-the-hood.md
+++ b/docs/docs/under-the-hood.md
@@ -221,7 +221,7 @@ to a common supertype: `Any`. So from the JVM perspective, after type erasure, w
     ```
 
 At the end of this chain is an object which the macro (from `.transform`) can access to extract from it a `From` value
-and a `RuntimeDataStore` value (currently `type RuntimeDataStore = Vector[Any]`). It means, that as long as macro would
+and a `RuntimeDataStore` value. It means, that as long as macro would
 know what is stored at each `RuntimeDataStore` index, and what is the runtime type of the value, it would have all the
 information we provided it.
 


### PR DESCRIPTION
## Summary

- Replaces `Vector[Any]` runtime data store with a custom cons-cell linked list (`RuntimeDataStore`) that materializes into a flat `Array[Any]` on first indexed access
- **Prepend is O(1)** — a single object allocation per DSL step (vs. Vector's copy-on-prepend)
- **Branching is safe** — `val`-captured definitions share the immutable cons chain; each branch gets its own materialized array
- Thread-safe via benign race on materialization
- Updates docs (`DESIGN.md`, `index.md`, `under-the-hood.md`) to reflect the new backing store
- Adds `toString` for debuggability

### Compile-time DSL chain flattening

The terminal macros (`.transform`, `.buildTransformer`, `.patch`) now analyze the prefix tree at compile time and emit optimized `RuntimeDataStore` construction:

| Pattern | Optimization | Allocations |
|---------|-------------|-------------|
| **Full linear chain** (`define.withFieldConst(...).buildTransformer`) | `RuntimeDataStore.wrap(Array(...))` | 1 array |
| **Partial chain** (`val b = define.withFieldConst(...); b.withFieldConst(...).buildTransformer`) | `b.runtimeData.prependedAll(Array(...))` | 1 array + 1 flat store |
| **Flag wrappers** (`.enableDefaultValues`, `.withTargetFlag`, etc.) | Transparent — walk recurses through wrappers | Same as underlying chain |
| **No optimization** (opaque base, no collected data) | Fallback to `prefix.runtimeData` | Cons-cell chain (unchanged) |

The walk uses `hasEmptyOverrides` (checks for `TransformerOverrides.Empty` / `PatcherOverrides.Empty` type args) to distinguish extension methods (valid chain bases) from flag wrappers (must recurse through). Works on both Scala 2.13 and Scala 3.

### Benchmark results (JMH, Scala 2.13, 22-field case class)

```
Benchmark                              BEFORE (ops/ms)   AFTER (ops/ms)   Change
────────────────────────────────────   ───────────────   ──────────────   ──────
largeConstChimneyIntoSplit                  16,444           25,275       +54%
largeConstChimneyDefinedSplit              15,650           26,014       +66%
largeConstChimneyInto                      16,582           16,635        ~0%
largeConstChimneyDefined                   83,904           91,586        ~0%
largeComputeChimneyInto                    17,124           17,163        ~0%
largeRenameChimneyInto                    180,523          178,944        ~0%
largeConstByHand (baseline)               183,157          188,010        ~0%
```

Addresses https://github.com/scalalandio/chimney/issues/602.

## Test plan

- [x] 1236 tests pass on Scala 3.9.0 and Scala 2.13.18 (core + allocation specs)
- [x] 312 cats integration tests pass
- [x] 39 protobufs integration tests pass
- [x] 70 java-collections integration tests pass
- [x] 19 `RuntimeDataStoreSpec` tests (including 5 `prependedAll` tests)
- [x] 66 allocation-correctness tests across 6 spec files
- [x] JMH benchmarks show 54-66% improvement on partial chains, no regression on linear chains
- [ ] Scala.js / Scala Native build verification (not yet run)